### PR TITLE
Improve amidst.json

### DIFF
--- a/bucket/amidst.json
+++ b/bucket/amidst.json
@@ -6,16 +6,24 @@
     "suggest": {
         "Java Runtime Environment": "java/adoptopenjdk-hotspot-jre"
     },
-    "url": "https://github.com/toolbox4minecraft/amidst/releases/download/v4.6/amidst-v4-6.jar#/amidst.jar",
-    "hash": "137f4f718815f04a933325243ddca126c1d8d7720dcf8026926678a8a1ebe65b",
+    "url": [
+        "https://github.com/toolbox4minecraft/amidst/releases/download/v4.6/amidst-v4-6.jar#/amidst.jar",
+        "https://raw.githubusercontent.com/toolbox4minecraft/amidst/master/src/main/resources/amidst/icon/amidst.ico"
+    ],
+    "hash": [
+        "137f4f718815f04a933325243ddca126c1d8d7720dcf8026926678a8a1ebe65b",
+        "72a590ca98fc21d315b090b2ae82a46b99a56934c1d17e3c7ea0bba6f45a5d61"
+    ],
     "bin": "amidst.bat",
     "shortcuts": [
         [
             "amidst.bat",
-            "Amidst"
+            "Amidst",
+            "",
+            "amidst.ico"
         ]
     ],
-    "pre_install": "Set-Content -Path \"$dir\\amidst.bat\" -Value \"pushd $dir && javaw -jar amidst.jar && popd\"",
+    "pre_install": "Set-Content -Path \"$dir\\amidst.bat\" -Value \"@echo off`njava -jar `\"$dir\\amidst.jar`\" %*\"",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/toolbox4minecraft/amidst/releases/download/v$version/amidst-v$dashVersion.jar#/amidst.jar"

--- a/bucket/amidst.json
+++ b/bucket/amidst.json
@@ -1,8 +1,11 @@
 {
-    "homepage": "https://github.com/toolbox4minecraft/amidst",
-    "description": "Minecraft interface and data/structure tracking tool",
     "version": "4.6",
+    "description": "Minecraft interface and data/structure tracking tool",
+    "homepage": "https://github.com/toolbox4minecraft/amidst",
     "license": "GPL-3.0-only",
+    "suggest": {
+        "Java Runtime Environment": "java/adoptopenjdk-hotspot-jre"
+    },
     "url": "https://github.com/toolbox4minecraft/amidst/releases/download/v4.6/amidst-v4-6.jar#/amidst.jar",
     "hash": "137f4f718815f04a933325243ddca126c1d8d7720dcf8026926678a8a1ebe65b",
     "bin": "amidst.bat",
@@ -13,9 +16,6 @@
         ]
     ],
     "pre_install": "Set-Content -Path \"$dir\\amidst.bat\" -Value \"pushd $dir && javaw -jar amidst.jar && popd\"",
-    "suggest": {
-        "Java Runtime Environment": "java/adoptopenjdk-hotspot-jre"
-    },
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/toolbox4minecraft/amidst/releases/download/v$version/amidst-v$dashVersion.jar#/amidst.jar"


### PR DESCRIPTION
Take 2 of #184, it keeps the `jar` version of amidst and so should work fine for everyone.
* adds amidst icon to start menu
* shows log output in batch window
* provides access to the amidst cli

I also formatted the file first with `formatjson.ps1`. 