### PR TITLE
sixcells: Add version 2.4.3

### DIFF
--- a/bucket/sixcells.json
+++ b/bucket/sixcells.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.4.3",
+    "description": "Level editor for Hexcells",
+    "homepage": "https://github.com/oprypin/sixcells",
+    "license": "GPL-3.0",
+    "url": "https://github.com/oprypin/sixcells/releases/download/v2.4.3/sixcells-2.4.3-win32.zip",
+    "hash": "5b1bac288dd559f0fcb41d1eef61e79fd0b277d02032d3b4d549dec45fa46aa7",
+    "extract_dir": "sixcells",
+    "shortcuts": [
+        [
+            "player.exe",
+            "SixCells Player"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/oprypin/sixcells/releases/download/v$version/sixcells-$version-win32.zip",
+        "extract_dir": "sixcells"
+    }
+}


### PR DESCRIPTION
[sixcells](https://github.com/oprypin/sixcells) is a level editor for [Hexcells](http://store.steampowered.com/app/304410/).

<!--
  By opening this PR you confirm that will follow the contribution guidelines. You agree to submit a fully featured working manifest that creates shortcuts, bin shims, persists data, enable portable mode, and auto updates.
-->

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [ ] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [ ] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
