### PR TITLE
0ad: Add version 0.0.23b

### DIFF
--- a/bucket/0ad.json
+++ b/bucket/0ad.json
@@ -1,0 +1,25 @@
+{
+    "homepage": "https://play0ad.com/",
+    "description": "A free, open-source game of ancient warfare",
+    "version": "0.0.23b",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://github.com/0ad/0ad/blob/master/LICENSE.txt"
+    },
+    "url": "http://releases.wildfiregames.com/0ad-0.0.23b-alpha-win32.exe#/setup.exe",
+    "hash": "8e2cbeed69ff9e770ec81bd80e12c77ba89c1c1470381f1aab70db1130dfb3a4",
+    "installer": {
+        "script": "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList \"/S\", \"/D=$dir\" -Wait"
+    },
+    "uninstaller": {
+        "script": "Start-Process -FilePath \"$dir\\Uninstall.exe\" -ArgumentList /S -Wait"
+    },
+    "bin": "binaries\\system\\pyrogenesis.exe",
+    "checkver": {
+        "url": "https://play0ad.com/download/win/",
+        "regex": "0ad-([\\w.]+)-alpha-win32.exe"
+    },
+    "autoupdate": {
+        "url": "http://releases.wildfiregames.com/0ad-$version-alpha-win32.exe#/setup.exe"
+    }
+}


### PR DESCRIPTION
**0 A.D.** ([homepage](https://play0ad.com/)) is a free, open-source game of ancient warfare.

Notes:
* This package installs the files by **running the installer**. Is this acceptable in the game bucket?

I know that in the general criteria of scoop, it is preferred to extract the files manually (rather than running the installer). The installer seems to be created by [this NSIS script](https://github.com/0ad/0ad/blob/master/source/tools/dist/0ad.nsi), but I could not find a way to extract it using 7zip/uniextract/innounp.

Therefore, I followed [this example from the nonportable bucket](https://github.com/oltolm/scoop-nonportable/blob/master/notepadplusplus-np.json) to create the manifest. The files will be installed under the scoop directory, and the shortcuts are created by the installer itself.

* The file name of the installer is `0ad-0.0.23b-alpha-win32.exe`. I tend to think `-alpha` is not a part of the **version identifier** (it is just stating that the game is still in development), since `-alpha` exists in the filename of every releases.