### PR TITLE
ares: Fix autoupdate and extract_dir

### DIFF
--- a/bucket/ares.json
+++ b/bucket/ares.json
@@ -9,7 +9,7 @@
             "hash": "95ee28a1f527a498c35eb156ed60fb9ed43173eb9d8179e7fc80d433ecb859b9"
         }
     },
-    "extract_dir": "ares-v124",
+    "extract_dir": "ares-v127",
     "bin": "ares.exe",
     "shortcuts": [
         [
@@ -29,8 +29,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ares-emulator/ares/releases/download/v$version/ares-windows.zip",
-                "extract_dir": "ares-v$version"
+                "url": "https://github.com/ares-emulator/ares/releases/download/v$cleanVersion/ares-windows.zip",
+                "extract_dir": "ares-v$cleanVersion"
             }
         }
     },


### PR DESCRIPTION
This should fix the extract dir by correcting it to the current version which is 127, and autoupdate by using cleanVersion.