### PR TITLE
dgvoodoo2: Add version 2.77

### DIFF
--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -1,0 +1,25 @@
+{
+	"homepage": "https://github.com/dege-diosg/dgVoodoo2",
+	"description": "Glide/DirectX implementation on D3D11/12. Play your old Glide and DirectX games even on the latest, modern version of Windows.",
+	"version": "2.74",
+	"license": "http://dege.freeweb.hu/dgVoodoo2/ReadmeGeneral/#redistributionrights",
+    "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.74/dgVoodoo2_74.zip",
+    "hash": "c309fc13d13b85aa24a137015682d746076077feb3aea9568811f9fcbdd4b08d",
+    "checkver": "github",
+    "autoupdate": {	
+		"url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v$version/dgVoodoo$underscoreVersion.zip"	
+	},
+	"notes": [
+		"",
+		"An excellent guide for using the software can be found here: https://www.pcgamingwiki.com/wiki/DgVoodoo_2",
+		"",
+		"Basically you take the DLL for whatever API you need to convert and copy it to the directory of the application you want to run.",
+		"",
+		"Then if you want to customize any settings, copy dgVoodooCpl.exe and dgVoodoo.conf to the app directory as well.",
+		"",
+		"dgVoodooCpl.exe gives you a GUI to configure your settings, while dgVoodoo.conf is edited with a text editor.", 
+		"",
+		"Some advanced features are not available through the dgVoodooCpl program, but can be set manually in the dgVoodoo.conf file.",
+		""
+    ]
+}

--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -13,13 +13,13 @@
         "",
         "An excellent guide for using the software can be found here: https://www.pcgamingwiki.com/wiki/DgVoodoo_2",
         "",
-        "Basically you take the DLL for whatever API you need to convert and copy it to the directory of the application you want to run.",
+        "Basically you take the DLLs for whatever API you need to convert and copy them to the directory of the application you want to run.",
         "",
         "Then if you want to customize any settings, copy dgVoodooCpl.exe and dgVoodoo.conf to the app directory as well.",
         "",
         "dgVoodooCpl.exe gives you a GUI to configure your settings, while dgVoodoo.conf is edited with a text editor.",
         "",
-        "Some advanced features are not available through the dgVoodooCpl program, but can be set manually in the dgVoodoo.conf file.",
+        "Some advanced features are not available through the dgVoodooCpl app, but can be set manually in the dgVoodoo.conf file.",
         ""
     ]
 }

