### PR TITLE
Update spearmint.json

### DIFF
--- a/bucket/spearmint.json
+++ b/bucket/spearmint.json
@@ -1,11 +1,31 @@
 {
     "homepage": "https://clover.moe/spearmint/",
-    "description": "Modern source port for Quake III Arena, Quake III: Team Arena and OpenArena",
+    "description": "Heavily modified version of the Quake III Arena engine, directly based on ioquake3 (November 2018)",
     "version": "1.0.3",
     "license": "https://github.com/zturtleman/spearmint/blob/master/COPYING.txt",
+    "suggest": {
+        "Quake 3 engines": "openarena"
+    },
     "url": "https://github.com/zturtleman/spearmint/releases/download/release-1.0.3/spearmint-1.0.3-windows.zip",
     "hash": "d179d9a9d2213cc013e442df876090cc1f428dd9a98057a3065a8806c823872c",
     "extract_dir": "spearmint-1.0.3-windows",
+    "installer": {
+        "script": [
+            "$persistFolders = @(",
+            "   \"baseoa\"",
+            "   \"baseq3\"",
+            "   \"demoq3\"",
+            "   \"missionpack\"",
+            "   \"missionpackoa\"",
+            "   \"tademo\"",
+            ")",
+            "$persistFolders | ForEach-Object {",
+            "   if (Test-Path \"$persist_dir\\$_\") {",
+            "      Copy-Item -Force -Recurse \"$dir\\$_\\*\" \"$persist_dir\\$_\"",
+            "   }",
+            "}"
+        ]
+    },
     "architecture": {
         "64bit": {
             "bin": [
@@ -31,8 +51,13 @@
                 ],
                 [
                     "spearmint_x86_64.exe",
-                    "Spearmint OpenArena",
+                    "Spearmint Quake 3 using OpenArena data",
                     "+set fs_game baseoa"
+                ],
+                [
+                    "spearmint_x86_64.exe",
+                    "Spearmint Quake 3 - TA using OA data",
+                    "+set fs_game missionpackoa"
                 ]
             ]
         },
@@ -60,16 +85,25 @@
                 ],
                 [
                     "spearmint_x86.exe",
-                    "Spearmint OpenArena",
+                    "Spearmint Quake 3 using OpenArena data",
                     "+set fs_game baseoa"
+                ],
+                [
+                    "spearmint_x86.exe",
+                    "Spearmint Quake 3 - TA using OA data",
+                    "+set fs_game missionpackoa"
                 ]
             ]
         }
     },
     "persist": [
-        "settings\\baseq3",
-        "settings\\missionpack",
-        "settings\\baseoa"
+        "baseoa",
+        "baseq3",
+        "demoq3",
+        "missionpack",
+        "missionpackoa",
+        "settings",
+        "tademo"
     ],
     "notes": [
         "Place game data files (such as pak0.pk3-pak8.pk3) in:",
@@ -81,7 +115,14 @@
         "    $persist_dir\\missionpack\\",
         "",
         "- OpenArena:",
-        "    $persist_dir\\baseoa\\"
+        "-- baseoa",
+        "    $persist_dir\\baseoa\\",
+        "-- missionpack",
+        "    $persist_dir\\missionpackoa\\",
+        "",
+        "If you're missing some of the Quake 3 or Team Arena patch pk3s (pak1 or higher),",
+        "they are available at http://ioquake3.org/extras/patch-data/",
+        ""
     ],
     "checkver": {
         "url": "https://github.com/zturtleman/spearmint/releases/latest",


### PR DESCRIPTION
Speamint can play Quake 3 using OpenArena data, but it doesn't play OpenArena, so fix shortcuts.
Added to suggest for easier access to openarena data.
Add Persist folders.
Add scripts to update the libraries in the Persist folders. This is required for all Quake 2/3 engines.
Additional information about data placement.