### PR TITLE
rpcs3-dev: Allow for multiple digits in version

### DIFF
--- a/bucket/rpcs3-dev.json
+++ b/bucket/rpcs3-dev.json
@@ -19,7 +19,7 @@
     ],
     "checkver": {
         "url": "https://rpcs3.net/compatibility?b",
-        "regex": "/rpcs3-binaries-win/releases/download/build-(?<fullhash>[0-9a-f]+)/rpcs3-v(?<build>[0-9]\\.[0-9]\\.[0-9]\\-[0-9]+)-(?<shorthash>[0-9a-f]{8})",
+        "regex": "/rpcs3-binaries-win/releases/download/build-(?<fullhash>[0-9a-f]+)/rpcs3-v(?<build>[0-9]+\\.[0-9]+\\.[0-9]+\\-[0-9]+)-(?<shorthash>[0-9a-f]{8})",
         "replace": "${build}"
     },
     "autoupdate": {


### PR DESCRIPTION
I'm dumb, I thought something was wrong with the excavator but I went and looked at the release page today, they just bumped the base version from 0.0.9 to 0.0.10 and for some reason I didn't account for that in the original regex.  I didn't bother manually bumping the version but it should get picked up on the next excavator run.