--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -1,6 +1,6 @@
 {
 	"homepage": "https://github.com/dege-diosg/dgVoodoo2",
-	"description": "Glide/DirectX implementation on D3D11/12. Play your old Glide and DirectX games even on the latest, modern version of Windows.",
+	"description": "Glide/DirectX implementation on D3D11/12. Play your old Glide and DirectX games even on the latest, modern versions of Windows.",
 	"version": "2.74",
 	"license": "http://dege.freeweb.hu/dgVoodoo2/ReadmeGeneral/#redistributionrights",
     "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.74/dgVoodoo2_74.zip",

--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://github.com/dege-diosg/dgVoodoo2",
     "description": "Glide/DirectX implementation on D3D11/12. Play your old Glide and DirectX games even on the latest, modern versions of Windows.",
-    "version": "2.74",
+    "version": "2.77",
     "license": "http://dege.freeweb.hu/dgVoodoo2/ReadmeGeneral/#redistributionrights",
-    "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.74/dgVoodoo2_74.zip",
-    "hash": "c309fc13d13b85aa24a137015682d746076077feb3aea9568811f9fcbdd4b08d",
+    "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.77/dgVoodoo2_77.zip",
+    "hash": "0bb63158ab25d2b91a461bc954683289a1a443068ab9c77c5d754deb1823c8d1",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v$version/dgVoodoo$underscoreVersion.zip"

--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -11,13 +11,13 @@
     },
     "notes": [
         "",
-        "An excellent guide for using the software can be found here: https://www.pcgamingwiki.com/wiki/DgVoodoo_2",
+        "A guide for using the software can be found here: https://www.pcgamingwiki.com/wiki/DgVoodoo_2",
         "",
-        "Basically you take the DLLs for whatever API you need to convert and copy them to the directory of the application you want to run.",
+        "Basically, you take the DLLs for whatever API you need to convert and copy them to the directory of the application you want to run.",
         "",
-        "Then if you want to customize any settings, copy dgVoodooCpl.exe and dgVoodoo.conf to the app directory as well.",
+        "Then, if you want to customize any settings, copy dgVoodooCpl.exe and dgVoodoo.conf to the app directory as well.",
         "",
-        "dgVoodooCpl.exe gives you a GUI to configure your settings, while dgVoodoo.conf is edited with a text editor.",
+        "dgVoodooCpl.exe gives you a GUI to configure your settings, while dgVoodoo.conf must be edited with a text editor.",
         "",
         "Some advanced features are not available through the dgVoodooCpl app, but can be set manually in the dgVoodoo.conf file.",
         ""

--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -1,25 +1,25 @@
 {
-	"homepage": "https://github.com/dege-diosg/dgVoodoo2",
-	"description": "Glide/DirectX implementation on D3D11/12. Play your old Glide and DirectX games even on the latest, modern versions of Windows.",
-	"version": "2.74",
-	"license": "http://dege.freeweb.hu/dgVoodoo2/ReadmeGeneral/#redistributionrights",
+    "homepage": "https://github.com/dege-diosg/dgVoodoo2",
+    "description": "Glide/DirectX implementation on D3D11/12. Play your old Glide and DirectX games even on the latest, modern versions of Windows.",
+    "version": "2.74",
+    "license": "http://dege.freeweb.hu/dgVoodoo2/ReadmeGeneral/#redistributionrights",
     "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.74/dgVoodoo2_74.zip",
     "hash": "c309fc13d13b85aa24a137015682d746076077feb3aea9568811f9fcbdd4b08d",
     "checkver": "github",
     "autoupdate": {	
 		"url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v$version/dgVoodoo$underscoreVersion.zip"	
-	},
-	"notes": [
-		"",
-		"An excellent guide for using the software can be found here: https://www.pcgamingwiki.com/wiki/DgVoodoo_2",
-		"",
-		"Basically you take the DLL for whatever API you need to convert and copy it to the directory of the application you want to run.",
-		"",
-		"Then if you want to customize any settings, copy dgVoodooCpl.exe and dgVoodoo.conf to the app directory as well.",
-		"",
-		"dgVoodooCpl.exe gives you a GUI to configure your settings, while dgVoodoo.conf is edited with a text editor.", 
-		"",
-		"Some advanced features are not available through the dgVoodooCpl program, but can be set manually in the dgVoodoo.conf file.",
-		""
+    },
+    "notes": [
+        "",
+        "An excellent guide for using the software can be found here: https://www.pcgamingwiki.com/wiki/DgVoodoo_2",
+        "",
+        "Basically you take the DLL for whatever API you need to convert and copy it to the directory of the application you want to run.",
+        "",
+        "Then if you want to customize any settings, copy dgVoodooCpl.exe and dgVoodoo.conf to the app directory as well.",
+        "",
+        "dgVoodooCpl.exe gives you a GUI to configure your settings, while dgVoodoo.conf is edited with a text editor.", 
+        "",
+        "Some advanced features are not available through the dgVoodooCpl program, but can be set manually in the dgVoodoo.conf file.",
+        ""
     ]
 }

--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.74/dgVoodoo2_74.zip",
     "hash": "c309fc13d13b85aa24a137015682d746076077feb3aea9568811f9fcbdd4b08d",
     "checkver": "github",
-    "autoupdate": {	
-		"url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v$version/dgVoodoo$underscoreVersion.zip"	
+    "autoupdate": {
+        "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v$version/dgVoodoo$underscoreVersion.zip"	
     },
     "notes": [
         "",

--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.74/dgVoodoo2_74.zip",
     "hash": "c309fc13d13b85aa24a137015682d746076077feb3aea9568811f9fcbdd4b08d",
     "checkver": "github",
-    "autoupdate": { 
-        "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v$version/dgVoodoo$underscoreVersion.zip"	
+    "autoupdate": {
+        "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v$version/dgVoodoo$underscoreVersion.zip"
     },
     "notes": [
         "",

--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.74/dgVoodoo2_74.zip",
     "hash": "c309fc13d13b85aa24a137015682d746076077feb3aea9568811f9fcbdd4b08d",
     "checkver": "github",
-    "autoupdate": {
+    "autoupdate": { 
         "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v$version/dgVoodoo$underscoreVersion.zip"	
     },
     "notes": [
@@ -17,7 +17,7 @@
         "",
         "Then if you want to customize any settings, copy dgVoodooCpl.exe and dgVoodoo.conf to the app directory as well.",
         "",
-        "dgVoodooCpl.exe gives you a GUI to configure your settings, while dgVoodoo.conf is edited with a text editor.", 
+        "dgVoodooCpl.exe gives you a GUI to configure your settings, while dgVoodoo.conf is edited with a text editor.",
         "",
         "Some advanced features are not available through the dgVoodooCpl program, but can be set manually in the dgVoodoo.conf file.",
         ""


### PR DESCRIPTION
Glide/DirectX implementation on D3D11/12. Play your old Glide and DirectX games even on the latest, modern versions of Windows.