### PR TITLE
OpenRA: Update to version 20191117 (manually)

### DIFF
--- a/bucket/openra.json
+++ b/bucket/openra.json
@@ -1,10 +1,19 @@
 {
     "homepage": "http://www.openra.net",
     "description": "Real-time strategy game engine for early Westwood games such as Command & Conquer: Red Alert",
-    "version": "20190314",
+    "version": "20191117",
     "license": "GPL-3.0-or-later",
-    "url": "https://github.com/OpenRA/OpenRA/releases/download/release-20190314/OpenRA-release-20190314.exe#/OpenRA.7z",
-    "hash": "e0d51abd55098e4125b826ad03c092dad620e4a1674a7b75ccc53708a3bee73f",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/OpenRA/OpenRA/releases/download/release-20191117/OpenRA-release-20191117-x64.exe#/dl.7z",
+            "hash": "b609a9608a77f68b13c700a562fe69374f1c1b4ea260c6fc949d16343a3ca970"
+        },
+        "32bit": {
+            "url": "https://github.com/OpenRA/OpenRA/releases/download/release-20191117/OpenRA-release-20191117-x86.exe#/dl.7z",
+            "hash": "304f9f7a758c69f081d85d9aed4a4a1726f1b3ff34a698c5bae74da99a881191"
+        }
+    },
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstaller.exe\" -Force -Recurse",
     "bin": [
         "Dune2000.exe",
         "RedAlert.exe",
@@ -25,10 +34,17 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/OpenRA/OpenRA/releases",
-        "regex": "Release ([\\d]{8})</a>"
+        "github": "https://github.com/OpenRA/OpenRA",
+        "regex": "Release (\\d{8})</a>"
     },
     "autoupdate": {
-        "url": "https://github.com/OpenRA/OpenRA/releases/download/release-$version/OpenRA-release-$version.exe#/OpenRA.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/OpenRA/OpenRA/releases/download/release-$version/OpenRA-release-$version-x64.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/OpenRA/OpenRA/releases/download/release-$version/OpenRA-release-$version-x86.exe#/dl.7z"
+            }
+        }
     }
 }


### PR DESCRIPTION
* **OpenRA** now provides both 32-bit and 64-bit binaries, and changed the file name pattern. Therefore *the Excavator* cannot update the package automatically. This fixes the issue.

* OpenRA stores its user settings in `$Env:UserProfile\Documents\OpenRA`. (Therefore *persist* is not needed for this package)