### PR TITLE
sw-exporter: Update to version 0.0.31 (manually)

### DIFF
--- a/bucket/sw-exporter.json
+++ b/bucket/sw-exporter.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://github.com/Xzandro/sw-exporter",
-    "description": "This tool will parse intercepted data from Summoner's War and extract information on the monsters and runes of the user. They can then be uploaded to https://swarfarm.com/ for example.",
+    "description": "Parse intercepted data from Summoner's War and extract information on the monsters and runes of the user. They can then be uploaded to https://swarfarm.com/ for example.",
     "license": "Apache-2.0",
-    "version": "0.0.30",
-    "url": "https://github.com/Xzandro/sw-exporter/releases/download/0.0.30/sw-exporter-0.0.30.exe#/sw-exporter.exe",
-    "hash": "1d3262d232d52702438539a9832763b92da31ac7ec1ecea81ae25f8453c85733",
+    "version": "0.0.31",
+    "url": "https://github.com/Xzandro/sw-exporter/releases/download/0.0.31/Summoners-War-Exporter-Portable-0.0.31-win.exe#/sw-exporter.exe",
+    "hash": "c4c47a78e59ae523e4e5e97f949c3be9403d1126fb995c2d7065ce0f50fedc6f",
     "bin": "sw-exporter.exe",
     "shortcuts": [
         [
@@ -12,10 +12,8 @@
             "Summoner's War Exporter"
         ]
     ],
-    "checkver": {
-        "github": "https://github.com/Xzandro/sw-exporter"
-    },
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Xzandro/sw-exporter/releases/download/$version/sw-exporter-$version.exe#/sw-exporter.exe"
+        "url": "https://github.com/Xzandro/sw-exporter/releases/download/$version/Summoners-War-Exporter-Portable-$version-win.exe#/sw-exporter.exe"
     }
 }


### PR DESCRIPTION
**Summoner's War Exporter** has changed their file name pattern.  Therefore the package cannot be automatically updated by the *Excavator*. This fixes the issue.