### PR TITLE
spraygen: Add version 1.3.4

### DIFF
--- a/bucket/spraygen.json
+++ b/bucket/spraygen.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.3.4",
+    "description": "A .vtf spray generator for TF2/CSS/L4D/L4D2",
+    "homepage": "https://code.google.com/archive/p/spraygen/",
+    "license": "GPL-3.0",
+    "url": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/spraygen/spraygen-1.3.4.zip",
+    "hash": "6547a3708df5649ce28c784307a6463b309af94e94dc2717fdd7b887918fa568",
+    "extract_dir": "spraygen",
+    "shortcuts": [
+        [
+            "spraygen.exe",
+            "Spraygen"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.googleapis.com/storage/v1/b/google-code-archive/o/v2%2Fcode.google.com%2Fspraygen%2Fdownloads-page-1.json?alt=media&stripTrailingSlashes=false",
+        "jsonpath": "$.downloads.[0].filename",
+        "regex": "spraygen-([\\d.]+)\\.zip"
+    },
+    "autoupdate": {
+        "url": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/spraygen/spraygen-$version.zip",
+        "extract_dir": "spraygen"
+    }
+}


### PR DESCRIPTION
[spraygen](https://code.google.com/archive/p/spraygen/) is a .vtf spray generator for TF2/CSS/L4D/L4D2.
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that will follow the contribution guidelines. You agree to submit a fully featured working manifest that creates shortcuts, bin shims, persists data, enable portable mode, and auto updates.
-->

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [ ] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [ ] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
