### PR TITLE
MAME: Add version 0.217

### DIFF
--- a/bucket/mame.json
+++ b/bucket/mame.json
@@ -1,0 +1,59 @@
+{
+    "homepage": "http://mamedev.org",
+    "description": "Arcade machine emulator",
+    "version": "0.217",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mamedev/mame/releases/download/mame0217/mame0217b_64bit.exe#/dl.7z",
+            "hash": "89cf4918cf7f3a818968268918c773c3912688b0aa016e2f8dcb0af3af467e4e",
+            "pre_install": "if(!(Test-Path \"$persist_dir\\mame.ini\")) { Start-Process \"$dir\\mame64.exe\" -WorkingDirectory \"$dir\" -ArgumentList @('-createconfig') }",
+            "bin": [
+                [
+                    "mame64.exe",
+                    "mame"
+                ]
+            ],
+            "shortcuts":[
+                [
+                    "mame64.exe",
+                    "MAME"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/mamedev/mame/releases/download/mame0217/mame0217b_32bit.exe#/dl.7z",
+            "hash": "f763580223a35eaa9283b567a3652cf49154e6181bd78122ed993edfa90b8eef",
+            "pre_install": "if(!(Test-Path \"$persist_dir\\mame.ini\")) { Start-Process \"$dir\\mame.exe\" -WorkingDirectory \"$dir\" -ArgumentList @('-createconfig') }",
+            "bin": "mame.exe",
+            "shortcuts":[
+                [
+                    "mame.exe",
+                    "MAME"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "ctrlr",
+        "plugins",
+        "roms",
+        "mame.ini",
+        "ui.ini",
+        "plugin.ini"
+    ],
+    "checkver": {
+        "github": "https://github.com/mamedev/mame",
+        "regex": "MAME ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mamedev/mame/releases/download/mame$cleanVersion/mame$cleanVersionb_64bit.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/mamedev/mame/releases/download/mame$cleanVersion/mame$cleanVersionb_32bit.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
**MAME** ([homepage](http://mamedev.org)) is an arcade machine emulator.

Notes:
* The config files (`mame.ini`, `ui.ini` and `plugin.ini`) will be produced *in the current working directory* when running `mame.exe -createconfig`