### PR TITLE
gzdoom: Persist config file

### DIFF
--- a/bucket/gzdoom.json
+++ b/bucket/gzdoom.json
@@ -20,7 +20,11 @@
             "GZDoom"
         ]
     ],
-    "pre_install": "New-Item -ItemType Directory -Force -Path $persist_dir\\..\\_doom | Out-Null",
+    "pre_install": [
+        "New-Item -ItemType Directory -Force -Path $persist_dir\\..\\_doom | Out-Null",
+        "New-Item -Path $dir -Name gzdoom_portable.ini -ItemType File -ErrorAction Ignore | Out-Null"
+    ],
+    "persist": "gzdoom_portable.ini",
     "env_set": {
         "DOOMWADDIR": "$persist_dir\\..\\_doom"
     },


### PR DESCRIPTION
This PR adds persistence for the GZDoom portable config file. The portable config file is documented [here](https://zdoom.org/wiki/Configuration_file) for ZDoom. GZDoom automatically detects the presence of `gzdoom_portable.ini` and uses it over the default config file (`gzdoom-<user>.ini`).