### PR TITLE
q2pro: Add 64-bit and persist, use versioned release

### DIFF
--- a/bucket/q2pro.json
+++ b/bucket/q2pro.json
@@ -1,22 +1,61 @@
 {
-    "homepage": "http://www.skuller.net/q2pro/",
+    "version": "r1861",
     "description": "Quake 2 source port focused on multiplayer gameplay",
-    "version": "nightly",
+    "homepage": "http://www.skuller.net/q2pro/",
     "license": "GPL-2.0-or-later",
-    "url": "http://www.skuller.net/q2pro/nightly/q2pro-client_win32_x86.zip",
-    "bin": [
-        [
-            "q2pro.exe",
-            "q2pro"
+    "architecture": {
+        "64bit": {
+            "url": "https://skuller.net/q2pro/archive/r1861/q2pro-client_r1861_win64_x64.zip",
+            "hash": "2745c07740bb9645654e66e289fe49ca97850361d1f6f929a1d4d2b3a1fcea17",
+            "bin": "q2pro64.exe",
+            "shortcuts": [
+                [
+                    "q2pro64.exe",
+                    "Q2PRO Client"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://skuller.net/q2pro/archive/r1861/q2pro-client_r1861_win32_x86.zip",
+            "hash": "7b3d4dc19fa27c4d7ba00ed4af7b2f62f66aceecfd20924708a3f9a9675cb0b4",
+            "bin": "q2pro.exe",
+            "shortcuts": [
+                [
+                    "q2pro.exe",
+                    "Q2PRO Client"
+                ]
+            ]
+        }
+    },
+    "installer": {
+        "script": [
+            "$persistFolders = @(",
+            "   \"baseq2\"",
+            ")",
+            "$persistFolders | ForEach-Object {",
+            "   if (Test-Path \"$persist_dir\\$_\") {",
+            "      Copy-Item -Force -Recurse \"$dir\\$_\\*.dll\" \"$persist_dir\\$_\"",
+            "   }",
+            "}"
         ]
-    ],
-    "shortcuts": [
-        [
-            "q2pro.exe",
-            "Q2PRO"
-        ]
-    ],
+    },
     "persist": "baseq2",
+    "checkver": {
+        "url": "https://skuller.net/q2pro/archive/",
+        "regex": ">r(?<no>\\d+)<\\/a>.*?Directory",
+        "replace": "r${no}",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://skuller.net/q2pro/archive/$version/q2pro-client_$version_win64_x64.zip"
+            },
+            "32bit": {
+                "url": "https://skuller.net/q2pro/archive/$version/q2pro-client_$version_win32_x86.zip"
+            }
+        }
+    },
     "notes": [
         "Place game data files (such as pak0.pak-pak2.pak) in:",
         "",


### PR DESCRIPTION
The version is indicated.
Added 64 bit version.
Automatic update enabled.
Libraries in the Persist folder are now updated on update.
The menu file is assumed to be customized, so it is excluded.