### PR TITLE
freeorion: Add fullscreen shortcut, remove broken `bin`

### DIFF
--- a/bucket/freeorion.json
+++ b/bucket/freeorion.json
@@ -5,11 +5,15 @@
     "license": "GPL-2.0",
     "url": "https://sourceforge.net/projects/freeorion/files/FreeOrion/FreeOrion%20Version%200.4.10/FreeOrion_v0.4.10.2_2021-08-01.f663dad_Win32_Setup.exe#/dl.zip",
     "hash": "sha1:427bee2806be31138c8ddbb379e911f554f53479",
-    "bin": "FreeOrion.exe",
     "shortcuts": [
         [
             "FreeOrion.exe",
-            "FreeOrion"
+            "FreeOrion Windowed"
+        ],
+        [
+            "FreeOrion.exe",
+            "FreeOrion Fullscreen",
+            "-f"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
Like the official installer, I have added a full-screen shortcut.
It was mentioned in the official wiki, so I decided it was necessary.
The bin was removed because it could not be executed normally outside of the installation folder.