### PR TITLE
pingus: Add version 0.7.6

### DIFF
--- a/bucket/pingus.json
+++ b/bucket/pingus.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.7.6",
+    "description": "Pingus is a free Lemmingstm-like puzzle game",
+    "homepage": "https://pingus.gitlab.io/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://github.com/Pingus/downloads/blob/master/Pingus-0.7.6.exe?raw=true#/setup.exe",
+    "hash": "f08e45a96a95f293767e7c2dba98ae3feefd3a1d13e5c6461bcc8a111aa9618d",
+    "installer": {
+        "script": "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList \"/S\", \"/D=$dir\" -Wait"
+    },
+    "uninstaller": {
+        "script": "Start-Process -FilePath \"$dir\\Uninstall.exe\" -ArgumentList /S -Wait"
+    },
+    "post_install": [
+        "Remove-Item \"$dir\\doc\", \"$dir\\external\", \"$dir\\extra\", \"$dir\\src\", \"$dir\\test\", \"$dir\\tools\", \"$dir\\windows-installer\" -Force -Recurse",
+        "Remove-Item \"$dir\\pingus.sln\", \"$dir\\pingus.vcproj\", \"$dir\\TODO\", \"$dir\\VERSION\", \"$dir\\.gitignore\", \"$dir\\INSTALL.*\", \"$dir\\Makefile\", \"$dir\\NEWS\", \"$dir\\SConscript*\", \"$dir\\SConstruct*\", \"$dir\\setup.exe\" -Force"
+    ],
+    "bin": "pingus.exe",
+    "shortcuts": [
+        [
+            "pingus.exe",
+            "Pingus"
+        ]
+    ],
+    "checkver": {
+        "url": "https://pingus.gitlab.io/download.html",
+        "re": "Pingus-([\\d.]+).exe"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Pingus/downloads/blob/master/Pingus-$version.exe?raw=true#/setup.exe"
+    }
+}


### PR DESCRIPTION
# Pingus

Pingus is a free Lemmingstm-like puzzle game covered under the GNU GPL. It features currently 77 playable levels and runs under a wide variety of operating systems (Linux, Windows, MacOSX, etc.)

Homepage: https://pingus.gitlab.io

## Screenshot
![tutorial](https://pingus.gitlab.io/images/screen_0.7.0-4.jpg)

## PR comments

- Pingus project is officially on Gitlab, but binaries are downloaded from Github. It's what it is.
- Installation contains a lot of mess, that's why I clean it up in post_install section

This game is simple and beautiful.
