### PR TITLE
rbxfpsunlocker: Update to version 4.4.1, fix autoupdate

### DIFF
--- a/bucket/rbxfpsunlocker.json
+++ b/bucket/rbxfpsunlocker.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.4.0",
+    "version": "4.4.1",
     "description": "Removes Roblox's default 60 FPS cap",
     "homepage": "https://github.com/axstin/rbxfpsunlocker",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/axstin/rbxfpsunlocker/files/6897488/rbxfpsunlocker-x64.zip",
-            "hash": "df044d923dd45c8187cb6a9359667d10a4554771aa860e5fa411cb009a0eb110"
+            "url": "https://github.com/axstin/rbxfpsunlocker/releases/download/v4.4.1/rbxfpsunlocker-x64.zip",
+            "hash": "f0bad3a2c8e84dc60066ef7e462ed2da4c19f293ea2ca797859d751f5ebdda63"
         }
     },
     "pre_install": [
@@ -22,14 +22,11 @@
         ]
     ],
     "persist": "settings",
-    "checkver": {
-        "url": "https://github.com/axstin/rbxfpsunlocker/releases/latest",
-        "regex": "tag/v([\\d.]+)[\\s\\S]+\"https://github.com/axstin/rbxfpsunlocker/files/(?<id>\\d+)/rbxfpsunlocker-x64.zip\""
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/axstin/rbxfpsunlocker/files/$matchId/rbxfpsunlocker-x64.zip"
+                "url": "https://github.com/axstin/rbxfpsunlocker/releases/download/v$version/rbxfpsunlocker-x64.zip"
             }
         }
     }


### PR DESCRIPTION
changes checkver to `github` mode (as it should've been when this manifest was added, rbxfpsunlocker uses the releases system on github so we can benefit from it here) and changes the autoupdate urls to use github release urls instead of file IDs.