### PR TITLE
doom-retro: Improve the Notes section

### DIFF
--- a/bucket/doom-retro.json
+++ b/bucket/doom-retro.json
@@ -47,8 +47,10 @@
         }
     },
     "notes": [
+        "",
         "ATTENTION: DOOM Retro requires WAD files, e.g. from a commercial DOOM copy (DOOM 1, 2, Ultimate DOOM, etc).",
-        "Place WAD files in the _doom directory under: $persist_dir",
+        "",
+        "Place the WAD files in the _doom directory which is under your persist dir.",
         "",
         "If you want to bind controls in the config file, here are some examples:",
         "",
@@ -58,6 +60,7 @@
         "",
         "Basically it's: bind control +action",
         "",
-        "See the corresponding wiki section here for reference: https://github.com/bradharding/doomretro/wiki/THE-CONTROLS"
+        "See the corresponding wiki section here for reference: https://github.com/bradharding/doomretro/wiki/THE-CONTROLS",
+        ""
     ]
 }

--- a/bucket/doom-retro.json
+++ b/bucket/doom-retro.json
@@ -58,9 +58,9 @@
         "bind 's' +back",
         "bind mouse1 +fire",
         "",
-        "Basically it's: bind control +action",
+        "Basically it's: bind control +action, where singular letters and signs need to have apostrophes surrounding them in the config file.",
         "",
-        "See the corresponding wiki section here for reference: https://github.com/bradharding/doomretro/wiki/THE-CONTROLS",
+        "See the corresponding wiki section here for reference: https://github.com/bradharding/doomretro/wiki/CONSOLE-COMMANDS#ACTIONS",
         ""
     ]
 }

--- a/bucket/doom-retro.json
+++ b/bucket/doom-retro.json
@@ -58,7 +58,7 @@
         "bind 's' +back",
         "bind mouse1 +fire",
         "",
-        "Basically it's: bind control +action, where singular letters and signs need to have apostrophes surrounding them in the config file.",
+        "Basically, it's: bind control +action, where singular letters and signs need to have apostrophes surrounding them in the config file.",
         "",
         "See the corresponding wiki section here for reference: https://github.com/bradharding/doomretro/wiki/CONSOLE-COMMANDS#ACTIONS",
         ""


### PR DESCRIPTION
The notes described the _doom dir as being under the DOOM Retro persist dir, which is not correct - so this corrects that.

It also inserts some space in the notes section to make it more readable and aesthetically pleasing.