### PR TITLE
mame: Update to version 0.243, fix autoupdate

### DIFF
--- a/bucket/mame.json
+++ b/bucket/mame.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.241",
+    "version": "0.243",
     "description": "Arcade machine emulator",
     "homepage": "http://mamedev.org",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "32bit": {
-            "url": "https://file-examples-com.github.io/uploads/2017/02/file_example_JSON_1kb.json",
-            "hash": "aa20e971f6a0a7c482f3ed70cc6edc115eb577f987322ba42e5c3869e1d714d1",
+            "url": "https://raw.githubusercontent.com/Calinou/scoop-games/27ba46f443a3446a70bf1f93eeb09797be0fb286/bucket/mame.json",
+            "hash": "c5000bfb8d01c568cb4b7df64cb16f2361729e19d43dd7bee30d1db72ac1b2c5",
             "pre_install": [
                 "Write-Host -ForegroundColor Yellow \"WARN: MAME no longer provides up to date 32bit binaries\"",
                 "Write-Host -ForegroundColor Yellow \"Continue installing latest 32bit release (0.217)? \"",
@@ -28,8 +28,8 @@
             ]
         },
         "64bit": {
-            "url": "https://github.com/mamedev/mame/releases/download/mame0241/mame0241b_64bit.exe#/dl.7z",
-            "hash": "8b643ef1c9a5842133b98a99e96126ca530ee01d1a2bc335f8da96db61a3aea2",
+            "url": "https://github.com/mamedev/mame/releases/download/mame0243/mame0243b_64bit.exe#/dl.7z",
+            "hash": "a4b3d1660fbbd6a51249e53f3f24d9c68c7c471c00d13af473c9d46908921f84",
             "pre_install": [
                 "if(!(Test-Path \"$persist_dir\\mame.ini\")) {",
                 "   Start-Process \"$dir\\mame.exe\" -WorkingDirectory \"$dir\" -ArgumentList \"-createconfig\"",

--- a/bucket/mame.json
+++ b/bucket/mame.json
@@ -65,7 +65,7 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://file-examples-com.github.io/uploads/2017/02/file_example_JSON_1kb.json"
+                "url": "https://raw.githubusercontent.com/Calinou/scoop-games/27ba46f443a3446a70bf1f93eeb09797be0fb286/bucket/mame.json"
             },
             "64bit": {
                 "url": "https://github.com/mamedev/mame/releases/download/mame$cleanVersion/mame$cleanVersionb_64bit.exe#/dl.7z"


### PR DESCRIPTION
The dummy URL added in https://github.com/Calinou/scoop-games/pull/269 for the 32-bit version of MAME is no longer online. This caused MAME's autoupdate to stop working, as reported in #612.

This PR changes it to the URL of the manifest JSON itself, which should stay valid for a long time. I also updated the manifest using `check-ver.ps1`.