### PR TITLE
xenia: Update download location for 1.0.2555

### DIFF
--- a/bucket/xenia.json
+++ b/bucket/xenia.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://ci.appveyor.com/api/buildjobs/yfgrvu0a4skdl9al/artifacts/xenia_master.zip",
+            "url": "https://github.com/xenia-project/release-builds-windows/releases/download/v1.0.2555-master/xenia_master.zip",
             "hash": "98b45499cb8557fec67c1f1a4d3227d084abad2b7694ccbb093740d5fa18d5e9"
         }
     },
@@ -39,13 +39,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://ci.appveyor.com/api/projects/benvanik/xenia/branch/master",
-        "regex": "\"jobId\":\"(?<jobid>.*?)\".*\"version\":\"(?<version>[\\d\\.]+)-master\""
+        "github": "https://github.com/xenia-project/release-builds-windows",
+        "regex": "v([\\d.]+)-master\/xenia_master\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://ci.appveyor.com/api/buildjobs/$matchJobid/artifacts/xenia_master.zip"
+                "url": "https://github.com/xenia-project/release-builds-windows/releases/download/v$version-master/xenia_master.zip"
             }
         }
     }


### PR DESCRIPTION
According to the [Xenia download page](https://xenia.jp/download/), the new [GitHub releases repo](https://github.com/xenia-project/release-builds-windows/releases) is the place to get the latest releases.