### PR TITLE
duckstation: Fix installation, update to version 20210929-g13c5ee8

### DIFF
--- a/bucket/duckstation.json
+++ b/bucket/duckstation.json
@@ -2,25 +2,24 @@
     "homepage": "https://github.com/stenzek/duckstation/",
     "description": "A fast PlayStation 1 emulator for PC and Android",
     "license": "GPL-3.0-only",
-    "version": "nightly",
+    "version": "20210929-g13c5ee8",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/stenzek/duckstation/releases/download/latest/duckstation-windows-x64-release.zip"
+            "url": "https://github.com/stenzek/duckstation/releases/download/latest/duckstation-windows-x64-release.zip",
+            "hash": "bd01108a7e9fcb0f22ccb86045d377c781420535081e290125d7edad1b2e18fa"
         }
     },
     "installer": {
         "script": [
-        "if (!(Test-Path \"$persist_dir\")) {",
-        "   '[Main]', 'SettingsVersion = 3', '[AutoUpdater]', 'CheckAtStartup = false' | Set-Content \"$dir\\settings.ini\"",
-        "   New-item \"$dir\\portable.txt\" -ItemType File | Out-Null",
-        "}"
+            "if (!(Test-Path \"$persist_dir\")) {",
+            "   '[Main]', 'SettingsVersion = 3', '[AutoUpdater]', 'CheckAtStartup = false' | Set-Content \"$dir\\settings.ini\"",
+            "   New-item \"$dir\\portable.txt\" -ItemType File | Out-Null",
+            "}"
         ]
     },
     "bin": [
-        [
-            "duckstation-qt-x64-ReleaseLTCG.exe",
-            "duckstation-nogui-x64-ReleaseLTCG.exe"
-        ]
+        "duckstation-nogui-x64-ReleaseLTCG.exe",
+        "duckstation-qt-x64-ReleaseLTCG.exe"
     ],
     "shortcuts": [
         [
@@ -47,7 +46,16 @@
         "settings.ini"
     ],
     "checkver": {
-        "github": "https://github.com/stenzek/duckstation"
+        "url": "https://github.com/stenzek/duckstation/releases/tag/latest",
+        "regex": " datetime=\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})[\\s\\S]*?.*duckstation/commit/(?<commit>[0-9a-f]{7})",
+        "replace": "${year}${month}${day}-g${commit}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/stenzek/duckstation/releases/download/latest/duckstation-windows-x64-release.zip"
+            }
+        }
     },
     "notes": [
         "ATTENTION: Duckstation requires a PSX BIOS to function.",


### PR DESCRIPTION
The version display was changed to build date and Commit number instead of nightly.
Fix simlink.

Closes #358