### PR TITLE
katrain: Add version 1.7

### DIFF
--- a/bucket/katrain.json
+++ b/bucket/katrain.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://github.com/sanderland/katrain",
+    "description": "A tool for analyzing and playing go with AI feedback from KataGo.",
+    "version": "1.7",
+    "license": "MIT",
+    "url": "https://github.com/sanderland/katrain/releases/download/1.7/KaTrain.zip",
+    "hash": "b5f15d77be14b31a4551248cbb9751ef361df3e7d59556bd98488d434146b998",
+    "extract_dir": "KaTrain",
+    "bin": "KaTrain.exe",
+    "shortcuts": [
+        [
+            "KaTrain.exe",
+            "KaTrain"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/sanderland/katrain/releases/download/$version/KaTrain.zip",
+        "hash": {
+            "url": "$baseurl/SHA2-256SUMS"
+        }
+    }
+}

--- a/bucket/katrain.json
+++ b/bucket/katrain.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/sanderland/katrain",
-    "description": "A tool for analyzing and playing go with AI feedback from KataGo.",
+    "description": "A tool for analyzing and playing go with AI feedback from KataGo",
     "version": "1.7",
     "license": "MIT",
     "url": "https://github.com/sanderland/katrain/releases/download/1.7/KaTrain.zip",


### PR DESCRIPTION
KaTrain is a tool for analyzing and playing go with AI feedback from KataGo.

It is a very helpful software to play Go but also to get AI feedback on our games. More info on their [github](https://github.com/sanderland/katrain).