### PR TITLE
pcsx2-dev: Fix download URL for Qt release

### DIFF
--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -20,13 +20,13 @@
             "hash": "b190eff56abf44f15c37efa37086cf35b53814506e133f3a3f541a8ff856fdaa",
             "bin": [
                 [
-                    "pcsx2x64-avx2.exe",
+                    "pcsx2-qtx64-avx2.exe",
                     "pcsx2-dev"
                 ]
             ],
             "shortcuts": [
                 [
-                    "pcsx2x64-avx2.exe",
+                    "pcsx2-qtx64-avx2.exe",
                     "PCSX2 (development)"
                 ]
             ]
@@ -46,13 +46,16 @@
         "bios",
         "cheats_ws",
         "cheats",
+        "covers",
+        "gamesettings",
         "inis",
         "logs",
         "memcards",
         "portable.ini",
-        "shaders\\GSdx_FX_Settings.ini",
+        "shaders\\GS_FX_Settings.ini",
         "snaps",
-        "sstates"
+        "sstates",
+        "textures"
     ],
     "checkver": {
         "url": "https://github.com/PCSX2/pcsx2/releases.atom",
@@ -62,7 +65,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/PCSX2/pcsx2/releases/download/v$version/pcsx2-v$version-windows-64bit-AVX2.7z"
+                "url": "https://github.com/PCSX2/pcsx2/releases/download/v$version/pcsx2-v$version-windows-64bit-AVX2-Qt.7z"
             }
         }
     }


### PR DESCRIPTION
PCSX2's development builds recently switched to a new Qt user interface and changed some of the files.

In this PR, I fix the the download URL/executable name and add new folders to the persist list.