### PR TITLE
flycast: Add version 1.1

### DIFF
--- a/bucket/flycast.json
+++ b/bucket/flycast.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://github.com/flyinghead/flycast",
+    "description": "Flycast is a multi-platform Sega Dreamcast, Naomi and Atomiswave emulator derived from reicast",
+    "version": "1.1",
+    "license": "https://github.com/flyinghead/flycast/blob/master/LICENSE",
+    "url": "https://github.com/flyinghead/flycast/releases/download/v1.1/flycast-v1.1-win64.zip",
+    "hash": "c26b62de388b4fcccc1243476dbd87dd514523134dafe59887de46aa20df3ff4",
+    "bin": "flycast.exe",
+    "shortcuts": [
+        [
+            "flycast.exe",
+            "Flycast"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/flyinghead/flycast/releases/download/v$version/flycast-v$version-win64.zip"
+    },
+    "persist": [
+        "data",
+        "mappings"
+    ]
+}


### PR DESCRIPTION
Here's a manifest for the great emulator that's mainly for Sega Dreamcast, but also other platforms like Naomi and Atomiswave (also based on Sega's hardware).

What's missing is a link to its cfg file since this is created on first run - by the way, should files that are linked use a symbolic link or a hard link, and what's the reasoning behind that?