### PR TITLE
openmw-nightly: Fix URLs and checkver following migration

### DIFF
--- a/bucket/openmw-nightly.json
+++ b/bucket/openmw-nightly.json
@@ -1,16 +1,16 @@
 {
     "homepage": "http://openmw.org/",
     "description": "An open-source open-world RPG game engine that supports playing Morrowind. (nightly version)",
-    "version": "d77047e1c",
+    "version": "12833d66a",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "http://www.lysator.liu.se/~ace/OpenMW/nightlies/OpenMW-d77047e1c-win64.exe#/dl.7z",
-            "hash": "md5:b3ea9909417ba3917dac0f3b4f4e1844"
+            "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-12833d66a-win64.exe#/dl.7z",
+            "hash": "2e52e7d48302285e4e272ea0d660291731908cf2cffb37c647e145e9f71c34d9"
         },
         "32bit": {
-            "url": "http://www.lysator.liu.se/~ace/OpenMW/nightlies/OpenMW-d77047e1c-win32.exe#/dl.7z",
-            "hash": "md5:dda34f89fd71ebab8f9c4c88846f0c5f"
+            "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-12833d66a-win32.exe#/dl.7z",
+            "hash": "9e391b4e2c554af73ea981e38ce27bfcd7db164235b740c053adb3a824de077c"
         }
     },
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse",
@@ -47,23 +47,23 @@
     ],
     "notes": "Please run the OpenMW Launcher in the start menu to configure the game data path. Otherwise, OpenMW won't start correctly.",
     "checkver": {
-        "url": "http://www.lysator.liu.se/~ace/OpenMW/OpenMW-latest-win32.exe.md5",
-        "regex": "nightlies/OpenMW-([a-z0-9]+)-win32"
+        "url": "https://rgw.ctrl-c.liu.se/openmw/latest-32",
+        "regex": "([a-z0-9]{9})"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.lysator.liu.se/~ace/OpenMW/nightlies/OpenMW-$version-win64.exe#/dl.7z",
+                "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-$version-win64.exe#/dl.7z",
                 "hash": {
-                    "url": "http://www.lysator.liu.se/~ace/OpenMW/OpenMW-latest-win64.exe.md5",
-                    "find": "([A-Fa-f0-9]{32})"
+                    "url": "https://openmw-nightlies.kubernetes.ctrl-c.liu.se/latest/OpenMW-latest-win64.sha256",
+                    "find": "([A-Fa-f0-9]{64})"
                 }
             },
             "32bit": {
-                "url": "http://www.lysator.liu.se/~ace/OpenMW/nightlies/OpenMW-$version-win32.exe#/dl.7z",
+                "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-$version-win32.exe#/dl.7z",
                 "hash": {
-                    "url": "http://www.lysator.liu.se/~ace/OpenMW/OpenMW-latest-win32.exe.md5",
-                    "find": "([A-Fa-f0-9]{32})"
+                    "url": "https://openmw-nightlies.kubernetes.ctrl-c.liu.se/latest/OpenMW-latest-win32.sha256",
+                    "find": "([A-Fa-f0-9]{64})"
                 }
             }
         }


### PR DESCRIPTION
The nightly version of OpenMW has a new hosting system which therefore broke the autoupdate. The manifest has been updated with the relevant information.