### PR TITLE
Add cataclysm-dda and cataclysm-dda-tiles.

### DIFF
--- a/bucket/cataclysm-dda-tiles.json
+++ b/bucket/cataclysm-dda-tiles.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://cataclysmdda.org",
+    "description": "Turn-based survival game set in a post-apocalyptic world (with graphical tiles)",
+    "version": "0.D",
+    "license": "CC-BY-SA-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.D/cataclysmdda-0.D-8574-Win64-Tiles.zip",
+            "hash": "aa19ea7b2a201de7ee30d9a3ba95b9bb290347a02198ae4f4e2601631f5dbf09"
+        },
+        "32bit": {
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.D/cataclysmdda-0.D-8574-Win-Tiles.zip",
+            "hash": "232e2fdba375e8e6b3ba5cf996ee33dc7d381e2df6eb21683cedd70c8cc8c2cc"
+        }
+    },
+    "shortcuts": [
+        [
+            "cataclysm-tiles.exe",
+            "Cataclysm DDA Tiles"
+        ]
+    ]
+}

--- a/bucket/cataclysm-dda.json
+++ b/bucket/cataclysm-dda.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://cataclysmdda.org",
+    "description": "Turn-based survival game set in a post-apocalyptic world (with text-based graphics)",
+    "version": "0.D",
+    "license": "CC-BY-SA-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.D/cataclysmdda-0.D-8574-Win64-Curses.zip",
+            "hash": "806b0664f03e8c2756c0b5f21465e7be874b0290c74251842563e7a37da81ea1"
+        },
+        "32bit": {
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.D/cataclysmdda-0.D-8574-Win-Curses.zip",
+            "hash": "3b02e98801ef578fba2e73429d173a7c534d8df04b99b4bc9d8ba0ef05e2a9e6"
+        }
+    },
+    "shortcuts": [
+        [
+            "cataclysm.exe",
+            "Cataclysm DDA"
+        ]
+    ]
+}


### PR DESCRIPTION
This adds the open source roguelike Cataclysm: Dark Days Ahead curses and graphical versions.

I didn't include an autoupdate for these manifests because the version for releases are non-semver and scheduled for 6-month intervals (https://cataclysmdda.org/releases/)