### PR TITLE
demulshooter: Add version 10.4.1

### DIFF
--- a/bucket/demulshooter.json
+++ b/bucket/demulshooter.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/argonlefou/DemulShooter",
-    "description": "DemulShooter is an app that hooks into emulators to allow users to play rail shooter games with up to 4 lightguns or HID devices",
+    "description": "DemulShooter is an app that hooks into (mostly) emulators to allow users to play rail shooter games with up to 4 lightguns or HID devices",
     "version": "10.4.1",
     "license": "Unknown",
     "url": "https://github.com/argonlefou/DemulShooter/releases/download/v10.4.1/DemulShooter_v10.4.1.zip",

--- a/bucket/demulshooter.json
+++ b/bucket/demulshooter.json
@@ -1,0 +1,20 @@
+{
+    "homepage": "https://github.com/argonlefou/DemulShooter",
+    "description": "DemulShooter is an app that hooks into emulators to allow users to play railshooter games with up to 4 lightguns or HID devices",
+    "version": "10.4.1",
+    "license": "Unknown",
+    "url": "https://github.com/argonlefou/DemulShooter/releases/download/v10.4.1/DemulShooter_v10.4.1.zip",
+    "hash": "9ce598979f8269a44b2b35aaf8ea4652bd14dc5f7a36555f3bdcffcd5592b8cd",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\config.ini\")) { New-Item -ItemType File \"$dir\\config.ini\" | Out-Null }",
+    "shortcuts": [
+        [
+            "DemulShooter_GUI.exe",
+            "DemulShooter"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/argonlefou/DemulShooter/releases/download/v$version/DemulShooter_v$version.zip"
+    },
+    "persist": "config.ini"
+}

--- a/bucket/demulshooter.json
+++ b/bucket/demulshooter.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/argonlefou/DemulShooter",
-    "description": "DemulShooter is an app that hooks into emulators to allow users to play railshooter games with up to 4 lightguns or HID devices",
+    "description": "DemulShooter is an app that hooks into emulators to allow users to play rail shooter games with up to 4 lightguns or HID devices",
     "version": "10.4.1",
     "license": "Unknown",
     "url": "https://github.com/argonlefou/DemulShooter/releases/download/v10.4.1/DemulShooter_v10.4.1.zip",

--- a/bucket/demulshooter.json
+++ b/bucket/demulshooter.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/argonlefou/DemulShooter",
-    "description": "DemulShooter is an app that hooks into (mostly) emulators to allow users to play rail shooter games with up to 4 lightguns or HID devices",
+    "description": "Hook into (mostly) emulators to allow playing rail shooter games with up to 4 lightguns or HID devices",
     "version": "10.4.1",
     "license": "Unknown",
     "url": "https://github.com/argonlefou/DemulShooter/releases/download/v10.4.1/DemulShooter_v10.4.1.zip",

--- a/bucket/demulshooter.json
+++ b/bucket/demulshooter.json
@@ -16,5 +16,10 @@
     "autoupdate": {
         "url": "https://github.com/argonlefou/DemulShooter/releases/download/v$version/DemulShooter_v$version.zip"
     },
-    "persist": "config.ini"
+    "persist": "config.ini",
+    "notes": [
+        "",
+        "The usage instructions for the app can be found here: https://github.com/argonlefou/DemulShooter/wiki/Usage",
+        ""
+    ]
 }


### PR DESCRIPTION
DemulShooter is an app that hooks into (mostly) emulators to allow users to play rail shooter games with up to 4 lightguns or HID devices.