### PR TITLE
Rework amidst.json

### DIFF
--- a/bucket/amidst.json
+++ b/bucket/amidst.json
@@ -1,23 +1,19 @@
 {
-    "homepage": "https://github.com/toolbox4minecraft/amidst",
-    "description": "Minecraft interface and data/structure tracking tool",
     "version": "4.6",
+    "description": "Minecraft interface and data/structure tracking tool",
+    "homepage": "https://github.com/toolbox4minecraft/amidst",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/toolbox4minecraft/amidst/releases/download/v4.6/amidst-v4-6.jar#/amidst.jar",
-    "hash": "137f4f718815f04a933325243ddca126c1d8d7720dcf8026926678a8a1ebe65b",
-    "bin": "amidst.bat",
+    "url": "https://github.com/toolbox4minecraft/amidst/releases/download/v4.6/amidst-v4-6.exe#/amidst.exe",
+    "hash": "8b75f93aca5c73074d3f1578d9251a4d05bbafcac3dd0d4e68b2d499eded6305",
+    "bin": "amidst.exe",
     "shortcuts": [
         [
-            "amidst.bat",
+            "amidst.exe",
             "Amidst"
         ]
     ],
-    "pre_install": "Set-Content -Path \"$dir\\amidst.bat\" -Value \"pushd $dir && javaw -jar amidst.jar && popd\"",
-    "suggest": {
-        "Java Runtime Environment": "java/adoptopenjdk-hotspot-jre"
-    },
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/toolbox4minecraft/amidst/releases/download/v$version/amidst-v$dashVersion.jar#/amidst.jar"
+        "url": "https://github.com/toolbox4minecraft/amidst/releases/download/v$version/amidst-v$dashVersion.exe#/amidst.exe"
     }
 }

--- a/bucket/amidst.json
+++ b/bucket/amidst.json
@@ -12,6 +12,9 @@
             "Amidst"
         ]
     ],
+    "suggest": {
+        "Java Runtime Environment": "java/adoptopenjdk-hotspot-jre"
+    },
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/toolbox4minecraft/amidst/releases/download/v$version/amidst-v$dashVersion.exe#/amidst.exe"


### PR DESCRIPTION
Switches to using the `.exe` version of amidst, this provides a simpler manifest/install. It also adds a start menu icon, which the batch file used previously did not.

I also moved the version field to the top, based on the scoop formatting standards.