### PR TITLE
Update openttd.json

### DIFF
--- a/bucket/openttd.json
+++ b/bucket/openttd.json
@@ -61,5 +61,5 @@
             "find": "checksum-$basename[\\s\\S]*?([a-fA-F\\d]{64})"
         }
     },
-    "notes": "To save the data in persist folder, run OpenTTD from the Start menu or openttd-persist.exe on CLI"
+    "notes": "To save the data in persist folder, run OpenTTD from the Start menu or openttd.exe on CLI"
 }

--- a/bucket/openttd.json
+++ b/bucket/openttd.json
@@ -30,7 +30,7 @@
     "bin": [
         [
             "openttd.exe",
-            "openttd-persist",
+            "openttd",
             "-c \"$persist_dir\\openttd.cfg\""
         ]
     ],

--- a/bucket/openttd.json
+++ b/bucket/openttd.json
@@ -1,48 +1,65 @@
 {
     "homepage": "https://www.openttd.org/",
     "description": "Simulation game based upon Transport Tycoon Deluxe",
-    "version": "1.10.0",
+    "version": "12.0",
     "license": "GPL-2.0-or-later",
     "architecture": {
-        "64bit": {
-            "url": [
-                "https://cdn.openttd.org/openttd-releases/1.10.0/openttd-1.10.0-windows-win64.zip",
-                "https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip",
-                "https://cdn.openttd.org/opensfx-releases/0.2.3/opensfx-0.2.3-all.zip",
-                "https://cdn.openttd.org/openmsx-releases/0.3.1/openmsx-0.3.1-all.zip"
-            ],
-            "hash": [
-                "263f0b51d9630a1ef60538e822de064138ea3599f1ace4cc070943e81aa5bc4d",
-                "d419c0f5f22131de15f66ebefde464df3b34eb10e0645fe218c59cbc26c20774",
-                "6831b651b3dc8b494026f7277989a1d757961b67c17b75d3c2e097451f75af02",
-                "92e293ae89f13ad679f43185e83fb81fb8cad47fe63f4af3d3d9f955130460f5"
-            ]
-        },
         "32bit": {
-            "url": [
-                "https://cdn.openttd.org/openttd-releases/1.10.0/openttd-1.10.0-windows-win32.zip",
-                "https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip",
-                "https://cdn.openttd.org/opensfx-releases/0.2.3/opensfx-0.2.3-all.zip",
-                "https://cdn.openttd.org/openmsx-releases/0.3.1/openmsx-0.3.1-all.zip"
-            ],
-            "hash": [
-                "4f10643582e0c57afeb8b327364d4ff20f3c28e10399d8be7ddf83104b3806cf",
-                "d419c0f5f22131de15f66ebefde464df3b34eb10e0645fe218c59cbc26c20774",
-                "6831b651b3dc8b494026f7277989a1d757961b67c17b75d3c2e097451f75af02",
-                "92e293ae89f13ad679f43185e83fb81fb8cad47fe63f4af3d3d9f955130460f5"
-            ]
+            "url": "https://cdn.openttd.org/openttd-releases/12.0/openttd-12.0-windows-win32.zip",
+            "hash": "1086f94a9888a9e77c5201d0a2612d1fcd6d45b49acb4250394b073917f309ca",
+            "extract_dir": "openttd-12.0-windows-win32"
+        },
+        "64bit": {
+            "url": "https://cdn.openttd.org/openttd-releases/12.0/openttd-12.0-windows-win64.zip",
+            "hash": "872afdbba74fce18dd6f0d3ba2a7baef8800fe0ef486b383b997a0f3b285c7a4",
+            "extract_dir": "openttd-12.0-windows-win64"
         }
     },
-    "pre_install": [
-        "Move-Item \"$dir\\opengfx-0.6.0.tar\" \"$dir\\baseset\"",
-        "Move-Item \"$dir\\opensfx-0.2.3\" \"$dir\\baseset\"",
-        "Move-Item \"$dir\\openmsx-0.3.1\" \"$dir\\baseset\""
+    "post_install": [
+        "if (!(Test-Path \"$persist_dir\\openttd.cfg\")) {",
+        "   New-item -ItemType File \"$persist_dir\\openttd.cfg\" | Out-Null",
+        "}"
     ],
-    "bin": "openttd.exe",
+    "persist": [
+        "content_download",
+        "newgrf",
+        "save",
+        "scenario",
+        "screenshot"
+    ],
+    "bin": [
+        [
+            "openttd.exe",
+            "openttd-persist",
+            "-c \"$persist_dir\\openttd.cfg\""
+        ]
+    ],
     "shortcuts": [
         [
             "openttd.exe",
-            "OpenTTD"
+            "OpenTTD",
+            "-c \"$persist_dir\\openttd.cfg\""
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "https://www.openttd.org/downloads/openttd-releases/latest",
+        "regex": "openttd-([\\d.]+)-windows-win64.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://cdn.openttd.org/openttd-releases/$version/openttd-$version-windows-win32.zip",
+                "extract_dir": "openttd-$version-windows-win32"
+            },
+            "64bit": {
+                "url": "https://cdn.openttd.org/openttd-releases/$version/openttd-$version-windows-win64.zip",
+                "extract_dir": "openttd-$version-windows-win64"
+            }
+        },
+        "hash": {
+            "url": "https://www.openttd.org/downloads/openttd-releases/latest",
+            "find": "checksum-$basename[\\s\\S]*?([a-fA-F\\d]{64})"
+        }
+    },
+    "notes": "To save the data in persist folder, run OpenTTD from the Start menu or openttd-persist.exe on CLI"
 }


### PR DESCRIPTION
Autoupdate now works.
Make portable.
Autoupdate can manage only one file.
Graphics and music data are managed by a different version and should be managed by the built-in downloader.

Closes #334