### PR TITLE
Enigma: Add version 1.21

### DIFF
--- a/bucket/enigma.json
+++ b/bucket/enigma.json
@@ -1,0 +1,28 @@
+{
+    "homepage": "https://www.nongnu.org/enigma/index.html",
+    "description": "A puzzle game inspired by Oxyd on the Atari ST and Rock'n'Roll on the Amiga",
+    "version": "1.21",
+    "license": "GPL-2.0-or-later | LGPL-2.1-or-later",
+    "url": "https://downloads.sourceforge.net/project/enigma-game/Release%201.21/Enigma-w32-1.21.zip",
+    "hash": "b2709110cd1e4a26af1997112b9374a5cde2b7f02d8c7b249ac9d6a1fde46a98",
+    "extract_dir": "Enigma-1.21",
+    "bin": "enigma.exe",
+    "shortcuts": [
+        [
+            "enigma.exe",
+            "Enigma"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.nongnu.org/enigma/download.html",
+        "regex": "(?sm)<b>Windows</b>.+?\\.zip file \\(([\\d.]+)\\)"
+    },
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/enigma-game/Release%20$version/Enigma-w32-$version.zip",
+        "hash": {
+            "url": "https://www.nongnu.org/enigma/download.html",
+            "regex": "(?sm)<b>Windows</b>.+?\\.zip file.+?<li>sha256 - $sha256</li>"
+        },
+        "extract_dir": "Enigma-$version"
+    }
+}


### PR DESCRIPTION
close #78

**Enigma** ([homepage](https://www.nongnu.org/enigma/index.html)) is a puzzle game inspired by Oxyd on the Atari ST and Rock'n'Roll on the Amiga. The object of the game is to find uncover pairs of identically colored Oxyd stones.

Notes:

* **license**: Enigma is both licensed as `GPL 2.0 (or later)` and `LGPL 2.1 (or later)`. I seperate them using `|` following the example on [Scoop's wiki page](https://github.com/lukesampson/scoop/wiki/App-Manifests).

* **persist** is not needed because *Enigma* stores its user settings (and save data) under `$Env:AppData\Enigma`.