### PR TITLE
opdessertstorm: Remove trailing whitespace

### DIFF
--- a/bucket/opdessertstorm.json
+++ b/bucket/opdessertstorm.json
@@ -27,5 +27,4 @@
             "Operation: Dessert Storm"
         ]
     ]
-  }
-  
+}


### PR DESCRIPTION
It was causing errors in CI:

```
Executing script C:\projects\scoop-games\Scoop-Bucket.Tests.ps1
  Describing Style constraints for non-binary project files
    [+] non-binary project files exist (202 found) 21ms
    [+] files do not contain leading UTF-8 BOM 248ms
    [+] files end with a newline 24ms
    [+] file newlines are CRLF 164ms
    [-] files have no lines containing trailing whitespace 85ms
      RuntimeException: The following 1 lines contain trailing whitespace: 
      File: C:\projects\scoop-games\bucket\opdessertstorm.json, Line: 31
      at <ScriptBlock>, C:\projects\scoop\test\Import-File-Tests.ps1: line 123
    [+] any leading whitespace consists only of spaces (excepting makefiles) 54ms
```