### PR TITLE
assetstudio: Update to version 0.15.47, add autoupdate

### DIFF
--- a/bucket/assetstudio.json
+++ b/bucket/assetstudio.json
@@ -1,19 +1,16 @@
 {
     "homepage": "https://github.com/Perfare/AssetStudio",
     "description": "Tool for exploring, extracting and exporting Unity assets and assetbundles.",
-    "version": "0.15.23",
+    "version": "0.15.47",
     "license": "MIT",
-    "url": "https://ci.appveyor.com/api/buildjobs/wxno7kxf5rk7bpsa/artifacts/AssetStudioGUI%2Fbin%2FAssetStudio.v0.15.23.zip",
-    "hash": "f538f01e32b98757ed58d7179c1f6ca410dd25f87cb7dd0795e3607e3604a705",
+    "url": "https://github.com/Perfare/AssetStudio/releases/download/v0.15.47/AssetStudio.v0.15.47.zip",
+    "hash": "542BF3E416656CC28DB45F648FF2735B57E97C8207C8025C7A0CF792D85CBD91",
     "bin": "AssetStudioGUI.exe",
-    "shortcuts": [
-        [
-            "AssetStudioGUI.exe",
-            "AssetStudio"
-        ]
-    ],
+    "shortcuts": [["AssetStudioGUI.exe", "AssetStudio"]],
     "checkver": {
-        "url": "https://ci.appveyor.com/api/projects/Perfare/assetstudio/history?recordsNumber=10",
-        "regex": "\"version\":\"([\\d.]+)\""
+        "github": "https://github.com/Perfare/AssetStudio"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Perfare/AssetStudio/releases/download/v$version/AssetStudio.v$version.zip"
     }
 }


### PR DESCRIPTION
They started using the github release again for the release, so autoupdate is now available.