### PR TITLE
gdidrop: Add version 1

### DIFF
--- a/bucket/gdidrop.json
+++ b/bucket/gdidrop.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/feyris-tan/gdidrop",
+    "description": "Tool to convert bin/cue files of Redump Dreamcast Images to gdi/bin/raw in order to run on Demul",
+    "version": "1",
+    "license": "BSD-2-Clause",
+    "url": "https://github.com/feyris-tan/gdidrop/releases/download/1/gdidrop.zip",
+    "hash": "a05635e2aad563f0225ad30e0dd285fbf1bec19fe087fdc87b0819cbc590de45",
+    "shortcuts": [
+        [
+            "gdidrop.exe",
+            "gdidrop"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/feyris-tan/gdidrop/releases/download/$version/gdidrop.zip"
+    }
+}


### PR DESCRIPTION
Tool to convert bin/cue files of Redump Dreamcast Images to gdi/bin/raw in order to run on Demul.
Closes #406