### PR TITLE
xenia: Fix persist list

### DIFF
--- a/bucket/xenia.json
+++ b/bucket/xenia.json
@@ -31,12 +31,10 @@
         ]
     ],
     "persist": [
-        [
-            "portable.txt",
-            "xenia.config.toml",
-            "content",
-            "cache"
-        ]
+        "portable.txt",
+        "xenia.config.toml",
+        "content",
+        "cache"
     ],
     "checkver": {
         "github": "https://github.com/xenia-project/release-builds-windows",


### PR DESCRIPTION
The persist list was incorrectly nested, which caused incorrect persisting after an update.

Specifically, it was causing the contents of all the files to be written to `portable.txt` and skipping the other files:

![image](https://user-images.githubusercontent.com/25037249/151723983-fa1da888-661c-4d3b-b7d2-507fa7f83a7b.png)
