### PR TITLE
fbneo: Fix autoupdate

### DIFF
--- a/bucket/fbneo.json
+++ b/bucket/fbneo.json
@@ -15,7 +15,7 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/finalburnneo/FBNeo/releases/download/$version/fbneo.zip"
+        "url": "https://github.com/finalburnneo/FBNeo/releases/download/v$version/fbneo.zip"
     },
     "notes": [
         "",


### PR DESCRIPTION
Noticed that a "v" was missing before the version variable in the autoupdate URL - dunno if it actually mattered, but better safe than sorry.