### PR TITLE
l4d2modmanager: Fix persist with a pre_install script

### DIFF
--- a/bucket/l4d2modmanager.json
+++ b/bucket/l4d2modmanager.json
@@ -5,6 +5,10 @@
     "license": "MIT",
     "url": "https://github.com/xavier-cai/L4D2ModManager/raw/master/Release/Release.zip",
     "hash": "1d6ee3be4ecad84f9a7afdb4616f0d37973750c5884711352fa4b7ce5ae6b348",
+    "pre_install": [
+        "if (!(Test-Path -Path \"$persist_dir\\list-box.ini\")) { New-Item -Path \"$dir\" -Name \"list-box.ini\" -Value \"[]\" | Out-Null }",
+        "if (!(Test-Path -Path \"$persist_dir\\view-list.ini\")) { New-Item -Path \"$dir\" -Name \"view-list.ini\" -Value \"[]\" | Out-Null }"
+    ],
     "shortcuts": [
         [
             "L4D2ModManager.exe",


### PR DESCRIPTION
Fix persist with a pre_install script.

<!--
  By opening this PR you confirm that will follow the contribution guidelines. You agree to submit a fully featured working manifest that creates shortcuts, bin shims, persists data, enable portable mode, and auto updates.
-->

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [ ] properly named and capitalized shortcuts?
> - [ ] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [ ] license identifier and url
> - [ ] a short terse description matching existing style.
> - [ ] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [ ] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [ ] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
