### PR TITLE
pcsx2-dev: Fix autoupdate commit regex

### DIFF
--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -43,7 +43,7 @@
     },
     "checkver": {
         "url": "https://buildbot.orphis.net/pcsx2/index.php",
-        "regex": "(?<basever>[\\d\\.]+)-dev-(?<build>[\\d]+)-(?<commit>g[a-f\\d]{9})",
+        "regex": "(?<basever>[\\d\\.]+)-dev-(?<build>[\\d]+)-(?<commit>g[a-f\\d]{10})",
         "replace": "${basever}-${build}"
     },
     "autoupdate": {


### PR DESCRIPTION
For the last 5 versions of pcsx2-dev, the autoupdate regex was creating faulty URLs that fail to install.

For example, version 1.7.0-1806 has the following URL which downloads an incorrect file that is over a year old:
https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v1.7.0-dev-1806-gc1fea5bc1&platform=windows-x86#/dl.7z

The correct URL should be this one, which has an additional character in the commit hash:
https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v1.7.0-dev-1806-gc1fea5bc16&platform=windows-x86#/dl.7z

The solution is to adjust the regex to match one additional character for the commit hash.