### PR TITLE
gzdoom, lzdoom: Update manually

### DIFF
--- a/bucket/gzdoom.json
+++ b/bucket/gzdoom.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://zdoom.org/",
     "description": "Modern source port for Doom, Heretic, Hexen and more",
-    "version": "4.2.0",
+    "version": "4.2.4",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/coelckers/gzdoom/releases/download/g4.2.0/gzdoom-bin-4-2-0-Windows-x64.zip",
-            "hash": "09331af60f53d9db7cc6f23a90871d9f890e7c66cc4ab7b6484fdbb127d4c4f1"
+            "url": "https://github.com/coelckers/gzdoom/releases/download/g4.2.4/gzdoom-4-2-4-Windows-64bit.zip",
+            "hash": "b99fd372a955c75ca8c84487da02a72e7148971a4eace24a41aba57bcd688d72"
         },
         "32bit": {
-            "url": "https://github.com/coelckers/gzdoom/releases/download/g4.2.0/gzdoom-bin-4-2-0-Windows-x86.zip",
-            "hash": "ee67e2b387589918c241d8fe833ac20bb86ea47fde0d53be62a489c16a23ba1d"
+            "url": "https://github.com/coelckers/gzdoom/releases/download/g4.2.4/gzdoom-4-2-4-Windows-32bit.zip",
+            "hash": "30728f6bb6da00b058bf14f7862ee32154798c70451ee299e597471be61b112d"
         }
     },
     "bin": "gzdoom.exe",
@@ -31,10 +31,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/coelckers/gzdoom/releases/download/g$version/gzdoom-bin-$dashVersion-Windows-x64.zip"
+                "url": "https://github.com/coelckers/gzdoom/releases/download/g$version/gzdoom-$dashVersion-Windows-64bit.zip"
             },
             "32bit": {
-                "url": "https://github.com/coelckers/gzdoom/releases/download/g$version/gzdoom-bin-$dashVersion-Windows-x86.zip"
+                "url": "https://github.com/coelckers/gzdoom/releases/download/g$version/gzdoom-$dashVersion-Windows-32bit.zip"
             }
         }
     },

--- a/bucket/lzdoom.json
+++ b/bucket/lzdoom.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://zdoom.org/",
     "description": "Legacy source port for Doom, Heretic, Hexen and more (based on GZDoom)",
-    "version": "3.82",
+    "version": "3.84",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/drfrag666/gzdoom/releases/download/3.82/LZDoom_3.82_x64.zip",
-            "hash": "02fdf20cc1b6f7bef2ee0497dd561faa8c1d51b55993b362dfe7c48f101d9f18"
+            "url": "https://github.com/drfrag666/gzdoom/releases/download/3.84/LZDoom_3.84_x64.zip",
+            "hash": "4d81c8d22abd0cfbefdc1a80830e3d49616a38bb74123a4837864fc2b79ee1ad"
         },
         "32bit": {
-            "url": "https://github.com/drfrag666/gzdoom/releases/download/3.82/LZDoom_3.82.zip",
-            "hash": "57c242eef6309377cda225689c89d9ee838ca1c944aebf1d6b05ffe687d4b048"
+            "url": "https://github.com/drfrag666/gzdoom/releases/download/3.84/LZDoom_3.84_x86.zip",
+            "hash": "64ecf53cf03e0b08f74d9b7a67f5b1499cd67c90fe497c884e624780c4980de1"
         }
     },
     "bin": "lzdoom.exe",
@@ -33,7 +33,7 @@
                 "url": "https://github.com/drfrag666/gzdoom/releases/download/$version/LZDoom_$version_x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/drfrag666/gzdoom/releases/download/$version/LZDoom_$version.zip"
+                "url": "https://github.com/drfrag666/gzdoom/releases/download/$version/LZDoom_$version_x86.zip"
             }
         }
     },


### PR DESCRIPTION
**gzdoom** and **lzdoom** has changed their file name pattern. Therefore the packages cannot be automatically updated by the Excavator. This fixes the issue.