### PR TITLE
nanoboyadvance: Fix hash

### DIFF
--- a/bucket/nanoboyadvance.json
+++ b/bucket/nanoboyadvance.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/nba-emu/NanoBoyAdvance/releases/download/v1.4/NanoBoyAdvance-1.4-win64.zip",
-            "hash": "e3e871fba9e1f7500bd9f4a52436eadba7aade932b48dad362460c71da540e64"
+            "hash": "f4b678d7868b613588e01e25fb091a0677e10cd87906d3298e44ee71fd53b07c"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
Seems like the download has gotten a new hash making the download fail in Scoop, this corrects it to the latest one.