### PR TITLE
mesen: Add version 0.9.8

### DIFF
--- a/bucket/mesen.json
+++ b/bucket/mesen.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "https://www.mesen.ca",
+    "description": "A high-accuracy NES and Famicom emulator and NSF player.",
+    "version": "0.9.8",
+    "license": "GPL-3.0",
+    "url": "https://github.com/SourMesen/Mesen/releases/download/0.9.8/Mesen.0.9.8.zip",
+    "hash": "cf040795ed3c5605f8ff7215119c203d7649392828a9c843b5693c6ab82ac438",
+    "pre_install": [
+        "if(!(Test-Path(\"$persist_dir\\settings.xml\"))) { New-Item \"$dir\\settings.xml\" | Out-Null }",
+        "if(!(Test-Path(\"$persist_dir\\MesenDB.txt\"))) { New-Item \"$dir\\MesenDB.txt\" | Out-Null }"
+    ],
+    "shortcuts": [
+        [
+            "Mesen.exe",
+            "Mesen"
+        ]
+    ],
+    "persist": [
+        "settings.xml",
+        "MesenDB.txt",
+        "RecentGames",
+        "Saves",
+        "SaveStates",
+        "Resources",
+        "Screenshots",
+        "HdPacks"
+    ],
+    "checkver": {
+        "github": "https://github.com/SourMesen/Mesen"
+    },
+    "autoupdate": {
+        "url": "https://github.com/SourMesen/Mesen/releases/download/$version/Mesen.$version.zip"
+    }
+}


### PR DESCRIPTION
[Mesen](https://www.mesen.ca/): a high-accuracy NES and Famicom emulator and NSF player for Windows and Linux.

Github: https://github.com/SourMesen/Mesen

**Note:**
It's data can be saved into the user's document folder or application folder. If user download the zip, extract and execute the mesen.exe, will let user select which folder to save data. Here I force save data in the appdata by create a settings.xml file.