### PR TITLE
Adds Summoner's War Exporter (current version: 0.0.25)

### DIFF
--- a/bucket/sw-exporter.json
+++ b/bucket/sw-exporter.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://github.com/Xzandro/sw-exporter",
+    "description": "This tool will parse intercepted data from Summoner's War and extract information on the monsters and runes of the user. They can then be uploaded to https://swarfarm.com/ for example.",
+    "license": "Apache-2.0",
+    "version": "0.0.25",
+    "url": "https://github.com/Xzandro/sw-exporter/releases/download/0.0.25/sw-exporter-0.0.25.exe#/sw-exporter.exe",
+    "hash": "546fed0f6ff5aaf1ca5f541e9af1c31b66d76d6869f943f2181737a5fb885c7f",
+    "bin": "sw-exporter.exe",
+    "shortcuts": [
+        [
+            "sw-exporter.exe",
+            "Summoner's War Exporter"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Xzandro/sw-exporter"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Xzandro/sw-exporter/releases/download/$version/sw-exporter-$version.exe#/sw-exporter.exe"
+    }
+}


### PR DESCRIPTION
Summoner's War Exporter is a Proxy which will capture your game data for Summoners War: Sky Arena, which may then be used to optimize runes or to manage monsters at online platforms such as https://swarfarm.com/.

Summoners War: Sky Arena, is a mobile turn-based strategy MMO game for Android and iOS.

See Also:

* https://swarfarm.com/
* https://github.com/Xzandro/sw-exporter