### PR TITLE
lf2: Add version 2.0a

### DIFF
--- a/bucket/lf2.json
+++ b/bucket/lf2.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0a",
+    "description": "Little Fighter 2. A Fighting game.",
+    "homepage": "http://www.lf2.net/",
+    "license": "Freeware",
+    "url": "http://201708.mediafire.com/file/j2ddn2qqc27u5x1/LittleFighter_2.0a_azo.exe/file#/dl.7z",
+    "hash": "254c79d8fb0af8df72eef042aa2f0c3d9409a0da391f6ab40964450fb0ade034",
+    "extract_dir": "LittleFighter",
+    "pre_install": "Remove-Item \"$dir\\*.url\"",
+    "bin": "lf2.exe",
+    "shortcuts": [
+        [
+            "lf2.exe",
+            "Little Fighter 2"
+        ]
+    ]
+}

--- a/bucket/lf2.json
+++ b/bucket/lf2.json
@@ -6,12 +6,18 @@
     "url": "http://201708.mediafire.com/file/j2ddn2qqc27u5x1/LittleFighter_2.0a_azo.exe/file#/dl.7z",
     "hash": "254c79d8fb0af8df72eef042aa2f0c3d9409a0da391f6ab40964450fb0ade034",
     "extract_dir": "LittleFighter",
-    "pre_install": "Remove-Item \"$dir\\*.url\"",
-    "bin": "lf2.exe",
+    "pre_install": [
+        "Set-Content \"$dir\\lf2.ps1\" -Value 'Start-Process \"$PSScriptRoot\\lf2.exe\" -WorkingDirectory $PSScriptRoot' -Encoding Ascii",
+        "Remove-Item \"$dir\\*.url\""
+    ],
+    "bin": "lf2.ps1",
     "shortcuts": [
         [
             "lf2.exe",
             "Little Fighter 2"
         ]
-    ]
+    ],
+    "suggest": {
+        "Visual C++ 2005 Redistributable": "extras/vcredist2005"
+    }
 }


### PR DESCRIPTION
**Little Fighter 2** (often abbreviated as **LF2**) is a free fighting game that is well-known in the Chinese-speaking region.  ([homepage](http://www.lf2.net/)) ([Wikipedia](https://en.wikipedia.org/wiki/Little_Fighter_2))

Notes:
* *checkver/autoupdate* is not needed because **LF2** has not been updated since 2009.

* The installer from the official source cannot be properly extracted. Also the silent switch (`/S`) causes error for some reason. Therefore I use a **third-party source** ([azo freeware](https://www.azofreeware.com/2011/12/little-fighter-20a.html)) instead. Is this acceptable?
