### PR TITLE
Add persist for BGB, Kega-Fusion, Snes9x packages

### DIFF
--- a/bucket/bgb.json
+++ b/bucket/bgb.json
@@ -27,6 +27,7 @@
             ]
         }
     },
+    "persist": "bgb.ini",
     "checkver": {
         "url": "http://bgb.bircd.org/",
         "regex": "\\(current version: BGB ([\\d]+[\\.][\\d]+[\\.][\\d]+)\\)<\\/title>"

--- a/bucket/kega-fusion.json
+++ b/bucket/kega-fusion.json
@@ -6,6 +6,7 @@
     "url": "https://www.carpeludum.com/download/Fusion364.zip",
     "hash": "6365101eb417c5c2a5e6609573f354b7b7ea86632cbfd968676a1eec070e0ca3",
     "extract_dir": "Fusion364",
+    "pre_install": "If(!(Test-Path(\"$persist_dir\\Fusion.ini\"))){New-Item -ItemType File \"$dir\\Fusion.ini\" | Out-Null }",
     "bin": "Fusion.exe",
     "shortcuts": [
         [
@@ -13,6 +14,7 @@
             "Kega Fusion"
         ]
     ],
+    "persist": "Fusion.ini",
     "checkver": {
         "url": "https://www.carpeludum.com/kega-fusion/",
         "regex": "Kega Fusion ([\\d]+[\\.][\\d]+) Windows<\\/a>"

--- a/bucket/snes9x.json
+++ b/bucket/snes9x.json
@@ -32,6 +32,11 @@
             ]
         }
     },
+    "pre_install": "If(!(Test-Path(\"$persist_dir\\snes9x.conf\"))){New-Item -ItemType File \"$dir\\snes9x.conf\" | Out-Null }",
+    "persist": [
+        "Saves",
+        "snes9x.conf"
+    ],
     "checkver": {
         "url": "http://www.s9x-w32.de/dl/",
         "regex": "Snes9x ([\\d]+[\\.][\\d]+) Windows Version"


### PR DESCRIPTION
close #75

This adds **persist** to `BGB`, `Kega-Fusion` and `Snes9x` packages.

* `BGB` already have its config file (bgb.ini) in the archive, therefore we don't need to create a new file in the **pre_install** section.

* I have tested the packages to make sure that `Kega-Fusion` and `Snes9x` works properly (will not crash) with an empty config file.