### PR TITLE
katrain: Fix autoupdate

### DIFF
--- a/bucket/katrain.json
+++ b/bucket/katrain.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://github.com/sanderland/katrain",
     "description": "A tool for analyzing and playing go with AI feedback from KataGo",
-    "version": "1.7.1",
+    "version": "1.7.6",
     "license": "MIT",
-    "url": "https://github.com/sanderland/katrain/releases/download/1.7.1/KaTrain.zip",
-    "hash": "7797e10c39075e1ec518187236f8cb56b5e04bf8d86bcfd8837aa5aad6b83479",
+    "url": "https://github.com/sanderland/katrain/releases/download/v1.7.6/KaTrain.zip",
+    "hash": "e7bf4912759a05078148e12f9197baf159ac8b3fafe29d711737e5483f1cdc66",
     "extract_dir": "KaTrain",
     "bin": "KaTrain.exe",
     "shortcuts": [
@@ -15,9 +15,6 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/sanderland/katrain/releases/download/$version/KaTrain.zip",
-        "hash": {
-            "url": "$baseurl/SHA2-256SUMS"
-        }
+        "url": "https://github.com/sanderland/katrain/releases/download/v$version/KaTrain.zip"
     }
 }


### PR DESCRIPTION
The version tags on Github were changed so I had to change the autoupdate URL.