### PR TITLE
Add Infra Arcana version 20.0

### DIFF
--- a/bucket/infraarcana.json
+++ b/bucket/infraarcana.json
@@ -8,7 +8,6 @@
     },
     "url": "https://gitlab.com/martin-tornqvist/ia/-/jobs/382433728/artifacts/download.zip",
     "hash": "2917ee563369bba7aae2d226edba9c80a0d4430f213c0590ef51a3ccc600ba71",
-    "bin": "ia.exe",
     "extract_dir": "ia windows x64 c38f34aa 2019-12-17",
     "shortcuts": [
         ["ia.exe", "Infra Arcana"],

--- a/bucket/infraarcana.json
+++ b/bucket/infraarcana.json
@@ -1,0 +1,17 @@
+{
+    "version": "20.0.0",
+    "description": "A roguelike game set in the early 20th century",
+    "homepage": "https://sites.google.com/site/infraarcana/home",
+    "license": {
+        "identifier": "AGPL-3.0-or-later",
+        "url": "https://gitlab.com/martin-tornqvist/ia/-/blob/develop/installed_files/LICENSE.txt"
+    },
+    "url": "https://gitlab.com/martin-tornqvist/ia/-/jobs/382433728/artifacts/download.zip",
+    "hash": "2917ee563369bba7aae2d226edba9c80a0d4430f213c0590ef51a3ccc600ba71",
+    "bin": "ia.exe",
+    "extract_dir": "ia windows x64 c38f34aa 2019-12-17",
+    "shortcuts": [
+        ["ia.exe", "Infra Arcana"],
+        ["manual.txt", "Infra Arcana Manual"]
+    ]
+}


### PR DESCRIPTION
Add Infra arcana v20.0
The download url points to a build artifact on gitlab. From what I checked over several weeks, the url is permanent. The download page also directs to gitlab pipelines which eventually redirect the browser to the build artifact. I haven't been able to find a way to make scoop follow that url. 

In the meantime, this is a way to install Infra Arcana using scoop.