### PR TITLE
Tweaks to minecraft.json

### DIFF
--- a/bucket/minecraft.json
+++ b/bucket/minecraft.json
@@ -1,20 +1,22 @@
 {
+    "version": "nightly",
+    "description": "Official launcher for Minecraft, a sandbox voxel game.",
     "homepage": "https://minecraft.net/",
-    "description": "Official launcher for Minecraft, a sandbox voxel game",
-    "version": "java-edition",
     "license": {
-        "identifier": "Freeware",
+        "identifier": "Proprietary",
         "url": "https://account.mojang.com/terms"
     },
     "url": "https://launcher.mojang.com/download/Minecraft.exe",
-    "hash": "a541356a3103201145eac713c3a056674253634d895810b249f87d2d7a654d17",
-    "##": "Using the `current` junction prevents Minecraft from loading the login screen.",
-    "bin": "../java-edition/Minecraft.exe",
+    "notes": "This is only the launcher; you need to log in with a premium account to play Minecraft.",
+    "bin": "Minecraft.exe",
     "shortcuts": [
         [
-            "../java-edition/Minecraft.exe",
+            "Minecraft.exe",
             "Minecraft"
         ]
     ],
-    "notes": "This is only the launcher; you need to log in with a premium account to play Minecraft."
+    "persist": [
+        "game",
+        "runtime"
+    ]
 }


### PR DESCRIPTION
Feedback is welcome. Here are the changes I made:
* `version` has been changed to `nightly` so that the hash doesn't have to be manually updated.
* `license.identifier` has been changed to `Proprietary` as the game is not free (although I suppose the *launcher* is free).
* Using the `current` junction no longer causes any issues, at least for me.
* Added `game` and `runtime` to persist. This is because I use `scoop update minecraft --force --no-cache` to update Minecraft, and redownloading `game` and `runtime` every time the launcher is updated is time-consuming.
:)