### PR TITLE
openmw-nightly: Fix for new archive filename

### DIFF
--- a/bucket/openmw-nightly.json
+++ b/bucket/openmw-nightly.json
@@ -9,8 +9,8 @@
             "hash": "bbd8cd38f7b93983b60c324f36dc287431434c5565d75a0af0c2b80927dfc162"
         }
     },
-    "pre_install": "Expand-ZipArchive \"$dir\\OpenMW_MSVC2019_64_Release_master_*.zip\" \"$dir\"",
-    "post_install": "Remove-Item \"$dir\\MSVC2019_64_Ninja\", \"$dir\\chocolatey.log\", \"$dir\\OpenMW_MSVC2019_64_Release_master_*.zip\" -Force -Recurse",
+    "pre_install": "Expand-ZipArchive \"$dir\\OpenMW_MSVC2019_64_Release_master*.zip\" \"$dir\"",
+    "post_install": "Remove-Item \"$dir\\MSVC2019_64_Ninja\", \"$dir\\chocolatey.log\", \"$dir\\OpenMW_MSVC2019_64_Release_master*.zip\" -Force -Recurse",
     "bin": [
         "openmw.exe",
         "openmw-launcher.exe",


### PR DESCRIPTION
A small fix as the way the files were named changed slightly with a commit yesterday.