### PR TITLE
dosbox-staging: Add version 0.78.1

### DIFF
--- a/bucket/dosbox-staging.json
+++ b/bucket/dosbox-staging.json
@@ -1,0 +1,43 @@
+{
+    "version": "0.78.1",
+    "description": "DOSBox Staging is DOS/x86 emulator focusing on ease of use. Based on DOSBox",
+    "homepage": "https://dosbox-staging.github.io/",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-msys2-x86_64-v0.78.1.zip",
+            "hash": "3c2f408125351154a37e93de8a4bd05d0c722bbf53e1f583909e4ca6c3eb9204"
+        },
+        "32bit": {
+            "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-msys2-i686-v0.78.1.zip",
+            "hash": "8ffd54502f2411f49d7b9f8e74a7a1861f008fcd1192ed4441262f829c05a608"
+        }
+    },
+    "pre_install": "if (!(Test-Path \"$persist_dir\\dosbox-staging.conf\")) { New-Item -ItemType File \"$dir\\dosbox-staging.conf\" | Out-Null }",
+    "bin": "dosbox.exe",
+    "shortcuts": [
+        [
+            "dosbox.exe",
+            "DOSBox Staging"
+        ]
+    ],
+    "persist": [
+        "dosbox-staging.conf",
+        "glshaders",
+        "mt32-roms",
+        "soundfonts"
+    ],
+    "checkver": {
+        "github": "https://github.com/dosbox-staging/dosbox-staging"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-msys2-x86_64-v$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-msys2-i686-v$version.zip"
+            }
+        }
+    }
+}

--- a/bucket/dosbox-staging.json
+++ b/bucket/dosbox-staging.json
@@ -1,6 +1,6 @@
 {
     "version": "0.78.1",
-    "description": "DOSBox Staging is DOS/x86 emulator focusing on ease of use. Based on DOSBox",
+    "description": "DOSBox Staging is DOS/x86 emulator focusing on ease of use. Based on DOSBox.",
     "homepage": "https://dosbox-staging.github.io/",
     "license": "GPL-2.0-or-later",
     "architecture": {
@@ -39,5 +39,10 @@
                 "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-msys2-i686-v$version.zip"
             }
         }
-    }
+    },
+    "notes": [
+        "",
+        "Config file examples can be found on the project's wiki here: https://github.com/dosbox-staging/dosbox-staging/wiki/Config-file-examples",
+        ""
+    ]
 }

--- a/bucket/dosbox-staging.json
+++ b/bucket/dosbox-staging.json
@@ -1,6 +1,6 @@
 {
     "version": "0.78.1",
-    "description": "DOSBox Staging is DOS/x86 emulator focusing on ease of use. Based on DOSBox.",
+    "description": "A DOS/x86 emulator based on DOSBox which focuses on ease of use.",
     "homepage": "https://dosbox-staging.github.io/",
     "license": "GPL-2.0-or-later",
     "architecture": {
@@ -14,7 +14,10 @@
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\dosbox-staging.conf\")) { New-Item -ItemType File \"$dir\\dosbox-staging.conf\" | Out-Null }",
-    "bin": "dosbox.exe",
+    "bin": [
+        "dosbox.exe",
+        "dosbox_with_debugger.exe"
+    ],
     "shortcuts": [
         [
             "dosbox.exe",
@@ -40,9 +43,5 @@
             }
         }
     },
-    "notes": [
-        "",
-        "Config file examples can be found on the project's wiki here: https://github.com/dosbox-staging/dosbox-staging/wiki/Config-file-examples",
-        ""
-    ]
+    "notes": "For config file examples see: https://github.com/dosbox-staging/dosbox-staging/wiki/Config-file-examples"
 }


### PR DESCRIPTION
DOSBox Staging is DOS/x86 emulator focusing on ease of use. Based on DOSBox.

---

Tested first by running it separately outside of Scoop to figure out persist/portable mode.

Basically if you don't have a dosbox-staging.conf in your root, it will use Local AppData - whilst if you do have it, it will use the config in the root, and create folders for glshaders, mt32-roms, and soundfonts. So all of this is persisted in the manifest and the config file is created through pre install with an If statement.