### PR TITLE
pcsx2-dev: fix extract_dir

### DIFF
--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -5,7 +5,7 @@
     "version": "1.7.0-1806",
     "url": "https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v1.7.0-dev-1806-gc1fea5bc1&platform=windows-x86#/dl.7z",
     "hash": "01d9a56a0c668921629d24af7e9ed65cdf8ef8893d3d7446e13b423d053bb3ec",
-    "extract_dir": "pcsx2-v1.7.0-dev-1806-gc1fea5bc1-windows-x86",
+    "extract_dir": "pcsx2-v1.7.0-dev-windows-x86",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-item \"$persist_dir\" -ItemType Directory | Out-Null",
@@ -48,7 +48,7 @@
     },
     "autoupdate": {
         "url": "https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v$matchBasever-dev-$matchBuild-$matchCommit&platform=windows-x86#/dl.7z",
-        "extract_dir": "pcsx2-v$matchBasever-dev-$matchBuild-$matchCommit-windows-x86"
+        "extract_dir": "pcsx2-v$matchBasever-dev-windows-x86"
     },
     "notes": [
         "ATTENTION: PCSX2 requires a dump of the PS2 BIOS to function.",


### PR DESCRIPTION
The last 5 versions of pcsx2-dev have failed to install with an error like this:

```
Extracting dl.7z ... Exception: C:\dev\scoop\apps\scoop\current\lib\core.ps1:510
Line |
 510 |          throw "Could not find '$(fname $from)'! (error $($proc.ExitCo …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Could not find 'pcsx2-v1.7.0-dev-1806-gc1fea5bc1-windows-x86'! (error 16)
```

This is because the directory inside the 7z file seems to no longer include the build ID or commit hash.

This PR removes the build ID and commit hash from the current `extract_dir` as well as the template in `autoupdate`.