### PR TITLE
pcsx2-dev: Remove 32-bit builds

### DIFF
--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -15,22 +15,6 @@
         "Microsoft Visual C++ Runtime 2019": "extras/vcredist2019"
     },
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/PCSX2/pcsx2/releases/download/v1.7.2484/pcsx2-v1.7.2484-windows-32bit-AVX2.7z",
-            "hash": "7b3f4cdef5ac057955552a9caf6ac5b02aa66f07f17f492061ae307f2dc4819c",
-            "bin": [
-                [
-                    "pcsx2-avx2.exe",
-                    "pcsx2-dev"
-                ]
-            ],
-            "shortcuts": [
-                [
-                    "pcsx2-avx2.exe",
-                    "PCSX2 (development)"
-                ]
-            ]
-        },
         "64bit": {
             "url": "https://github.com/PCSX2/pcsx2/releases/download/v1.7.2484/pcsx2-v1.7.2484-windows-64bit-AVX2.7z",
             "hash": "3cf5c3f0438b302485d06f88084a62248077221b3b741080acc408513d18774d",
@@ -77,9 +61,6 @@
     },
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/PCSX2/pcsx2/releases/download/v$version/pcsx2-v$version-windows-32bit-AVX2.7z"
-            },
             "64bit": {
                 "url": "https://github.com/PCSX2/pcsx2/releases/download/v$version/pcsx2-v$version-windows-64bit-AVX2.7z"
             }


### PR DESCRIPTION
The PCSX2 repository no longer provides 32 bit builds in their releases page: https://github.com/PCSX2/pcsx2/commit/8a4f1ef51a037d77d2746304d89bef6a325a790b

I believe the now broken `32bit` section in this manifest was preventing it from being autoupdated.