### PR TITLE
mgba: Update to version 0.9.3, tweak checkver and autoupdate

### DIFF
--- a/bucket/mgba.json
+++ b/bucket/mgba.json
@@ -2,17 +2,17 @@
     "homepage": "https://mgba.io/",
     "description": "A fast, accurate, and portable GBA emulator",
     "license": "MPL-2.0",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mgba-emu/mgba/releases/download/0.9.2/mGBA-0.9.2-win64.7z",
-            "hash": "d4128d77ea3dac0ca87c360c67eb600f94741e551c03587bf17ed29af0bdc084",
-            "extract_dir": "mGBA-0.9.2-win64"
+            "url": "https://github.com/mgba-emu/mgba/releases/download/0.9.3/mGBA-0.9.3-win64.7z",
+            "hash": "a84ba662a2808f2d47de6f00d437981359194b807447043860a33ce15b3f5468",
+            "extract_dir": "mGBA-0.9.3-win64"
         },
         "32bit": {
-            "url": "https://github.com/mgba-emu/mgba/releases/download/0.9.2/mGBA-0.9.2-win32.7z",
-            "hash": "0e3bcbc08963d3c10e368d7b6740c43640f5769ea7fd50d91f055321ab2dcd69",
-            "extract_dir": "mGBA-0.9.2-win32"
+            "url": "https://github.com/mgba-emu/mgba/releases/download/0.9.3/mGBA-0.9.3-win32.7z",
+            "hash": "54df53ba5bb463395da0b85db8692234259c2ab7210781d49426b78e5a259757",
+            "extract_dir": "mGBA-0.9.3-win32"
         }
     },
     "installer": {
@@ -49,20 +49,16 @@
         "qt.ini",
         "config.ini"
     ],
-    "checkver": {
-        "github": "https://github.com/mgba-emu/mgba",
-        "regex": "mGBA-(?<ver>[\\d.]+)((?<beta>-b1)?)",
-        "replace": "${2}${1}"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mgba-emu/mgba/releases/download/$matchVer$matchBeta/mGBA-$matchVer$matchBeta-win64.7z",
-                "extract_dir": "mGBA-$matchVer$matchBeta-win64"
+                "url": "https://github.com/mgba-emu/mgba/releases/download/$version/mGBA-$version-win64.7z",
+                "extract_dir": "mGBA-$version-win64"
             },
             "32bit": {
-                "url": "https://github.com/mgba-emu/mgba/releases/download/$matchVer$matchBeta/mGBA-$matchVer$matchBeta-win32.7z",
-                "extract_dir": "mGBA-$matchVer$matchBeta-win32"
+                "url": "https://github.com/mgba-emu/mgba/releases/download/$version/mGBA-$version-win32.7z",
+                "extract_dir": "mGBA-$version-win32"
             }
         }
     }


### PR DESCRIPTION
mGBA has had very simple versioning for a while.

This updates:

- The version to 0.9.3 which was released almost a day ago
- Checkver to simply use the github method
- Autoupdate to simply use the $version for matching