### PR TITLE
openmw-nightly: Update only if the build passed

### DIFF
--- a/bucket/openmw-nightly.json
+++ b/bucket/openmw-nightly.json
@@ -36,7 +36,7 @@
     "notes": "Please run the OpenMW Launcher in the start menu to configure the game data path. Otherwise, OpenMW won't start correctly.",
     "checkver": {
         "url": "https://gitlab.com/OpenMW/openmw/-/jobs",
-        "regex": "(?<commit>[0-9a-f]{8})(?:.*\\n){16}Windows_Ninja_Engine_Release(?:.*\\n){10}.*?datetime=\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})(?:.*\\n){8}.*?\\/OpenMW\\/openmw\\/-\\/jobs\\/(?<job>[0-9]{10})",
+        "regex": ">(?<commit>[0-9a-f]{8})(?:.*\\n){16}Windows_Ninja_Engine_Release(?:.*\\n){10}.*?datetime=\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})(?:.*\\n){8}.*?\\/OpenMW\\/openmw\\/-\\/jobs\\/(?<job>[0-9]{10})(?:.*\\n){8}passed",
         "replace": "${year}${month}${day}-${commit}"
     },
     "autoupdate": {


### PR DESCRIPTION
Since my last fix, the autoupdate could trigger on failed build, which made the installation fail. I updated the regex to check for this.