### PR TITLE
openmw-nightly: Fix manifest for new build system

### DIFF
--- a/bucket/openmw-nightly.json
+++ b/bucket/openmw-nightly.json
@@ -1,30 +1,25 @@
 {
     "homepage": "http://openmw.org/",
     "description": "An open-source open-world RPG game engine that supports playing Morrowind. (nightly version)",
-    "version": "20200808-f73aa9f27",
+    "version": "20210207-31f41836",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-f73aa9f27-win64.exe#/dl.7z",
-            "hash": "43738f1b79ed42064edfb5408292a2ccd0d467df581fc7f01c06198305deafc7"
-        },
-        "32bit": {
-            "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-f73aa9f27-win32.exe#/dl.7z",
-            "hash": "1cd766bbc470b9a535b01871cc64b5477438f106a3758fa63dd4adbc8b09f4b5"
+            "url": "https://gitlab.com/OpenMW/openmw/-/jobs/artifacts/31f41836/download?job=Windows_Ninja_Engine_Release",
+            "hash": "81419661fb788b0d7e47ef659eae5686773f31128107996bd8e9d1b5ef93eeba"
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse",
+    "pre_install": [
+        "Expand-ZipArchive \"$dir\\download\" \"$dir\"",
+        "Expand-ZipArchive \"$dir\\OpenMW_MSVC2019_64_Release_master_*.zip\" \"$dir\""
+    ],
+    "post_install": "Remove-Item \"$dir\\MSVC2019_64_Ninja\", \"$dir\\chocolatey.log\", \"$dir\\OpenMW_MSVC2019_64_Release_master_*.zip\", \"$dir\\download\" -Force -Recurse",
     "bin": [
         "openmw.exe",
-        "openmw-cs.exe",
         "openmw-launcher.exe",
         [
             "openmw.exe",
             "openmw-nightly"
-        ],
-        [
-            "openmw-cs.exe",
-            "openmw-cs-nightly"
         ],
         [
             "openmw-launcher.exe",
@@ -37,35 +32,20 @@
             "OpenMW (nightly)"
         ],
         [
-            "openmw-cs.exe",
-            "OpenMW Construction Set (nightly)"
-        ],
-        [
             "openmw-launcher.exe",
             "OpenMW Launcher (nightly)"
         ]
     ],
     "notes": "Please run the OpenMW Launcher in the start menu to configure the game data path. Otherwise, OpenMW won't start correctly.",
     "checkver": {
-        "url": "https://openmw-nightlies.kubernetes.ctrl-c.liu.se/latest/OpenMW-latest-win32.json",
-        "regex": "(OpenMW-(?<commit>[a-z0-9]{9})-win32.exe.*\"date\":\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2}))",
+        "url": "https://gitlab.com/OpenMW/openmw/-/commits/master",
+        "regex": "datetime=\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})(?:.*\\n){7}.+Pipeline: passed(?:.*\\n){4}(?<commit>[0-9a-f]{8})",
         "replace": "${year}${month}${day}-${commit}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-$matchCommit-win64.exe#/dl.7z",
-                "hash": {
-                    "url": "https://openmw-nightlies.kubernetes.ctrl-c.liu.se/latest/OpenMW-latest-win64.sha256",
-                    "find": "([A-Fa-f0-9]{64})"
-                }
-            },
-            "32bit": {
-                "url": "https://rgw.ctrl-c.liu.se/openmw/Nightlies/OpenMW-$matchCommit-win32.exe#/dl.7z",
-                "hash": {
-                    "url": "https://openmw-nightlies.kubernetes.ctrl-c.liu.se/latest/OpenMW-latest-win32.sha256",
-                    "find": "([A-Fa-f0-9]{64})"
-                }
+                "url": "https://gitlab.com/OpenMW/openmw/-/jobs/artifacts/$matchCommit/download?job=Windows_Ninja_Engine_Release"
             }
         }
     }


### PR DESCRIPTION
A fix once again for the new build system for openmw-nightly. The manifest was update to the latest version in the process.