### PR TITLE
melonds: Update to version 0.9.3, fix autoupdate

### DIFF
--- a/bucket/melonds.json
+++ b/bucket/melonds.json
@@ -2,9 +2,9 @@
     "homepage": "http://melonds.kuribo64.net/",
     "description": "A Nintendo DS emulator aiming for fast and accurate emulation",
     "license": "GPL-3.0-or-later",
-    "version": "0.9.2",
-    "url": "https://github.com/Arisotura/melonDS/releases/download/0.9.2/melonDS_0.9.2_win64.7z",
-    "hash": "aabed26e6056697b73ab7388b5c18a08318c66684f1fe7b907e7772f74ed6c94",
+    "version": "0.9.3",
+    "url": "https://github.com/Arisotura/melonDS/releases/download/0.9.3/melonDS_0.9.3_win_x64.7z",
+    "hash": "108693998ce58175b4acb02788177f80e9e277658fa2cc9c62a2c7ae34181b10",
     "installer": {
         "script": [
             "$FILE = 'bios7.bin'",
@@ -50,6 +50,6 @@
         "github": "https://github.com/Arisotura/melonDS"
     },
     "autoupdate": {
-        "url": "https://github.com/Arisotura/melonDS/releases/download/$version/melonDS_$version_win64.7z"
+        "url": "https://github.com/Arisotura/melonDS/releases/download/$version/melonDS_$version_win_64.7z"
     }
 }


### PR DESCRIPTION
They added an underscore before 'x64' in the URL making autoupdate string invalid - hopefully this is the only thing they changed this release.

EDIT: check fail says this:

"The following 1 lines contain trailing whitespace: 

File: C:\projects\scoop-games\bucket\opdessertstorm.json, Line: 31"

Don't know where this comes from as it's nothing to do with this manifest.