### PR TITLE
Add AssetStudio 0.15.0

### DIFF
--- a/bucket/assetstudio.json
+++ b/bucket/assetstudio.json
@@ -1,0 +1,19 @@
+{
+    "homepage": "https://github.com/Perfare/AssetStudio",
+    "description": "Tool for exploring, extracting and exporting Unity assets and assetbundles.",
+    "version": "0.15.23",
+    "license": "MIT",
+    "url": "https://ci.appveyor.com/api/buildjobs/wxno7kxf5rk7bpsa/artifacts/AssetStudioGUI%2Fbin%2FAssetStudio.v0.15.23.zip",
+    "hash": "f538f01e32b98757ed58d7179c1f6ca410dd25f87cb7dd0795e3607e3604a705",
+    "bin": "AssetStudioGUI.exe",
+    "shortcuts": [
+        [
+            "AssetStudioGUI.exe",
+            "AssetStudio"
+        ]
+    ],
+    "checkver": {
+        "url": "https://ci.appveyor.com/api/projects/Perfare/assetstudio/history?recordsNumber=10",
+        "regex": "\"version\":\"([\\d.]+)\""
+    }
+}


### PR DESCRIPTION
This is my first Manifest, so let me know if you find any mistakes!

It has a checkver, but no autoupdate. because need a JobID and a BuildID to download the artifact from AppVeyor, which requires two http requests.