### PR TITLE
raze: Update to version 1.0.1

### DIFF
--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://github.com/coelckers/Raze",
     "description": "Modern source port for Duke Nukem 3D, Blood, Redneck Rampage, Shadow Warrior and Exhumed/Powerslave",
-    "version": "0.9.1",
+    "version": "1.0.1",
     "license": "Custom",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/coelckers/Raze/releases/download/0.9.1_beta/raze_0.9.1.zip",
-            "hash": "45110801ba332586c94ecf24fef297e8f51407040ca0df79175bbbe38bf23083"
+            "url": "https://github.com/coelckers/Raze/releases/download/1.0.1/raze_1.0.1.zip",
+            "hash": "36b7be2ee2622e2b07947eebd25bfa3a739ea3402c25e2dafe57d5ad5f5f6b65"
         }
     },
     "bin": "raze.exe",
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/coelckers/Raze/releases/download/$version_beta/raze_$version.zip"
+                "url": "https://github.com/coelckers/Raze/releases/download/$version/raze_$version.zip"
             }
         }
     },


### PR DESCRIPTION
- Updated urls to match the new naming scheme; omitting the beta tag.
- This also makes the json update to the latest available version.