### PR TITLE
Add Blitz

### DIFF
--- a/bucket/blitz.json
+++ b/bucket/blitz.json
@@ -1,0 +1,28 @@
+{
+    "homepage": "https://blitz.gg/",
+    "description": "App that helps find runes and builds in League of Legends's champion selection phase",
+    "version": "nightly",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://blitzesports.com/tos"
+    },
+    "url": "https://dl.blitz.gg/download/windows#/dl.7z",
+    "depends": "7zip",
+    "installer": {
+        "script": [
+            "7z x \"$dir\\Blitz-*-full.nupkg\" -o\"$dir\" lib\\net45",
+            "Move-Item -Path \"$dir\\lib\\net45\\*\" -Destination \"$dir\" -Force",
+            "Remove-Item -Path \"$dir\\Blitz-*-full.nupkg\""
+        ]
+    },
+    "uninstaller": {
+        "script": "taskkill /F /IM Blitz.exe /FI \"status eq running\""
+    },
+    "bin": "Blitz.exe",
+    "shortcuts": [
+        [
+            "Blitz.exe",
+            "Blitz"
+        ]
+    ]
+}


### PR DESCRIPTION
Close #12.

**Blitz** ([homepage](https://blitz.gg/)) is an app that helps find runes and builds in League of Legends's champion selection phase.

Notes:
* I couldn't find any page that contains the current version number of **Blitz**. Therefore the only way to add this package is through **nightly versions**. Is this acceptable? (or do you prefer not to add this package into the *games* bucket?)

* **Blitz** will be running in the background (showing in the tray) after the main window is closed. The command in the *uninstall* section avoids error when the user tries to uninstall the package while Blitz is still running in the background.

