### PR TITLE
Create sabaki.json

### DIFF
--- a/bucket/sabaki.json
+++ b/bucket/sabaki.json
@@ -1,0 +1,50 @@
+{
+	"version": "0.52.0",
+	"description": "An elegant Go board and SGF editor for a more civilized age.",
+	"homepage": "https://sabaki.yichuanshen.de",
+	"license": "MIT",
+	"depends": "7zip",
+	"architecture": {
+		"64bit": {
+			"url": "https://github.com/SabakiHQ/Sabaki/releases/download/v0.52.0/sabaki-v0.52.0-win-x64-setup.exe#/setup.7z",
+			"installer": {
+				"script": [
+					"try {7z x \"$dir\\`$PLUGINSDIR\\app-64.7z\" -o\"$dir\"}",
+					"catch {Write-Error \"7Zip needs to be in the path\"; exit 1}"
+				]
+			}
+		},
+		"32bit": {
+			"url": "https://github.com/SabakiHQ/Sabaki/releases/download/v0.52.0/sabaki-v0.52.0-win-ia32-setup.exe#/setup.7z",
+			"installer": {
+				"script": [
+					"try {7z x \"$dir\\`$PLUGINSDIR\\app-32.7z\" -o\"$dir\"}",
+					"catch {Write-Error \"7Zip needs to be in the path\"; exit 1}"
+				]
+			}
+		}
+	},
+	"post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse",
+	"bin": [
+		"Sabaki.exe"
+	],
+	"shortcuts": [
+		[
+			"Sabaki.exe",
+			"Sabaki"
+		]
+	],
+	"checkver": {
+		"github": "https://github.com/SabakiHQ/Sabaki"
+	},
+	"autoupdate": {
+		"architecture": {
+			"64bit": {
+				"url": "https://github.com/SabakiHQ/Sabaki/releases/download/v$version/sabaki-v$version-win-x64-setup.exe#/setup.7z"
+			},
+			"32bit": {
+				"url": "https://github.com/SabakiHQ/Sabaki/releases/download/v$version/sabaki-v$version-win-ia32-setup.exe#/setup.7z"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Sabaki serves as a go board and is a popular tool among go players.
We are not entirely sure if the autoupdate section works and would like to ask a sanity check on it. When  we try to run `checkver.ps1 sabaki <dir> -u` on an older version we get `ERROR You cannot call a method on a null-valued expression.` Don't know what to make of it.

## What package release type is this?
> - [x] stable


> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [ ] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash **No hash available**
> - [x] bin entry for main binary
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
