### PR TITLE
rpcs3-dev: Create `.yml` files if they don't exist

### DIFF
--- a/bucket/rpcs3-dev.json
+++ b/bucket/rpcs3-dev.json
@@ -24,6 +24,16 @@
             "RPCS3-dev"
         ]
     ],
+    "installer": {
+        "script": [
+            "if (!(Test-Path \"$persist_dir\\config.yml\")) {",
+            "    New-Item \"$dir\\config.yml\" -Type File | Out-Null",
+            "}",
+            "if (!(Test-Path \"$persist_dir\\games.yml\")) {",
+            "    New-Item \"$dir\\games.yml\" -Type File | Out-Null",
+            "}"
+        ]
+    },
     "checkver": {
         "url": "https://rpcs3.net/compatibility?b",
         "regex": "/rpcs3-binaries-win/releases/download/build-(?<fullhash>[0-9a-f]+)/rpcs3-v(?<build>[0-9]+\\.[0-9]+\\.[0-9]+\\-[0-9]+)-(?<shorthash>[0-9a-f]{8})",


### PR DESCRIPTION
Overlooked this in the last PR (#310), scoop needs to create empty `config.yml` and `games.yml` persist files since they are not included in the RPCS3 default files.

Currently scoop creates  `config.yml` and `games.yml` as folders, which causes errors in RPCS3.

I used the same method as the cemu install script:

https://github.com/Calinou/scoop-games/blob/c3f650d568873c15a181611da28a750c7f2d5982/bucket/cemu.json#L20-L22