### PR TITLE
advanced-genie-editor: Add version 2021.3.15

### DIFF
--- a/bucket/advanced-genie-editor.json
+++ b/bucket/advanced-genie-editor.json
@@ -1,0 +1,26 @@
+{
+    "homepage": "https://github.com/Tapsa/AGE",
+    "version": "2021.3.15",
+    "license": "GPL-3.0-or-later",
+    "description": "Data editor for Age of Empires I/II (including DE), Star Wars Galactic Battlegrounds and Clone Campaigns",
+    "url": "https://docs.google.com/uc?export=download&id=1G5Z_TkXVP-CIC-haUYvOkLlmDt8aV6Di#/dl.zip",
+    "hash": "5b95bb4f75b0aba82c4f5d07f1ab6df8f7db26616a52710b2f6c437c8bd194a5",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\")) {New-Item \"$persist_dir\" -ItemType Directory | Out-Null}",
+        "else {Copy-Item \"$persist_dir\\*\" -Destination \"$dir\" -Recurse}"
+    ],
+    "uninstaller": {
+        "script": "Copy-Item \"$dir\\AGE3*.ini\" -Destination \"$persist_dir\" -Force -Recurse"
+    },
+    "checkver": {
+        "url": "http://aok.heavengames.com/blacksmith/showfile.php?fileid=11002",
+        "regex": "Version <b>([\\d.]+)</b>"
+    },
+    "bin": "AdvancedGenieEditor3.exe",
+    "shortcuts":[
+        [
+            "AdvancedGenieEditor3.exe",
+            "Advanced Genie Editor 3"
+        ]
+    ]
+}

--- a/bucket/advanced-genie-editor.json
+++ b/bucket/advanced-genie-editor.json
@@ -1,8 +1,8 @@
 {
-    "homepage": "https://github.com/Tapsa/AGE",
     "version": "2021.3.15",
-    "license": "GPL-3.0-or-later",
     "description": "Data editor for Age of Empires I/II (including DE), Star Wars Galactic Battlegrounds and Clone Campaigns",
+    "homepage": "https://github.com/Tapsa/AGE",
+    "license": "GPL-3.0-or-later",
     "url": "https://docs.google.com/uc?export=download&id=1G5Z_TkXVP-CIC-haUYvOkLlmDt8aV6Di#/dl.zip",
     "hash": "5b95bb4f75b0aba82c4f5d07f1ab6df8f7db26616a52710b2f6c437c8bd194a5",
     "pre_install": [
@@ -12,15 +12,15 @@
     "uninstaller": {
         "script": "Copy-Item \"$dir\\AGE3*.ini\" -Destination \"$persist_dir\" -Force -Recurse"
     },
-    "checkver": {
-        "url": "http://aok.heavengames.com/blacksmith/showfile.php?fileid=11002",
-        "regex": "Version <b>([\\d.]+)</b>"
-    },
     "bin": "AdvancedGenieEditor3.exe",
     "shortcuts":[
         [
             "AdvancedGenieEditor3.exe",
             "Advanced Genie Editor 3"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "http://aok.heavengames.com/blacksmith/showfile.php?fileid=11002",
+        "regex": "Version <b>([\\d.]+)</b>"
+    }
 }


### PR DESCRIPTION
[Advanced Genie Editor](http://aok.heavengames.com/blacksmith/showfile.php?fileid=11002) is a data editor for Age of Empires I/II (including DE), Star Wars Galactic Battlegrounds and Clone Campaigns.

Notes:

* **Direct download link** is not available on the official website. Therefore, I use an alternative link. Is this acceptable?

* GPL 3.0 license is specified in the [official repo](https://github.com/Tapsa/AGE/blob/master/Copying.txt).