### PR TITLE
bsnes-hd-beta: Add beta version 10.6

### DIFF
--- a/bucket/bsnes-hd.json
+++ b/bucket/bsnes-hd.json
@@ -1,0 +1,25 @@
+{
+    "version": "10.6",
+    "description": "bsnes-hd is a fork of bsnes that adds video features like rendering Mode 7 in a higher resolution, widescreen, and true color",
+    "homepage": "https://github.com/DerKoun/bsnes-hd",
+    "license": {
+        "identifier": "GPL-3.0-only",
+        "url": "https://github.com/DerKoun/bsnes-hd/blob/master/LICENSE"
+    },
+    "url": "https://github.com/DerKoun/bsnes-hd/releases/download/beta_10_6/bsnes_hd_beta_10_6_windows.zip",
+    "hash": "31c4d27e74ff8d87e9e7da7ca9c64960d5f69e6b6d6c805120145e955067e445",
+    "shortcuts": [
+        [
+            "bsnes_hd.exe",
+            "bsnes-hd"
+        ]
+    ],
+    "persist": [
+        "Firmware",
+        "settings.bml"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/DerKoun/bsnes-hd/releases/download/beta_$underscoreVersion/bsnes_hd_beta_$underscoreVersion_windows.zip"
+    }
+}


### PR DESCRIPTION
bsnes-hd is a fork of bsnes that adds video features like rendering Mode 7 in a higher resolution, widescreen, and true color.

## What package release type is this?

> - [ ] stable
> - [x] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
