### PR TITLE
blockbench: Add version 3.6.5

### DIFF
--- a/bucket/blockbench.json
+++ b/bucket/blockbench.json
@@ -1,7 +1,7 @@
 {
     "version": "3.6.5",
     "description": "Modern model editor for boxy models and pixel art textures.",
-    "homepage": "https://github.com/JannisX11/blockbench/",
+    "homepage": "https://blockbench.net/",
     "license": "GPL-3.0-or-later",
     "url": "https://github.com/JannisX11/blockbench/releases/download/v3.6.5/Blockbench_3.6.5.exe#/dl.7z",
     "hash": "sha512:373bfaea35bb2d0affebeee5a92214296f82c46339e37419df750734461849483486862a238bdfcea428618215a84ff2a1acf6a532f6cefdabe3dac418604ac6",
@@ -29,7 +29,9 @@
             "Blockbench"
         ]
     ],
-    "checkver": "github",
+    "checkver":{
+        "github": "https://github.com/JannisX11/blockbench/"
+    },
     "autoupdate": {
         "url": "https://github.com/JannisX11/blockbench/releases/download/v$version/Blockbench_$version.exe#/dl.7z",
         "hash": {

--- a/bucket/blockbench.json
+++ b/bucket/blockbench.json
@@ -1,0 +1,40 @@
+{
+    "version": "3.6.5",
+    "description": "Modern model editor for boxy models and pixel art textures.",
+    "homepage": "https://github.com/JannisX11/blockbench/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://github.com/JannisX11/blockbench/releases/download/v3.6.5/Blockbench_3.6.5.exe#/dl.7z",
+    "hash": "sha512:373bfaea35bb2d0affebeee5a92214296f82c46339e37419df750734461849483486862a238bdfcea428618215a84ff2a1acf6a532f6cefdabe3dac418604ac6",
+    "architecture": {
+        "64bit": {
+            "installer": {
+                "script": [
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
+                ]
+            }
+        },
+        "32bit": {
+            "installer": {
+                "script": [
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
+                ]
+            }
+        }
+    },
+    "shortcuts": [
+        [
+            "Blockbench.exe",
+            "Blockbench"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/JannisX11/blockbench/releases/download/v$version/Blockbench_$version.exe#/dl.7z",
+        "hash": {
+            "url": "$baseurl/latest.yml",
+            "find": "sha512:\\s+(.*)"
+        }
+    }
+}


### PR DESCRIPTION
[Blockbench](https://blockbench.net/) is a handy tool for creating models and textures for games like Minecraft.