### PR TITLE
openmw-nightly: Fix for Windows PowerShell

### DIFF
--- a/bucket/openmw-nightly.json
+++ b/bucket/openmw-nightly.json
@@ -1,19 +1,16 @@
 {
     "homepage": "http://openmw.org/",
     "description": "An open-source open-world RPG game engine that supports playing Morrowind. (nightly version)",
-    "version": "20210207-4b7d0053",
+    "version": "20210208-e2ec3b0d",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://gitlab.com/OpenMW/openmw/-/jobs/artifacts/4b7d0053/download?job=Windows_Ninja_Engine_Release",
-            "hash": "7e3dd862a4f3da1f732310527aa01a6a55f28b3021ac86f0548956a43460a348"
+            "url": "https://gitlab.com/OpenMW/openmw/-/jobs/artifacts/e2ec3b0d/download?job=Windows_Ninja_Engine_Release#/dl.7z",
+            "hash": "762cdd3e5ec1f0c2ab9a510442c91b24960f8ec071ceb377a6a74a89722f7342"
         }
     },
-    "pre_install": [
-        "Expand-ZipArchive \"$dir\\download\" \"$dir\"",
-        "Expand-ZipArchive \"$dir\\OpenMW_MSVC2019_64_Release_master_*.zip\" \"$dir\""
-    ],
-    "post_install": "Remove-Item \"$dir\\MSVC2019_64_Ninja\", \"$dir\\chocolatey.log\", \"$dir\\OpenMW_MSVC2019_64_Release_master_*.zip\", \"$dir\\download\" -Force -Recurse",
+    "pre_install": "Expand-ZipArchive \"$dir\\OpenMW_MSVC2019_64_Release_master_*.zip\" \"$dir\"",
+    "post_install": "Remove-Item \"$dir\\MSVC2019_64_Ninja\", \"$dir\\chocolatey.log\", \"$dir\\OpenMW_MSVC2019_64_Release_master_*.zip\" -Force -Recurse",
     "bin": [
         "openmw.exe",
         "openmw-launcher.exe",
@@ -45,7 +42,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://gitlab.com/OpenMW/openmw/-/jobs/artifacts/$matchCommit/download?job=Windows_Ninja_Engine_Release"
+                "url": "https://gitlab.com/OpenMW/openmw/-/jobs/artifacts/$matchCommit/download?job=Windows_Ninja_Engine_Release#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
I realized that the manifest I made yesterday was only compatible with PowerShell Core, so I corrected it for Windows PowerShell and made it a little bit cleaner in the process. Sorry for the trouble.