### PR TITLE
prboom-plus: Add `extract_dir`

### DIFF
--- a/bucket/prboom-plus.json
+++ b/bucket/prboom-plus.json
@@ -10,6 +10,7 @@
     ],
     "url": "https://github.com/coelckers/prboom-plus/releases/download/v2.6.2/prboom-plus-262-w32.zip",
     "hash": "20313e00d8841a618e23e7c671d65870194bee634468fecd2f3697ac05f21476",
+    "extract_dir": "prboom-plus-262-w32",
     "pre_install": "New-Item -ItemType Directory -Force -Path $persist_dir\\..\\_doom | Out-Null",
     "env_set": {
         "DOOMWADDIR": "$persist_dir\\..\\_doom"
@@ -55,6 +56,7 @@
         "github": "https://github.com/coelckers/prboom-plus"
     },
     "autoupdate": {
-        "url": "https://github.com/coelckers/prboom-plus/releases/download/v$version/prboom-plus-$cleanVersion-w32.zip"
+        "url": "https://github.com/coelckers/prboom-plus/releases/download/v$version/prboom-plus-$cleanVersion-w32.zip",
+        "extract_dir": "prboom-plus-$cleanVersion-w32"
     }
 }


### PR DESCRIPTION
The contents of [`prboom-plus-262-w32.zip`](https://github.com/coelckers/prboom-plus/releases/download/v2.6.2/prboom-plus-262-w32.zip) are wrapped in a folder.

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md).

## What package release type is this?
- [x] stable
- [ ] beta
- [ ] dev
- [ ] nightly/canary

- [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
- [x] tested install, checked persist, no errors.
