### PR TITLE
Add RPCS3 persist files and folders.

### DIFF
--- a/bucket/rpcs3-dev.json
+++ b/bucket/rpcs3-dev.json
@@ -9,7 +9,14 @@
     "depends": "vcredist2019",
     "persist": [
         "GuiConfigs",
-        "dev_hdd0"
+        "dev_hdd0",
+        "dev_flash",
+        "cache",
+        "config.yml",
+        "config",
+        "games.yml",
+        "Icons",
+        "patches"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
There are some files and folders that aren't persisted for RPCS3:

| Folder | Explanation |
| - | - |
| `dev_flash` | Where the firmware is installed to. Persisting this avoids having to reinstall the firmware every updated. |
| `cache` | PPU modules can take quite bit of time to compile on first run of a game, persisting this allows cache from the previous version to work. |
| `config.yml` | The global emulator configuration. |
| `config` | Game-specific emulator configuration and controller configurations. |
| `games.yml` | The games visible in the game list when you start RPCS3. |
| `Icons` | Custom icon location. |
| `patches` | Downloaded game patches. |

To my knowledge, the built-in RPCS3 updater persists these files and folders, so scoop should too.