### PR TITLE
vkquake: Add version 1.04.1

### DIFF
--- a/bucket/vkquake.json
+++ b/bucket/vkquake.json
@@ -1,0 +1,80 @@
+{
+    "homepage": "https://github.com/Novum/vkQuake",
+    "description": "Quake 1 port using Vulkan instead of OpenGL for rendering, based on QuakeSpasm",
+    "version": "1.04.1",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Novum/vkQuake/releases/download/1.04.1/vkquake-1.04.1_win64.zip",
+            "hash": "9ad91717f12660fe9577bd8aa9695d3064069905a9bb82b8aeb7a45bc23cbf62",
+            "extract_dir": "vkquake-1.04.1_win64"
+        },
+        "32bit": {
+            "url": "https://github.com/Novum/vkQuake/releases/download/1.04.1/vkquake-1.04.1_win32.zip",
+            "hash": "c911ef84e6d44f42a2688d6c6ad12d0bb98cc21deda48f7382358dce83022e10",
+            "extract_dir": "vkquake-1.04.1_win32"
+        }
+    },
+    "shortcuts": [
+        [
+            "vkQuake.exe",
+            "vkQuake",
+            "-game id1"
+        ],
+        [
+            "vkQuake.exe",
+            "vkQuake (Scourge of Armagon)",
+            "-game hipnotic"
+        ],
+        [
+            "vkQuake.exe",
+            "vkQuake (Dissolution of Eternity)",
+            "-game rogue"
+        ],
+        [
+            "vkQuake.exe",
+            "vkQuake (Abyss of Pandemonium)",
+            "-game abyss"
+        ]
+    ],
+    "persist": [
+        "id1",
+        "hipnotic",
+        "rogue",
+        "abyss"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Novum/vkQuake/releases/download/$version/vkquake-$version_win64.zip",
+                "extract_dir": "vkquake-$version_win64"
+            },
+            "32bit": {
+                "url": "https://github.com/Novum/vkQuake/releases/download/$version/vkquake-$version_win32.zip",
+                "extract_dir": "vkquake-$version_win32"
+            }
+        }
+    },
+    "notes": [
+        "vkQuake requires the Visual C++ Redistributable for Visual Studio 2019:",
+        "",
+        "- 32 bit: https://go.microsoft.com/fwlink/?LinkId=746571",
+        "",
+        "- 64 bit: https://go.microsoft.com/fwlink/?LinkId=746572",
+        "",
+        "Place game data files (such as pak0.pak and pak1.pak) in:",
+        "",
+        "- Quake:",
+        "    $persist_dir\\id1\\",
+        "",
+        "- Quake Mission Pack 1 - Scourge of Armagon:",
+        "    $persist_dir\\hipnotic\\",
+        "",
+        "- Quake Mission Pack 2 - Dissolution of Eternity:",
+        "    $persist_dir\\rogue\\",
+        "",
+        "- Quake Mission Pack 3 - Abyss of Pandemonium:",
+        "    $persist_dir\\abyss\\"
+    ]
+}

--- a/bucket/vkquake.json
+++ b/bucket/vkquake.json
@@ -15,6 +15,7 @@
             "extract_dir": "vkquake-1.04.1_win32"
         }
     },
+    "depends": "extras/vcredist2019",
     "shortcuts": [
         [
             "vkQuake.exe",
@@ -57,12 +58,6 @@
         }
     },
     "notes": [
-        "vkQuake requires the Visual C++ Redistributable for Visual Studio 2019:",
-        "",
-        "- 32 bit: https://go.microsoft.com/fwlink/?LinkId=746571",
-        "",
-        "- 64 bit: https://go.microsoft.com/fwlink/?LinkId=746572",
-        "",
         "Place game data files (such as pak0.pak and pak1.pak) in:",
         "",
         "- Quake:",


### PR DESCRIPTION
[vkQuake](https://github.com/Novum/vkQuake) is a Quake 1 port based on QuakeSpasm that uses the Vulkan graphics API for rendering.

I copied the QuakeSpasm manifest and made some basic additions for `checkver` and `autoupdate`. I also added a note from the vkQuake repo about needing the MSVC 2019 redists installed.