### PR TITLE
zdl: Add version 3-1.1

### DIFF
--- a/bucket/gzdoom.json
+++ b/bucket/gzdoom.json
@@ -20,7 +20,11 @@
             "GZDoom"
         ]
     ],
-    "pre_install": "New-Item -ItemType Directory -Force -Path $persist_dir\\..\\_doom | Out-Null",
+    "pre_install": [
+        "New-Item -ItemType Directory -Force -Path $persist_dir\\..\\_doom | Out-Null",
+        "New-Item -Path $dir -Name gzdoom_portable.ini -ItemType File -ErrorAction Ignore | Out-Null"
+    ],
+    "persist": "gzdoom_portable.ini",
     "env_set": {
         "DOOMWADDIR": "$persist_dir\\..\\_doom"
     },

--- a/bucket/zdl.json
+++ b/bucket/zdl.json
@@ -1,0 +1,37 @@
+{
+    "homepage": "https://zdoom.org/wiki/ZDL",
+    "description": "ZDL is a frontend (\"launcher\") for ZDoom based Doom engine source ports.",
+    "version": "3-1.1",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lcferrum/qzdl/releases/download/3-1.1/ZDL_3-1.1_Win_x86.zip",
+            "hash": "11a6775460df1823feedf3ca20e7d0cb691bf70f20c77b2e0255b99ced55691a"
+        },
+        "32bit": {
+            "url": "https://github.com/lcferrum/qzdl/releases/download/3-1.1/ZDL_3-1.1_Win_x86.zip",
+            "hash": "11a6775460df1823feedf3ca20e7d0cb691bf70f20c77b2e0255b99ced55691a"
+        }
+    },
+    "bin": "ZDL.exe",
+    "shortcuts": [
+        [
+            "ZDL.exe",
+            "ZDL"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/lcferrum/qzdl",
+        "regex": "/releases/tag/([\\w.-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lcferrum/qzdl/releases/download/$version/ZDL_$version_Win_x86.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/lcferrum/qzdl/releases/download/$version/ZDL_$version_Win_x86.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[ZDL](https://zdoom.org/wiki/ZDL) is the [ZDoom-recommended](https://zdoom.org/downloads#Support) (see also [here](https://zdoom.org/wiki/Frontend)) frontend/launcher for ZDoom engines.

This manifest installs the most up-to-date ZDL fork by lcferrum available [here](https://github.com/lcferrum/qzdl).

The fork stores its configuration in `AppData\Roaming\Vectec Software\qZDL.ini`, so no persistence is necessary.