### PR TITLE
mgba-dev: return to normal versioning

### DIFF
--- a/bucket/mgba-dev.json
+++ b/bucket/mgba-dev.json
@@ -2,7 +2,7 @@
     "homepage": "https://mgba.io/",
     "description": "A fast, accurate, and portable GBA emulator (development version)",
     "license": "MPL-2.0",
-    "version": "6783",
+    "version": "6783-20210215",
     "architecture": {
         "64bit": {
             "url": "https://s3.amazonaws.com/mgba/build/mGBA-build-2021-02-15-win64-6783-232aab5a088543d11712fc9e18bfe56f616e1f73.7z",
@@ -50,15 +50,16 @@
     ],
     "checkver": {
         "url": "https://mgba.io/builds/1/",
-        "regex": "build-(?<year>20\\d{2})-(?<month>\\d{2})-(?<day>\\d{2})-win32-(?<version>[\\d]+)-(?<git>\\w{40})\\.7z"
+        "regex": "build-(?<year>20\\d{2})-(?<month>\\d{2})-(?<day>\\d{2})-win32-(?<ver>[\\d]+)-(?<git>\\w{40})\\.7z",
+        "replace": "$4-$1$2$3"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://s3.amazonaws.com/mgba/build/mGBA-build-$matchYear-$matchMonth-$matchDay-win64-$version-$matchGit.7z"
+                "url": "https://s3.amazonaws.com/mgba/build/mGBA-build-$matchYear-$matchMonth-$matchDay-win64-$matchVer-$matchGit.7z"
             },
             "32bit": {
-                "url": "https://s3.amazonaws.com/mgba/build/mGBA-build-$matchYear-$matchMonth-$matchDay-win32-$version-$matchGit.7z"
+                "url": "https://s3.amazonaws.com/mgba/build/mGBA-build-$matchYear-$matchMonth-$matchDay-win32-$matchVer-$matchGit.7z"
             }
         }
     }

--- a/bucket/mgba-dev.json
+++ b/bucket/mgba-dev.json
@@ -2,13 +2,15 @@
     "homepage": "https://mgba.io/",
     "description": "A fast, accurate, and portable GBA emulator (development version)",
     "license": "MPL-2.0",
-    "version": "nightly",
+    "version": "6783",
     "architecture": {
         "64bit": {
-            "url": "https://s3.amazonaws.com/mgba/mGBA-build-latest-win64.7z"
+            "url": "https://s3.amazonaws.com/mgba/build/mGBA-build-2021-02-15-win64-6783-232aab5a088543d11712fc9e18bfe56f616e1f73.7z",
+            "hash": "4bfd7d4b0d263e844ff350ecd87a84b247d96215e6b280fad118cba5f57e7fde"
         },
         "32bit": {
-            "url": "https://s3.amazonaws.com/mgba/mGBA-build-latest-win32.7z"
+            "url": "https://s3.amazonaws.com/mgba/build/mGBA-build-2021-02-15-win32-6783-232aab5a088543d11712fc9e18bfe56f616e1f73.7z",
+            "hash": "6caddc36749e97f79cb3f1a21dd062b174790658794d037cb66dafe986370d72"
         }
     },
     "installer": {
@@ -45,5 +47,19 @@
         "shaders",
         "qt.ini",
         "config.ini"
-    ]
+    ],
+    "checkver": {
+        "url": "https://mgba.io/builds/1/",
+        "regex": "build-(?<year>20\\d{2})-(?<month>\\d{2})-(?<day>\\d{2})-win32-(?<version>[\\d]+)-(?<git>\\w{40})\\.7z"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://s3.amazonaws.com/mgba/build/mGBA-build-$matchYear-$matchMonth-$matchDay-win64-$version-$matchGit.7z"
+            },
+            "32bit": {
+                "url": "https://s3.amazonaws.com/mgba/build/mGBA-build-$matchYear-$matchMonth-$matchDay-win32-$version-$matchGit.7z"
+            }
+        }
+    }
 }


### PR DESCRIPTION
It looks like at some point in time (or maybe I just missed it when I made it) mgba got a [builds page](https://mgba.io/builds/1/).    
Using this we can reliably get a build and avoid the hash mismatch issues. 