### PR TITLE
Update speed-dreams.json

### DIFF
--- a/bucket/speed-dreams.json
+++ b/bucket/speed-dreams.json
@@ -1,30 +1,59 @@
 {
     "homepage": "http://www.speed-dreams.org/",
     "description": "3D simulation racing game",
-    "version": "2.2.2",
+    "version": "2.2.3-r7616",
     "license": "GPL-2.0-or-later",
-    "url": [
-        "https://downloads.sourceforge.net/project/speed-dreams/2.2.2/speed-dreams-base-2.2.2-r6553-win32-setup.exe#/dl1.7z",
-        "https://downloads.sourceforge.net/project/speed-dreams/2.2.2/speed-dreams-hq-cars-and-tracks-2.2.2-r6553-win32-setup.exe#/dl2.7z",
-        "https://downloads.sourceforge.net/project/speed-dreams/2.2.2/speed-dreams-more-hq-cars-and-tracks-2.2.2-r6553-win32-setup.exe#/dl3.7z",
-        "https://downloads.sourceforge.net/project/speed-dreams/2.2.2/speed-dreams-wip-cars-and-tracks-2.2.2-r6553-win32-setup.exe#/dl4.7z"
-    ],
-    "hash": [
-        "b5e398c5cba6530747dae6fa7e10a7747e807f1f4f040ed21f257798b7a22510",
-        "50afe14c5b97302e974b4f8a9ef52313bb23954d0a33ef850f98f9969e8086da",
-        "60e893ca636979163f3cad9ae78cdc42a7fa1bbe81e635492788fd7093cae2d9",
-        "eabe77bb09de90bac8de1e50490f7b4aae7e9959adb112c8d9e707a7880a320f"
-    ],
+    "url": "https://sourceforge.net/projects/speed-dreams/files/2.2.3/speed-dreams-base-2.2.3-r7616-win32-setup.exe#/dl.7z",
+    "hash": "sha1:6371069593c1f5d2b296b16dcbedaa3619673cae",
+    "installer": {
+        "script": [
+            "[void]($version -match '[\\d.]+')",
+            "$head = $matches[0]",
+            "$dlFile = 'dl.7z'",
+            "$archiveUrls = @(",
+            "   \"https://sourceforge.net/projects/speed-dreams/files/$head/speed-dreams-hq-cars-and-tracks-$version-win32-setup.exe\"",
+            "   \"https://sourceforge.net/projects/speed-dreams/files/$head/speed-dreams-more-hq-cars-and-tracks-$version-win32-setup.exe\"",
+            "   \"https://sourceforge.net/projects/speed-dreams/files/$head/speed-dreams-wip-cars-and-tracks-$version-win32-setup.exe\"",
+            ")",
+            "$archiveUrls | ForEach-Object {",
+            "   dl_with_cache $app $version \"$_\" \"$dir\\$dlFile\"",
+            "   Expand-7zipArchive \"$dir\\$dlFile\" \"$dir\" -Removal",
+            "}"
+        ]
+    },
     "bin": [
         [
             "bin\\speed-dreams-2.exe",
-            "speed-dreams"
+            "speed-dreams",
+            "-lc \"$persist_dir\\settings\""
         ]
     ],
     "shortcuts": [
         [
             "bin\\speed-dreams-2.exe",
-            "Speed Dreams"
+            "Speed Dreams",
+            "-lc \"$persist_dir\\settings\""
+        ],
+        [
+            "doc\\how_to_drive.html",
+            "Speed Dreams User Manual"
+        ],
+        [
+            "doc\\faq.html",
+            "Speed Dreams FAQ"
+        ],
+        [
+            "readme.txt",
+            "Speed Dreams Read Me"
         ]
-    ]
+    ],
+    "persist": "settings",
+    "checkver": {
+        "url": "https://sourceforge.net/projects/speed-dreams/files/",
+        "regex": "speed-dreams-base-([\\d\\-.a-z]+)-win"
+    },
+    "autoupdate": {
+        "url": "https://sourceforge.net/projects/speed-dreams/files/$matchHead/speed-dreams-base-$version-win32-setup.exe#/dl.7z"
+    },
+    "notes": "To save the data in persist folder, run from the Start menu or CLI"
 }


### PR DESCRIPTION
The Manifest URL is now one for automatic updates.
Added a script to download additional packages of the same version.
I made it possible to create the same shortcut as the official installer.
I made it portable.