### PR TITLE
Fix "invalid JSON primitive" error

### DIFF
--- a/bucket/mgba-dev.json
+++ b/bucket/mgba-dev.json
@@ -16,8 +16,8 @@
     "installer": {
         "script": [
             "Move-Item -Path \"$(Get-ChildItem -Path $dir)\\*\" -Destination \"$dir\"",
-            "Set-Location -Path $dir", //This is a little hacky but not much we can do
-            "Remove-Item -Path $(Get-ChildItem -Path $dir -Name -Include mGBA-build*)", //This is a little hacky but not much we can do
+            "Set-Location -Path $dir",
+            "Remove-Item -Path $(Get-ChildItem -Path $dir -Name -Include mGBA-build*)",
             "if (!(Test-Path \"$persist_dir\\qt.ini\")) {",
             "   New-Item \"$dir\\qt.ini\" -ItemType \"file\" | Out-Null ",
             "}",


### PR DESCRIPTION
The comment lines will cause following error message when searching for any apps:

```
convertfrom-json : 无效的 JSON 基元: 。(invalid JSON primitive)
所在位置 C:\Users\xxx\scoop\apps\scoop\current\lib\manifest.ps1:10 字符: 45
+     Get-Content $path -raw -Encoding UTF8 | convertfrom-json -ea stop
+                                             ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [ConvertFrom-Json], ArgumentException
    + FullyQualifiedErrorId : System.ArgumentException,Microsoft.PowerShell.Commands.ConvertFromJsonCommand
```