### PR TITLE
Update cataclysm-dda-tiles.json

### DIFF
--- a/bucket/cataclysm-dda-tiles.json
+++ b/bucket/cataclysm-dda-tiles.json
@@ -34,11 +34,11 @@
     },
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/$version/cataclysmdda-$majorVersion.$minorVersion-Windows-Tiles-$version.zip"
-            },
             "64bit": {
                 "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/$version/cataclysmdda-$majorVersion.$minorVersion-Windows_x64-Tiles-$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/$version/cataclysmdda-$majorVersion.$minorVersion-Windows-Tiles-$version.zip"
             }
         }
     }

--- a/bucket/cataclysm-dda-tiles.json
+++ b/bucket/cataclysm-dda-tiles.json
@@ -1,22 +1,45 @@
 {
     "homepage": "https://cataclysmdda.org",
-    "description": "Turn-based survival game set in a post-apocalyptic world (with graphical tiles)",
-    "version": "0.F",
-    "license": "CC-BY-SA-3.0",
+    "description": "Roguelike in a post-apocalyptic world (with sprite-based graphics)",
+    "version": "0.F-2",
+    "license": {
+        "identifier": "CC-BY-SA-3.0,GPL-2.0+,OFL-1.0,BSL-1.0,Zlib,MIT,BSD(libbacktrace)",
+        "url": "https://github.com/CleverRaven/Cataclysm-DDA/blob/master/LICENSE.txt"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.F/cdda-windows-tiles-x64-2021-07-03-0512.zip",
-            "hash": "54ff7a666879308d40a3b5867998e0fad64331e29bf9c436bda230f527054b4c"
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.F-2/cataclysmdda-0.F-Windows_x64-Tiles-0.F-2.zip",
+            "hash": "b705edb07ecc460b8065602c6ba06a4f380474304619bd761f02d2d4804c118e"
         },
         "32bit": {
-            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.F/cdda-windows-tiles-x32-2021-07-03-0512.zip",
-            "hash": "b9f089a31e643e5003343014c635b33671ab03cb39231aa31957b4a0fb16665e"
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.F-2/cataclysmdda-0.F-Windows-Tiles-0.F-2.zip",
+            "hash": "ba991e64e62547cd1ec4dbc307ff323f2d72b145711036e1ddd88e60db710734"
         }
     },
     "shortcuts": [
         [
             "cataclysm-tiles.exe",
-            "Cataclysm DDA Tiles"
+            "Cataclysm DDA\\Cataclysm DDA Tiles"
         ]
-    ]
+    ],
+    "persist": [
+        "config",
+        "save",
+        "sound",
+        "templates"
+    ],
+    "checkver": {
+        "url": "https://cataclysmdda.org/releases/",
+        "regex": "The most recent stable release is ([\\d\\-.A-Z]+)?( )"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/$version/cataclysmdda-$majorVersion.$minorVersion-Windows-Tiles-$version.zip"
+            },
+            "64bit": {
+                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/$version/cataclysmdda-$majorVersion.$minorVersion-Windows_x64-Tiles-$version.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Autoupdate now works.
Add a persist folder.
Added due to missing license.
Closes #330