### PR TITLE
rpcs3: Fix `config.yml` and `games.yml` not persisting between upgrades

### DIFF
--- a/bucket/rpcs3.json
+++ b/bucket/rpcs3.json
@@ -21,13 +21,15 @@
             "hash": "755f50b240e71ebdcd9e4f45b50e44259087f4666cffe7c00d7635e2fdf8d957"
         }
     },
-    "installer": {
+    "pre_install": [
+        "ensure \"$persist_dir\" | Out-Null",
+        "Get-ChildItem \"$persist_dir\\*\" -Include 'config.yml', 'games.yml' | Copy-Item -Destination \"$dir\" -ErrorAction SilentlyContinue"
+    ],
+    "uninstaller": {
         "script": [
-            "if (!(Test-Path \"$persist_dir\\config.yml\")) {",
-            "    New-Item \"$dir\\config.yml\" -Type File | Out-Null",
-            "}",
-            "if (!(Test-Path \"$persist_dir\\games.yml\")) {",
-            "    New-Item \"$dir\\games.yml\" -Type File | Out-Null",
+            "ensure \"$persist_dir\" | Out-Null",
+            "'config.yml', 'games.yml' | ForEach-Object {",
+            "    Copy-Item \"$dir\\$_\" \"$persist_dir\" -ErrorAction 'SilentlyContinue' -Force",
             "}"
         ]
     },
@@ -47,10 +49,8 @@
         "dev_usb000",
         "cache",
         "captures",
-        "config.yml",
         "config",
         "firmware",
-        "games.yml",
         "GuiConfigs",
         "Icons",
         "patches"


### PR DESCRIPTION
RPCS3 overwrites files config.yml and games.yml when saving changes to them, which eliminates the hardlinks created by Scoop when installing the app. Without the hardlinks, these files do not persist when un/re-installing the app.

This PR works around the overwrite behavior by copying the .yml files to the persist directory before uninstall (`"uninstaller"` definition) and copying them back to the app during installation (`"pre_install"` definition). Because Scoop's default persist handling does not work for these files, I also removed them from the `"persist"` definition.