### PR TITLE
vkquake: Implement various manifest improvements

### DIFF
--- a/bucket/vkquake.json
+++ b/bucket/vkquake.json
@@ -15,12 +15,17 @@
             "extract_dir": "vkquake-1.04.1_win32"
         }
     },
-    "depends": "extras/vcredist2019",
-    "shortcuts": [
+    "bin": [
         [
             "vkQuake.exe",
             "vkQuake",
-            "-game id1"
+            "-basedir $persist_dir"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "vkQuake.exe",
+            "vkQuake"
         ],
         [
             "vkQuake.exe",
@@ -44,6 +49,9 @@
         "rogue",
         "abyss"
     ],
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    },
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
* Add command-line shim
* Remove -game argument from default shortcut (makes shareware unusable)
* Use suggest instead of depends for vcredist

A note regarding the `-game id1` removal: That argument causes an error when using the shareware version of Quake (`id1\PAK0.PAK` without `id1\PAK1.PAK`):

![image](https://user-images.githubusercontent.com/1231924/82110473-72ce2f80-9704-11ea-9a9f-7d2cdbcbf571.png)

Additionally, vkQuake (like QuakeSpasm) selects `id1` as the game by default without that argument.

Regarding the use of `suggest` instead of `depends` for the vcredist, this approach seems to be the best practice in other manifests such as [pcsx2](https://github.com/Calinou/scoop-games/blob/1f5a1eeb3ec8634ad2942942cf69b3f2bef09be4/bucket/pcsx2.json) and [several main bucket packages](https://github.com/ScoopInstaller/Main/search?p=1&q=vcredist&unscoped_q=vcredist).