### PR TITLE
nethack: Update to version 3.6.4 (manually)

### DIFF
--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -1,10 +1,10 @@
 {
-    "version": "3.6.2",
-    "description": "A single player roguelike videogame",
+    "version": "3.6.4",
+    "description": "Single player rogue-like videogame",
     "license": "NGPL",
-    "homepage": "https://www.nethack.org/",
-    "url": "https://www.nethack.org/download/3.6.2/NetHack-362-win-x86.zip",
-    "hash": "244ffd07c59740fc076f1a86034256ecb95ed2e6076ae8099d9df8929fd89140",
+    "homepage": "https://www.nethack.org",
+    "url": "https://github.com/NetHack/NetHack/releases/download/NetHack-3.6.4_Released/NetHack-3.6.4_Released.x86.zip",
+    "hash": "9fb807866f8e015c802504eba56eb814c6aa8fa774f9a0a7eb99328543266167",
     "bin": "NetHack.exe",
     "shortcuts": [
         [
@@ -12,15 +12,15 @@
             "NetHack"
         ],
         [
-            "Guidebook.pdf",
+            "Guidebook.txt",
             "NetHack Guidebook"
         ]
     ],
     "checkver": {
-        "url": "https://www.nethack.org/index.html",
-        "re": "Version (.*)[<]"
+        "github": "https://github.com/NetHack/NetHack",
+        "regex": "Release build of NetHack ([\\d.]+)</a>"
     },
     "autoupdate": {
-        "url": "https://www.nethack.org/download/$version/NetHack-$cleanVersion-win-x86.zip"
+        "url": "https://github.com/NetHack/NetHack/releases/download/NetHack-$version_Released/NetHack-$version_Released.x86.zip"
     }
 }


### PR DESCRIPTION
**nethack** has changed their file name pattern. Therefore the package cannot be automatically updated by the Excavator. This fixes the issue.

I modified the manifest to download file from the Github repo instead of `nethack.org` because I cannot find a proper way to parse the pages to get the correct URL from `nethack.org`. 
(See https://www.nethack.org/common/index.html for details)