### PR TITLE
mameui: Add description, persist folders

### DIFF
--- a/bucket/mameui.json
+++ b/bucket/mameui.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.mameui.info/",
-    "description": "MAME is a multi-purpose emulation framework",
+    "description": "GUI frontend for MAME, the multi-purpose emulation framework",
     "version": "nightly",
     "license": "GPL-2.0-or-later",
     "architecture": {

--- a/bucket/mameui.json
+++ b/bucket/mameui.json
@@ -1,5 +1,6 @@
 {
     "homepage": "http://www.mameui.info/",
+    "description": "MAME is a multi-purpose emulation framework",
     "version": "nightly",
     "license": "GPL-2.0-or-later",
     "architecture": {
@@ -15,6 +16,16 @@
             ]
         }
     },
+    "persist": [
+        "cfg",
+        "diff",
+        "ini",
+        "inp",
+        "memcard",
+        "nvram",
+        "snap",
+        "sta"
+    ],
     "checkver": {
         "regex": "MAMEUI v\\.([\\d]+) Download",
         "replace": "0.${1}"


### PR DESCRIPTION
- Add description
- Persist folders that I believe to be the most appropriate; those that save things like settings, snapshots, nvram and similar, and not folders like roms and similar since these are often specified to custom directories anyway.

Sadly I can't persist the ini files in the root folder since these are created on the first startup of the software.