### PR TITLE
rayman-control-panel: Add version 12.1.0

### DIFF
--- a/bucket/rayman-control-panel.json
+++ b/bucket/rayman-control-panel.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/RayCarrot/RayCarrot.RCP.Metro",
-    "description": "The purpose of this program is to unify existing game patches and fixes, as well as allowing extended configuration, for all PC Rayman games",
+    "description": "The purpose of this app is to unify existing game patches and fixes, as well as allowing extended configuration, for all the PC Rayman games",
     "version": "12.1.0",
     "license": "MIT",
     "url": "https://github.com/RayCarrot/RayCarrot.RCP.Metro/releases/download/12.1.0/Rayman.Control.Panel.exe",

--- a/bucket/rayman-control-panel.json
+++ b/bucket/rayman-control-panel.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/RayCarrot/RayCarrot.RCP.Metro",
+    "description": "The purpose of this program is to unify existing game patches and fixes, as well as allowing extended configuration, for all PC Rayman games",
+    "version": "12.1.0",
+    "license": "MIT",
+    "url": "https://github.com/RayCarrot/RayCarrot.RCP.Metro/releases/download/12.1.0/Rayman.Control.Panel.exe",
+    "hash": "945b728bbd05b971d557ef0dd786940ef849c23f8a64f3fd39451663648f4a5f",
+    "shortcuts": [
+        [
+            "Rayman.Control.Panel.exe",
+            "Rayman Control Panel"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/RayCarrot/RayCarrot.RCP.Metro/releases/download/$version/Rayman.Control.Panel.exe"
+    }
+}

--- a/bucket/rayman-control-panel.json
+++ b/bucket/rayman-control-panel.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/RayCarrot/RayCarrot.RCP.Metro",
-    "description": "The purpose of this app is to unify existing game patches and fixes, as well as allowing extended configuration, for all the PC Rayman games",
+    "description": "Unified configuration and modding control panel for all PC Rayman games",
     "version": "12.1.0",
     "license": "MIT",
     "url": "https://github.com/RayCarrot/RayCarrot.RCP.Metro/releases/download/12.1.0/Rayman.Control.Panel.exe",


### PR DESCRIPTION
The purpose of this app is to unify existing game patches and fixes, as well as allowing extended configuration, for all the PC Rayman games.