### PR TITLE
Add PCSX2 and PCSX2-dev

### DIFF
--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -1,0 +1,45 @@
+{
+    "homepage": "https://pcsx2.net/",
+    "description": "A feature rich FOSS PlayStation 2 emulator (development version)",
+    "license": "LGPL-3.0-or-later",
+    "version": "1.5.0-3315",
+    "url": "https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v1.5.0-dev-3315-gf6600ec83&platform=windows-x86#/dl.7z",
+    "hash": "66d46158ec701439d52c59db4e754b5b6a15bc41f31fba08ed9bdf4f14deb84c",
+    "extract_dir": "pcsx2-v1.5.0-dev-3315-gf6600ec83-windows-x86",
+    "bin": "pcsx2.exe",
+    "persist": [
+        "bios",
+        "cheats",
+        "cheats_ws",
+        "docs",
+        "inis",
+        "Langs",
+        "logs",
+        "memcards",
+        "plugins",
+        "shaders",
+        "snaps",
+        "sstates",
+        "cheats_ws.zip"
+    ],
+    "shortcuts": [
+        [
+            "pcsx2.exe",
+            "PCSX2"
+        ]
+    ],
+    "checkver": {
+        "url": "https://buildbot.orphis.net/pcsx2/index.php",
+        "regex": "1.5.0-dev-(?<build>[\\d]+)-(?<garbage>.{10})",
+        "replace": "1.5.0-${build}"
+    },
+    "autoupdate": {
+        "url": "https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v1.5.0-dev-$matchBuild-$matchGarbage&platform=windows-x86#/dl.7z",
+        "extract_dir": "pcsx2-v1.5.0-dev-$matchBuild-$matchGarbage-windows-x86"
+    },
+    "notes": [
+        "ATTENTION: PCSX2 requires a dump of the PS2 BIOS to function.",
+        "Place the BIOS file in PCSX2's bios directory, you can see the path it is looking in on first setup.",
+        "Learn more at https://pcsx2.net/config-guide/official-english-pcsx2-configuration-guide.html#Bios"
+    ]
+}

--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -2,32 +2,35 @@
     "homepage": "https://pcsx2.net/",
     "description": "A feature rich FOSS PlayStation 2 emulator (development version)",
     "license": "LGPL-3.0-or-later",
-    "version": "1.5.0-3315",
-    "url": "https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v1.5.0-dev-3315-gf6600ec83&platform=windows-x86#/dl.7z",
-    "hash": "66d46158ec701439d52c59db4e754b5b6a15bc41f31fba08ed9bdf4f14deb84c",
-    "extract_dir": "pcsx2-v1.5.0-dev-3315-gf6600ec83-windows-x86",
+    "version": "1.5.0-3319",
+    "url": "https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v1.5.0-dev-3319-g2827394f3&platform=windows-x86#/dl.7z",
+    "hash": "f241f929ed5b16f4b530618595963d477e26b5b268af21e5657cd5f0f5be8e20",
+    "extract_dir": "pcsx2-v1.5.0-dev-3319-g2827394f3-windows-x86",
     "bin": "pcsx2.exe",
     "persist": [
         "bios",
         "cheats",
         "cheats_ws",
-        "docs",
         "inis",
-        "Langs",
         "logs",
         "memcards",
-        "plugins",
-        "shaders",
+        "shaders\\GSdx_FX_Settings.ini",
         "snaps",
         "sstates",
-        "cheats_ws.zip"
+        "portable.ini"
     ],
     "shortcuts": [
         [
             "pcsx2.exe",
-            "PCSX2"
+            "PCSX2-dev"
         ]
     ],
+    "suggest": {
+        "Visual Studio redist 2015": [
+            "vcredist",
+            "vcredist2015"
+        ]
+    },
     "checkver": {
         "url": "https://buildbot.orphis.net/pcsx2/index.php",
         "regex": "1.5.0-dev-(?<build>[\\d]+)-(?<garbage>.{10})",

--- a/bucket/pcsx2.json
+++ b/bucket/pcsx2.json
@@ -1,0 +1,36 @@
+{
+    "homepage": "https://pcsx2.net/",
+    "description": "A feature rich FOSS PlayStation 2 emulator",
+    "license": "LGPL-3.0-or-later",
+    "version": "1.4.0",
+    "url": "https://pcsx2.net/download/releases/windows/send/40-windows/119-pcsx2-1-4-0-binaries.html#/dl.7z",
+    "hash": "2160e8454bfd14caf54629e2eb2e5e4cabdf3a3a46a966e508a7754ce10ccdda",
+    "extract_dir": "PCSX2 1.4.0",
+    "bin": "pcsx2.exe",
+    "persist": [
+        "bios",
+        "cheats",
+        "cheats_ws",
+        "docs",
+        "inis",
+        "Langs",
+        "logs",
+        "memcards",
+        "plugins",
+        "shaders",
+        "snaps",
+        "sstates",
+        "cheats_ws.zip"
+    ],
+    "shortcuts": [
+        [
+            "pcsx2.exe",
+            "PCSX2"
+        ]
+    ],
+    "notes": [
+        "ATTENTION: PCSX2 requires a dump of the PS2 BIOS to function.",
+        "Place the BIOS file in PCSX2's bios directory, you can see the path it is looking in on first setup.",
+        "Learn more at https://pcsx2.net/config-guide/official-english-pcsx2-configuration-guide.html#Bios"
+    ]
+}

--- a/bucket/pcsx2.json
+++ b/bucket/pcsx2.json
@@ -11,16 +11,13 @@
         "bios",
         "cheats",
         "cheats_ws",
-        "docs",
         "inis",
-        "Langs",
         "logs",
         "memcards",
-        "plugins",
-        "shaders",
+        "shaders\\GSdx_FX_Settings.ini",
         "snaps",
         "sstates",
-        "cheats_ws.zip"
+        "portable.ini"
     ],
     "shortcuts": [
         [
@@ -28,6 +25,12 @@
             "PCSX2"
         ]
     ],
+    "suggest": {
+        "Visual Studio redist 2015": [
+            "vcredist",
+            "vcredist2015"
+        ]
+    },
     "notes": [
         "ATTENTION: PCSX2 requires a dump of the PS2 BIOS to function.",
         "Place the BIOS file in PCSX2's bios directory, you can see the path it is looking in on first setup.",


### PR DESCRIPTION
For some reason $matchRandom wouldn't work with an & immediately after it, and I couldn't figure out how to escape it.
Fortunately the git revision appended to each build is always 10 characters long. 