### PR TITLE
openxcom: Add version 2020_08_02_1732

### DIFF
--- a/bucket/openxcom.json
+++ b/bucket/openxcom.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://openxcom.org/",
-    "description": "Open-source clone of the 'UFO: Enemy Unknown' and 'X-COM: Terror From the Deep' video games.",
+    "description": "Open-source clone of the 'UFO: Enemy Unknown' and 'X-COM: Terror From the Deep' video games",
     "license": "GPL-3.0-or-later",
     "version": "2020_08_02_1732",
     "notes": [

--- a/bucket/openxcom.json
+++ b/bucket/openxcom.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://openxcom.org/",
-    "description": "Open-source clone of the 'UFO: Enemy Unknown' and 'X-COM: Terror From the Deep' video games",
+    "description": "Open source reimplementation of the 'UFO: Enemy Unknown' and 'X-COM: Terror From the Deep' video games",
     "license": "GPL-3.0-or-later",
     "version": "2020_08_02_1732",
     "notes": [

--- a/bucket/openxcom.json
+++ b/bucket/openxcom.json
@@ -1,0 +1,36 @@
+{
+    "homepage": "https://openxcom.org/",
+    "description": "Open-source clone of the 'UFO: Enemy Unknown' and 'X-COM: Terror From the Deep' video games.",
+    "license": "GPL-3.0-or-later",
+    "version": "2020_08_02_1732",
+    "notes": [
+        "OpenXcom requires a vanilla copy of the X-COM resources.",
+        "If you own the games on Steam, the Windows installer will automatically detect it and copy the resources over for you.",
+        "",
+        "If you want to copy things over manually, you can find the Steam game folders at:",
+        "　　UFO: 'Steam\\SteamApps\\common\\XCom UFO Defense\\XCOM'",
+        "　　TFTD: 'Steam\\SteamApps\\common\\X-COM Terror from the Deep\\TFD'"
+    ],
+    "url": "https://openxcom.org/git_builds/openxcom_git_master_2020_08_02_1732.zip",
+    "hash": "2a40d8f3de06b441bef1323dd315df4d9d9f93ba85f86ee570068dd16160ba78",
+    "extract_dir": "openxcom",
+    "bin": [
+        [
+            "openxcom.exe",
+            "OpenXcom"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "openxcom.exe",
+            "OpenXcom"
+        ]
+    ],
+    "checkver": {
+        "url": "https://openxcom.org/git-builds/",
+        "regex": "openxcom_git_master_([\\d_]+)\\.zip"
+    },
+    "autoupdate": {
+        "url": "https://openxcom.org/git_builds/openxcom_git_master_$version.zip"
+    }
+}


### PR DESCRIPTION
close #117

**OpenXcom** ([homepage](https://openxcom.org/)) ([Github repo](https://github.com/OpenXcom/OpenXcom)) is an open-source clone of "UFO: Enemy Unknown" ("X-COM: UFO Defense" in the USA release) and "X-COM: Terror From the Deep" videogames by Microprose.

Notes:
* **persist** is not needed because OpenXcom stores its config at `$Env:UserProfile\openxcom`.

* The **notes** section is written according to [the manual](https://github.com/OpenXcom/OpenXcom#installation).