### PR TITLE
pcsx2-dev: fix checkver regex and autoupdate url

### DIFF
--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -43,7 +43,7 @@
     },
     "checkver": {
         "url": "https://buildbot.orphis.net/pcsx2/index.php",
-        "regex": "(?<basever>\\d+\\.\\d+)\\.(?<build>\\d+)",
+        "regex": "v(?<basever>\\d+\\.\\d+)\\.(?<build>\\d+)",
         "replace": "${basever}-${build}"
     },
     "autoupdate": {

--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -43,12 +43,12 @@
     },
     "checkver": {
         "url": "https://buildbot.orphis.net/pcsx2/index.php",
-        "regex": "(?<basever>[\\d\\.]+)-dev-(?<build>[\\d]+)-(?<commit>g[a-f\\d]{10})",
+        "regex": "(?<basever>\\d+\\.\\d+)\\.(?<build>\\d+)",
         "replace": "${basever}-${build}"
     },
     "autoupdate": {
-        "url": "https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v$matchBasever-dev-$matchBuild-$matchCommit&platform=windows-x86#/dl.7z",
-        "extract_dir": "pcsx2-v$matchBasever-dev-$matchBuild-$matchCommit-windows-x86"
+        "url": "https://buildbot.orphis.net/pcsx2/index.php?m=dl&rev=v$matchBasever.$matchBuild&platform=windows-x86#/dl.7z",
+        "extract_dir": "pcsx2-v$matchBasever.$matchBuild-windows-x86"
     },
     "notes": [
         "ATTENTION: PCSX2 requires a dump of the PS2 BIOS to function.",


### PR DESCRIPTION
Fixes #463 

PCSX2 no longer uses commits and `dev` in their development build versions and download URLs.

Since the build number became simpler, matching the `v` at the beginning will prevent some unintentional matches.