### PR TITLE
yquake2: Update to version 8.00

### DIFF
--- a/bucket/yquake2.json
+++ b/bucket/yquake2.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://www.yamagi.org/quake2/",
     "description": "Conservative Quake 2 source port focused on singleplayer and cooperative gameplay",
-    "version": "7.45",
+    "version": "8.00",
     "license": "GPL-2.0-or-later",
-    "url": "https://deponie.yamagi.org/quake2/windows/quake2-7.45.zip",
-    "hash": "dbfa587ca66d22f2cbb7aa5bb24655f6e7561b6188b7e58bbf713027fb842a49",
-    "extract_dir": "quake2-7.45",
+    "url": "https://deponie.yamagi.org/quake2/windows/quake2-8.00.zip",
+    "hash": "86390febd8b50aabd4acf4aaa9852b8c95704a439e1b6355e0db6365b026e8a3",
+    "extract_dir": "quake2-8.00",
     "bin": [
         "yquake2.exe",
         "q2ded.exe"
@@ -65,10 +65,13 @@
         ""
     ],
     "checkver": {
-        "re": "Yamagi Quake II version <strong>(\\d+\\.\\d+)</strong> was released"
+        "url": "https://deponie.yamagi.org/quake2/windows",
+        "regex": "(?'ver'\\d\\.\\d{2}[a-z]?)",
+        "reverse": true,
+        "replace": "${ver}"
     },
     "autoupdate": {
-        "url": "https://deponie.yamagi.org/quake2/windows/quake2-$version.zip",
-        "extract_dir": "quake2-$version"
+        "url": "https://deponie.yamagi.org/quake2/windows/quake2-$matchVer.zip",
+        "extract_dir": "quake2-$matchVer"
     }
 }


### PR DESCRIPTION
Took another shot at it, turns out scoop has a built-in last match function. No need for regex non-sense.
This also updates yquake2 to 8.00
Closes #266 