### PR TITLE
actools: Add version 0.8.2123.36398

### DIFF
--- a/bucket/actools.json
+++ b/bucket/actools.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/gro-ove/actools",
+    "description": "Alternative launcher for Assetto Corsa named Content Manager, and some utils as well",
+    "version": "0.8.2123.36398",
+    "license": "MS-PL",
+    "url": "https://github.com/gro-ove/actools/releases/download/v0.8.2123.36398/Content.Manager.zip",
+    "hash": "02b350165e91fcb31df76ab12bb863c8b9c5f2d1624688430964ea6972700c29",
+    "shortcuts": [
+        [
+            "Content Manager.exe",
+            "Assetto Corsa Content Manager"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/gro-ove/actools/releases/download/v$version/Content.Manager.zip"
+    }
+}


### PR DESCRIPTION
> Alternative launcher for Assetto Corsa named Content Manager, and some utils as well

https://github.com/gro-ove/actools