### PR TITLE
Add League of Legends

### DIFF
--- a/bucket/leagueoflegends.json
+++ b/bucket/leagueoflegends.json
@@ -1,0 +1,50 @@
+{
+    "##": [
+        "BitRock installer. Requires admin privileges. Some of the unwanted behavior fixed in the post_install",
+        "Probably wanted behavior: adds a firewall rule.",
+        "Unwanted behavior: creates desktop and start menu shortcuts, adds a registry key for 'Programs and Features' uninstallation."
+    ],
+    "version": "nightly",
+    "homepage": "http://leagueoflegends.com/",
+    "description": "MOBA game published by Riot Games.",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://euw.leagueoflegends.com/en/legal/termsofuse"
+    },
+    "url": "https://riotgamespatcher-a.akamaihd.net/releases/live/installer/deploy/League%20of%20Legends%20installer%20EUW.exe#/installer_euw.exe",
+    "persist": [
+        "Config"
+    ],
+    "shortcuts": [
+        [
+            "LeagueClient.exe",
+            "League of Legends"
+        ]
+    ],
+    "pre_install": [
+        "$currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())",
+        "if (-Not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {",
+        "    Remove-Item $dir\\.. -Recurse",
+        "    Write-Host \"This installation requires elevated privileges. Rerun the command as an administrator.\" -ForegroundColor Red",
+        "    Exit",
+        "}"
+    ],
+    "installer": {
+        "file": "installer_euw.exe",
+        "args": [
+            "--mode", "unattended",
+            "--installdir", "$dir",
+            "--license_agreement", "1"
+        ]
+    },
+    "post_install": [
+        "Remove-Item \"$Env:PUBLIC\\Desktop\\League of Legends.lnk\"",
+        "$d = \"$Env:ALLUSERSPROFILE\\Microsoft\\Windows\\Start Menu\\Programs\\League of Legends\"",
+        "Remove-Item \"$d\\League of Legends.lnk\"",
+        "Remove-Item \"$d\\Uninstall League of Legends.lnk\"",
+        "if ((Get-ChildItem $d -Recurse -File | Measure-Object).Count -eq 0) { Remove-Item $d }"
+    ],
+    "uninstaller": {
+        "script": "Start-Process -FilePath \"$dir\\Uninstall League of Legends.exe\" -ArgumentList \"--mode unattended\" -Wait"
+    }
+}


### PR DESCRIPTION
There doesn't seem to be easy ways to extract BitRock installers but the pre- and
post-installation scripts make the experience not too bad.

The goal of the pre-installation script is to make sure that the installation is ran with
admin rights and that the installation cleanly exists otherwise.

The uninstaller sometimes threw errors when it was ran as _file+args_. Not sure
why that happens but when it's ran as _script_ with "start-process -wait" the occasional
errors seem to disappear.