### PR TITLE
cataclysm-dda-tiles-experimental: Update to 2021-10-30-0656, fix autoupdate, add persist

### DIFF
--- a/bucket/cataclysm-dda-tiles-experimental.json
+++ b/bucket/cataclysm-dda-tiles-experimental.json
@@ -2,10 +2,7 @@
     "homepage": "https://cataclysmdda.org",
     "description": "Roguelike in a post-apocalyptic world (with sprite-based graphics, experimental build)",
     "version": "2021-10-30-0656",
-    "license": {
-        "identifier": "CC-BY-SA-3.0,GPL-2.0+,OFL-1.0,BSL-1.0,Zlib,MIT,BSD(libbacktrace)",
-        "url": "https://github.com/CleverRaven/Cataclysm-DDA/blob/master/LICENSE.txt"
-    },
+    "license": "CC-BY-SA-3.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-experimental-2021-10-30-0656/cdda-windows-tiles-x64-2021-10-30-0656.zip",

--- a/bucket/cataclysm-dda-tiles-experimental.json
+++ b/bucket/cataclysm-dda-tiles-experimental.json
@@ -1,35 +1,44 @@
 {
     "homepage": "https://cataclysmdda.org",
-    "description": "Turn-based survival game set in a post-apocalyptic world (with graphical tiles, experimental build)",
-    "version": "10442",
-    "license": "CC-BY-SA-3.0",
+    "description": "Roguelike in a post-apocalyptic world (with sprite-based graphics, experimental build)",
+    "version": "2021-10-30-0656",
+    "license": {
+        "identifier": "CC-BY-SA-3.0,GPL-2.0+,OFL-1.0,BSL-1.0,Zlib,MIT,BSD(libbacktrace)",
+        "url": "https://github.com/CleverRaven/Cataclysm-DDA/blob/master/LICENSE.txt"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-jenkins-b10442/cataclysmdda-0.D-Windows_x64-Tiles-10442.zip",
-            "hash": "93ecf2a9db357a5af4185a6ea3061f1b0fec379b62631b3ab29aca7ef2c381ea"
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-experimental-2021-10-30-0656/cdda-windows-tiles-x64-2021-10-30-0656.zip",
+            "hash": "b70d46bcb1406c448ae25ed28274caccabd710f08f62af285c3ae4722852688a"
         },
         "32bit": {
-            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-jenkins-b10442/cataclysmdda-0.D-Windows-Tiles-10442.zip",
-            "hash": "45892f29fb859b8390d3f288e3a591ccb3dd7f56ce569c84a9047cc1a575f2e6"
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-experimental-2021-10-30-0656/cdda-windows-tiles-x32-2021-10-30-0656.zip",
+            "hash": "fbbc1fcbdd724c27811732e784a513ae52d9a293df5ffd581534fda41c626539"
         }
     },
     "shortcuts": [
         [
             "cataclysm-tiles.exe",
-            "Cataclysm DDA Tiles (Experimental)"
+            "Cataclysm DDA\\Cataclysm DDA Tiles (Experimental)"
         ]
+    ],
+    "persist": [
+        "config",
+        "save",
+        "sound",
+        "templates"
     ],
     "checkver": {
         "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/",
-        "re": "Cataclysm-DDA experimental build #(.*)[<]"
+        "re": "Cataclysm-DDA experimental build ([\\d.-]+)(<)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-jenkins-b$version/cataclysmdda-0.D-Windows_x64-Tiles-$version.zip"
+                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-experimental-$version/cdda-windows-tiles-x64-$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-jenkins-b$version/cataclysmdda-0.D-Windows-Tiles-$version.zip"
+                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-experimental-$version/cdda-windows-tiles-x32-$version.zip"
             }
         }
     }


### PR DESCRIPTION
Autoupdate now works.
Add a persist folder.
Added due to missing license.