### PR TITLE
nethack: Show data paths after installation, fix autoupdate

### DIFF
--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -5,6 +5,7 @@
     "homepage": "https://www.nethack.org",
     "url": "https://github.com/NetHack/NetHack/releases/download/NetHack-3.6.6_Released/NetHack-3.6.6_Released.x86.zip",
     "hash": "681799e42d7527621f27a30aee7efa5c2d61cd8ae97a9b7105460ea4c238b978",
+    "post_install": "nethack --showpaths",
     "bin": "NetHack.exe",
     "shortcuts": [
         [
@@ -18,7 +19,7 @@
     ],
     "checkver": {
         "github": "https://github.com/NetHack/NetHack",
-        "regex": "Release build of NetHack ([\\d.]+)</a>"
+        "regex": "Release build of NetHack ([\\d.]+)<"
     },
     "autoupdate": {
         "url": "https://github.com/NetHack/NetHack/releases/download/NetHack-$version_Released/NetHack-$version_Released.x86.zip"


### PR DESCRIPTION
Autoupdate now works.
After installation, a list of folders to store data is displayed.
It could theoretically be portable, but it's still a challenge.