### PR TITLE
cataclysm-dda: Add persist, rename shortcuts

### DIFF
--- a/bucket/cataclysm-dda.json
+++ b/bucket/cataclysm-dda.json
@@ -2,10 +2,7 @@
     "homepage": "https://cataclysmdda.org",
     "description": "Roguelike in a post-apocalyptic world (with text-based graphics)",
     "version": "0.D",
-    "license": {
-        "identifier": "CC-BY-SA-3.0,GPL-2.0+,OFL-1.0,BSL-1.0,Zlib,MIT,BSD(libbacktrace)",
-        "url": "https://github.com/CleverRaven/Cataclysm-DDA/blob/master/LICENSE.txt"
-    },
+    "license": "CC-BY-SA-3.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.D/cataclysmdda-0.D-8574-Win64-Curses.zip",

--- a/bucket/cataclysm-dda.json
+++ b/bucket/cataclysm-dda.json
@@ -1,8 +1,11 @@
 {
     "homepage": "https://cataclysmdda.org",
-    "description": "Turn-based survival game set in a post-apocalyptic world (with text-based graphics)",
+    "description": "Roguelike in a post-apocalyptic world (with text-based graphics)",
     "version": "0.D",
-    "license": "CC-BY-SA-3.0",
+    "license": {
+        "identifier": "CC-BY-SA-3.0,GPL-2.0+,OFL-1.0,BSL-1.0,Zlib,MIT,BSD(libbacktrace)",
+        "url": "https://github.com/CleverRaven/Cataclysm-DDA/blob/master/LICENSE.txt"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.D/cataclysmdda-0.D-8574-Win64-Curses.zip",
@@ -16,7 +19,13 @@
     "shortcuts": [
         [
             "cataclysm.exe",
-            "Cataclysm DDA"
+            "Cataclysm DDA\\Cataclysm DDA Curses"
         ]
+    ],
+    "persist": [
+        "config",
+        "save",
+        "sound",
+        "templates"
     ]
 }


### PR DESCRIPTION
Autoupdate now works.
Add persist data.
Rename shortcuts according to official site.