### PR TITLE
openmw-nightly: Change versioning scheme

### DIFF
--- a/bucket/openmw-nightly.json
+++ b/bucket/openmw-nightly.json
@@ -1,16 +1,16 @@
 {
     "homepage": "http://openmw.org/",
     "description": "An open-source open-world RPG game engine that supports playing Morrowind. (nightly version)",
-    "version": "32ee826a8",
+    "version": "20200520-61fbc1cd0",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-32ee826a8-win64.exe#/dl.7z",
-            "hash": "378157d1f9ecd62ce70b827452ba13e3f2475810d14c4c44906c5854cba98939"
+            "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-61fbc1cd0-win64.exe#/dl.7z",
+            "hash": "efaabe03ec5b83db9ff4c624b4665870fc3ff3b02f129653fe8486022d0d16a1"
         },
         "32bit": {
-            "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-32ee826a8-win32.exe#/dl.7z",
-            "hash": "563bed8006585589be6562a6d016f2ab347015d5daa64bafa7aa85fef6858b3b"
+            "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-61fbc1cd0-win32.exe#/dl.7z",
+            "hash": "1516a1d30773b747858b14f1690aedf60d4cc4cf217ad280a4557638716b2466"
         }
     },
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse",
@@ -47,20 +47,21 @@
     ],
     "notes": "Please run the OpenMW Launcher in the start menu to configure the game data path. Otherwise, OpenMW won't start correctly.",
     "checkver": {
-        "url": "https://rgw.ctrl-c.liu.se/openmw/latest-32",
-        "regex": "([a-z0-9]{9})"
+        "url": "https://openmw-nightlies.kubernetes.ctrl-c.liu.se/latest/OpenMW-latest-win32.json",
+        "regex": "(OpenMW-(?<commit>[a-z0-9]{9})-win32.exe.*\"date\":\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2}))",
+        "replace": "${year}${month}${day}-${commit}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-$version-win64.exe#/dl.7z",
+                "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-$matchCommit-win64.exe#/dl.7z",
                 "hash": {
                     "url": "https://openmw-nightlies.kubernetes.ctrl-c.liu.se/latest/OpenMW-latest-win64.sha256",
                     "find": "([A-Fa-f0-9]{64})"
                 }
             },
             "32bit": {
-                "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-$version-win32.exe#/dl.7z",
+                "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-$matchCommit-win32.exe#/dl.7z",
                 "hash": {
                     "url": "https://openmw-nightlies.kubernetes.ctrl-c.liu.se/latest/OpenMW-latest-win32.sha256",
                     "find": "([A-Fa-f0-9]{64})"


### PR DESCRIPTION
It seems that Scoop doesn't always update automatically this package even though the manifest version has changed. I suspect that is because the versioning scheme was only the commit hash and therefore was not 'incremental'.
I changed it with the versioning scheme of [ffmpeg-nightly](https://github.com/ScoopInstaller/Main/blob/master/bucket/ffmpeg-nightly.json) which seems to work correctly. It is now `YearMonthDay-commit`. I also think that having the date information is helpful for a nightly package.