### PR TITLE
pathofbuilding-community: Update to version 2.11.0, rename `bin`, fix autoupdate

### DIFF
--- a/bucket/pathofbuilding-community.json
+++ b/bucket/pathofbuilding-community.json
@@ -1,11 +1,16 @@
 {
     "homepage": "https://github.com/PathOfBuildingCommunity/PathOfBuilding",
     "description": "Offline build planner for Path of Exile, Community Fork",
-    "version": "1.4.169.1",
+    "version": "2.11.0",
     "license": "MIT",
-    "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/download/v1.4.169.1/PathOfBuildingCommunity-Setup-1.4.169.1.zip",
-    "hash": "e86cee34da4a166b86aa61b58635b1f0bd8432d7e69c47570034210f7d6e0830",
-    "bin": "Path of Building.exe",
+    "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/download/v2.11.0/PathOfBuildingCommunity-Portable-2.11.0.zip",
+    "hash": "03f00abf145e33619c5e0a6b2c94d634f141772ecb3dcfee1b54f8e2f86a6381",
+    "bin": [
+        [
+            "Path of Building.exe",
+            "pathofbuilding-community"
+        ]
+    ],
     "persist": [
         "Builds",
         "Settings.xml"
@@ -18,11 +23,11 @@
     "shortcuts": [
         [
             "Path of Building.exe",
-            "Path of Building"
+            "Path of Building Community"
         ]
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/download/v$version/PathOfBuilding-Setup-$version.zip"
+        "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/download/v$version/PathOfBuildingCommunity-Portable-$version.zip"
     }
 }


### PR DESCRIPTION
Autoupdate now works.
Rename bin to avoid conflicts.
Closes #336