### PR TITLE
ps3-system-software: Add version 4.86

### DIFF
--- a/bucket/ps3-system-software.json
+++ b/bucket/ps3-system-software.json
@@ -1,18 +1,17 @@
 {
     "version": "4.86",
-    "url": "http://dus01.ps3.update.playstation.net/update/ps3/image/us/2020_0331_cf9cb4ba53a83ad557501417837c8de9/PS3UPDAT.PUP",
-    "hash": "14ad0a4716d2bdf096dab9ecf77b9b838cc64435db7925837a38979fa05f4012",
     "description": "The PlayStation 3 system software is the updatable firmware and operating system of the PlayStation 3.",
     "license": {
         "identifier": "Proprietary",
         "url": "https://doc.dl.playstation.net/doc/ps3-eula/ps3_eula_en.html"
     },
+    "url": "http://dus01.ps3.update.playstation.net/update/ps3/image/us/2020_0331_cf9cb4ba53a83ad557501417837c8de9/PS3UPDAT.PUP",
+    "hash": "14ad0a4716d2bdf096dab9ecf77b9b838cc64435db7925837a38979fa05f4012",
     "checkver": {
         "url": "https://www.playstation.com/en-us/support/system-updates/ps3/",
-        "regex": "(Latest Version: (?<vernum>[0-9\\.]+))[\\s\\S]+(a href=\\\"(?<dlurl>http.+\\.update\\.playstation\\.net.+PS3UPDAT\\.PUP))",
-        "replace": "${vernum}"
+        "regex": "(?sm)Latest Version: ([\\d.]+).*?ps3/image/us/(?<time>[\\w_]+)/PS3UPDAT.PUP"
     },
     "autoupdate": {
-        "url": "$matchDlurl"
+        "url": "http://dus01.ps3.update.playstation.net/update/ps3/image/us/$matchTime/PS3UPDAT.PUP"
     }
 }

--- a/bucket/ps3-system-software.json
+++ b/bucket/ps3-system-software.json
@@ -1,0 +1,18 @@
+{
+    "version": "4.86",
+    "url": "http://dus01.ps3.update.playstation.net/update/ps3/image/us/2020_0331_cf9cb4ba53a83ad557501417837c8de9/PS3UPDAT.PUP",
+    "hash": "14ad0a4716d2bdf096dab9ecf77b9b838cc64435db7925837a38979fa05f4012",
+    "description": "The PlayStation 3 system software is the updatable firmware and operating system of the PlayStation 3.",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://doc.dl.playstation.net/doc/ps3-eula/ps3_eula_en.html"
+    },
+    "checkver": {
+        "url": "https://www.playstation.com/en-us/support/system-updates/ps3/",
+        "regex": "(Latest Version: (?<vernum>[0-9\\.]+))[\\s\\S]+(a href=\\\"(?<dlurl>http.+\\.update\\.playstation\\.net.+PS3UPDAT\\.PUP))",
+        "replace": "${vernum}"
+    },
+    "autoupdate": {
+        "url": "$matchDlurl"
+    }
+}

--- a/bucket/rpcs3-dev.json
+++ b/bucket/rpcs3-dev.json
@@ -29,9 +29,13 @@
             "regex": "Windows SHA-256: ($sha256)"
         }
     },
+    "suggest": {
+        "PS3 System Software": "games/ps3-system-software"
+    },
     "notes": [
         "ATTENTION: RPCS3 requires a copy of the official PS3 firmware to function.",
         "It is available here: https://www.playstation.com/en-us/support/system-updates/ps3",
-        "See the official quickstart guide for further instructions: https://rpcs3.net/quickstart"
+        "See the official quickstart guide for further instructions: https://rpcs3.net/quickstart",
+        "NEW: Alternatively, install the ps3-system-software package.  You must still manually load PS3UPDAT.PUP"
     ]
 }


### PR DESCRIPTION
Also added as a suggestion to rpcs3-dev.
This does not automatically set RPCS3 up to use the firmware.
You still have to install it through the interface.  This
just downloads it for you and should notify you via a package
upgrade when a new version is available.