### PR TITLE
doom-retro: Fix config file persist and add info to notes

### DIFF
--- a/bucket/doom-retro.json
+++ b/bucket/doom-retro.json
@@ -15,7 +15,7 @@
     },
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\doomretro.cfg\")) {",
-        "   New-Item -ItemType File \"$dir\\doomretro.cfg\" | Out-Null", 
+        "   New-Item -ItemType File \"$dir\\doomretro.cfg\" | Out-Null",
         "}",
         "if (!(Test-Path \"$scoopdir\\persist\\_doom\")) {",
         "   New-item \"$scoopdir\\persist\\_doom\" -ItemType Directory | Out-Null",

--- a/bucket/doom-retro.json
+++ b/bucket/doom-retro.json
@@ -14,11 +14,8 @@
         }
     },
     "pre_install": [
-        "if (!(Test-Path \"$persist_dir\")) {",
-        "   New-item \"$persist_dir\\savegames\" -ItemType Directory | Out-Null",
-        "   New-item \"$persist_dir\\screenshots\" -ItemType Directory | Out-Null",
-        "   New-item \"$persist_dir\\doomretro.cfg\" -ItemType File | Out-Null",
-        "   '; CVARs', \"iwadfolder= $scoopdir\\persist\\_doom\" | Set-Content \"$persist_dir\\doomretro.cfg\"",
+        "if (!(Test-Path \"$persist_dir\\doomretro.cfg\")) {",
+        "   New-Item -ItemType File \"$dir\\doomretro.cfg\" | Out-Null", 
         "}",
         "if (!(Test-Path \"$scoopdir\\persist\\_doom\")) {",
         "   New-item \"$scoopdir\\persist\\_doom\" -ItemType Directory | Out-Null",
@@ -50,7 +47,17 @@
         }
     },
     "notes": [
-        "ATTENTION: DOOM Retro requires WAD files from a commercial DOOM copy (DOOM 1, 2, Ultimate DOOM, etc)",
-        "Place WAD files in the _doom directory above $persist_dir"
+        "ATTENTION: DOOM Retro requires WAD files, e.g. from a commercial DOOM copy (DOOM 1, 2, Ultimate DOOM, etc)",
+        "Place WAD files in the _doom directory under: $persist_dir",
+        "",
+        "If you want to bind controls in the config file, here are some examples:",
+        "",
+        "bind capslock +alwaysrun",
+        "bind 's' +back",
+        "bind mouse1 +fire",
+        "",
+        "Basically it's: bind control +action",
+        "",
+        "See the corresponding wiki section here for reference: https://github.com/bradharding/doomretro/wiki/THE-CONTROLS"
     ]
 }

--- a/bucket/doom-retro.json
+++ b/bucket/doom-retro.json
@@ -47,7 +47,7 @@
         }
     },
     "notes": [
-        "ATTENTION: DOOM Retro requires WAD files, e.g. from a commercial DOOM copy (DOOM 1, 2, Ultimate DOOM, etc)",
+        "ATTENTION: DOOM Retro requires WAD files, e.g. from a commercial DOOM copy (DOOM 1, 2, Ultimate DOOM, etc).",
         "Place WAD files in the _doom directory under: $persist_dir",
         "",
         "If you want to bind controls in the config file, here are some examples:",


### PR DESCRIPTION
This fixes the persist of the config file, though it doesn't fix issue #315 since the controls still end up empty.

Therefore I've added this information in the notes to simply improve the situation a bit.