### PR TITLE
quakespasm: Implement various manifest improvements

### DIFF
--- a/bucket/quakespasm.json
+++ b/bucket/quakespasm.json
@@ -15,7 +15,13 @@
             "extract_dir": "quakespasm-0.93.2_windows"
         }
     },
-    "bin": "quakespasm.exe",
+    "bin": [
+        [
+            "quakespasm.exe",
+            "quakespasm",
+            "-basedir $persist_dir"
+        ]
+    ],
     "shortcuts": [
         [
             "quakespasm.exe",

--- a/bucket/quakespasm.json
+++ b/bucket/quakespasm.json
@@ -6,20 +6,20 @@
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/quakespasm/Windows/quakespasm-0.93.2_win64.zip",
-            "hash": "70d4dcd927f479709b887b429b18d904a4265861e63a0d8c226a3d40d4dda82f",
+            "hash": "sha1:1e86f886b40457afddc6de7855a627306e26c377",
             "extract_dir": "quakespasm-0.93.2_win64"
         },
         "32bit": {
             "url": "https://downloads.sourceforge.net/project/quakespasm/Windows/quakespasm-0.93.2_windows.zip",
-            "hash": "6cf9906efd392f31ff025aeefd4f94a2efb5d39f277e4093e52734daeae63c2f",
+            "hash": "sha1:18072838cb25d0404d4fa946a9f46736c93d8f5c",
             "extract_dir": "quakespasm-0.93.2_windows"
         }
     },
+    "bin": "quakespasm.exe",
     "shortcuts": [
         [
             "quakespasm.exe",
-            "QuakeSpasm",
-            "-game id1"
+            "QuakeSpasm"
         ],
         [
             "quakespasm.exe",
@@ -57,5 +57,21 @@
         "",
         "- Quake Mission Pack 3 - Abyss of Pandemonium:",
         "    $persist_dir\\abyss\\"
-    ]
+    ],
+    "checkver": {
+        "url": "http://quakespasm.sourceforge.net/download.htm",
+        "regex": "/Windows/quakespasm-(\\d+\\.\\d+\\.\\d+)_windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/quakespasm/Windows/quakespasm-$version_win64.zip",
+                "extract_dir": "quakespasm-$version_win64"
+            },
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/quakespasm/Windows/quakespasm-$version_windows.zip",
+                "extract_dir": "quakespasm-$version_windows"
+            }
+        }
+    }
 }


### PR DESCRIPTION
* Add checkver and autoupdate
* Add command-line shim
* Remove `-game` argument from default shortcut (makes shareware unusable)

A note regarding the `-game id1` removal: That argument causes an error when using the shareware version of Quake (`id1\PAK0.PAK` without `id1\PAK1.PAK`):

![image](https://user-images.githubusercontent.com/1231924/82109884-4e238900-96ff-11ea-9ea9-80c26fc0ebc7.png)

Additionally, QuakeSpasm selects `id1` as the game by default without that argument.