### PR TITLE
dolphin: Fix portable mode broken by c63f4af

### DIFF
--- a/bucket/dolphin-dev.json
+++ b/bucket/dolphin-dev.json
@@ -10,7 +10,6 @@
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-item \"$persist_dir\" -ItemType Directory | Out-Null",
         "   New-item \"$persist_dir\\User\" -ItemType Directory | Out-Null",
-        "   New-item \"$persist_dir\\portable.txt\" -ItemType File | Out-Null",
         "   if (Test-Path \"$env:USERPROFILE\\Documents\\Dolphin Emulator\") {",
         "       Write-host \"Migrating AppData...\" -ForegroundColor yellow",
         "       Copy-Item -Path \"$env:USERPROFILE\\Documents\\Dolphin Emulator\\*\" -Destination \"$persist_dir\\User\" -Recurse",
@@ -26,6 +25,7 @@
         ]
     ],
     "persist": "User",
+    "post_install": "Set-Content -Value $null -Path \"$dir\\portable.txt\"",
     "checkver": {
         "url": "https://dolphin-emu.org/download/",
         "regex": "\\/(?<rand1>.{2})\\/(?<rand2>.{2})\\/dolphin-master-(?<major>[\\d\\.]+)-(?<build>[\\d]+)",

--- a/bucket/dolphin.json
+++ b/bucket/dolphin.json
@@ -9,7 +9,6 @@
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-item \"$persist_dir\" -ItemType Directory | Out-Null",
         "   New-item \"$persist_dir\\User\" -ItemType Directory | Out-Null",
-        "   New-item \"$persist_dir\\portable.txt\" -ItemType File | Out-Null",
         "   if (Test-Path \"$env:USERPROFILE\\Documents\\Dolphin Emulator\") {",
         "       Write-host \"Migrating AppData...\" -ForegroundColor yellow",
         "       Copy-Item -Path \"$env:USERPROFILE\\Documents\\Dolphin Emulator\\*\" -Destination \"$persist_dir\\User\" -Recurse",
@@ -25,6 +24,7 @@
         ]
     ],
     "persist": "User",
+    "post_install": "Set-Content -Value $null -Path \"$dir\\portable.txt\"",
     "checkver": {
         "url": "https://dolphin-emu.org/download/",
         "regex": "dolphin-emu\\.org\\/(?<version>[\\d\\.]+)\\/"


### PR DESCRIPTION
Commit c63f4af broke dolphin portable mode by removing the `post_install` and instead creating `portable.txt` in `$persist_dir` during `pre_install`, which isn't correct.

Removed that line from `pre_install` and restored the removed `post_install`.