### PR TITLE
loot: Add version 0.15.1

### DIFF
--- a/bucket/loot.json
+++ b/bucket/loot.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/loot/loot",
-    "description": "Plugin load order optimisation tool for The Elder Scrolls and FallOut series",
+    "description": "Plugin load order optimisation tool for The Elder Scrolls and Fallout series",
     "license": "GPL-3.0-or-later",
     "version": "0.15.1",
     "url": "https://github.com/loot/loot/releases/download/0.15.1/loot_0.15.1-0-g82c756e_master.7z",

--- a/bucket/loot.json
+++ b/bucket/loot.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "https://github.com/loot/loot",
+    "description": "Plugin load order optimisation tool for TES III, IV and V",
+    "license": "GPL-3.0-or-later",
+    "version": "0.15.1",
+    "url": "https://github.com/loot/loot/releases/download/0.15.1/loot_0.15.1-0-g82c756e_master.7z",
+    "hash": "0d6764509c4f7d7ff21ec8f716b295b7fea015c6d4a39b0e6e0e0ad710ba87f8",
+    "extract_dir": "loot_0.15.1-0-g82c756e_master",
+    "bin": "LOOT.exe",
+    "shortcuts": [
+        [
+            "LOOT.exe",
+            "LOOT"
+        ]
+    ],
+    "suggests": {
+        "Visual C++ Redistributable 2019": "extras/vcredist2019"
+    },
+    "checkver": {
+        "github": "https://github.com/loot/loot",
+        "regex": "loot_([\\d.]+)-0-(?<commit>\\w+)_master\\.7z"
+    },
+    "autoupdate": {
+        "url": "https://github.com/loot/loot/releases/download/$version/loot_$version-0-$matchCommit_master.7z",
+        "extract_dir": "loot_$version-0-$matchCommit_master"
+    }
+}

--- a/bucket/loot.json
+++ b/bucket/loot.json
@@ -13,7 +13,7 @@
             "LOOT"
         ]
     ],
-    "suggests": {
+    "suggest": {
         "Visual C++ Redistributable 2019": "extras/vcredist2019"
     },
     "checkver": {

--- a/bucket/loot.json
+++ b/bucket/loot.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/loot/loot",
-    "description": "Plugin load order optimisation tool for TES III, IV and V",
+    "description": "Plugin load order optimisation tool for The Elder Scrolls and FallOut series",
     "license": "GPL-3.0-or-later",
     "version": "0.15.1",
     "url": "https://github.com/loot/loot/releases/download/0.15.1/loot_0.15.1-0-g82c756e_master.7z",


### PR DESCRIPTION
close #125 

**LOOT** ([Github repo](https://github.com/loot/loot)) is a plugin load order optimisation tool for TES III: Morrowind, TES IV: Oblivion, TES V: Skyrim, TES V: Skyrim Special Edition, Skyrim VR, Fallout 3, Fallout: New Vegas, Fallout 4 and Fallout 4 VR.

Notes:

* **persist** is not needed since *LOOT* stores its config at `$Env:LocalAppData\LOOT`.

*  MSVC 2017 x86 redistributable is required for *LOOT* to run properly. (see: https://github.com/loot/loot/releases/tag/0.15.1). Also, Visual C++ 2015, 2017 and 2019 all share the same redistributable files. Therefore I put **vcredist 2019** in suggest. (see: https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)

 