### PR TITLE
ferium: Add version 3.27.0

### DIFF
--- a/bucket/ferium.json
+++ b/bucket/ferium.json
@@ -1,0 +1,22 @@
+{
+    "version": "3.27.0",
+    "description": "Ferium is a CLI Minecraft mod manager for mods from Modrinth, CurseForge, and Github Releases.",
+    "homepage": "https://github.com/theRookieCoder/ferium",
+    "license": "MPL-2.0",
+    "architecture": {
+        "64bit": {
+                "url": "https://github.com/theRookieCoder/ferium/releases/download/v3.27.0/ferium-windows-msvc.zip",
+                "hash": "83e9d861077ec15f5d700bfc81b20e77f58df24d9f1538210a98b4667a238517"
+            }
+    },
+    "bin": "ferium.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/theRookieCoder/ferium/releases/download/v$version/ferium-windows-msvc.zip"
+            }
+        },
+        "hash": "https://github.com/theRookieCoder/ferium/releases/download/v$version/ferium-windows-msvc.zip.sha256"
+    }
+}


### PR DESCRIPTION
## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [ ] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [ ] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
