### PR TITLE
ferium: Fix version 4.0.2, update URLs

### DIFF
--- a/bucket/ferium.json
+++ b/bucket/ferium.json
@@ -5,8 +5,8 @@
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/theRookieCoder/ferium/releases/download/v4.0.1/ferium-windows-msvc.zip",
-            "hash": "a1d1acfec86165fd63150584833c11911d2f7d098675eaee3f5bc3782858aad1"
+            "url": "https://github.com/gorilla-devs/ferium/releases/download/v4.0.2/ferium-windows-msvc.zip",
+            "hash": "5a061d9a4089ab833ac083ee7665923c1d391f014d92fb3f3c58958629e9d959"
         }
     },
     "bin": "ferium.exe",
@@ -14,9 +14,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/theRookieCoder/ferium/releases/download/v$version/ferium-windows-msvc.zip"
+                "url": "https://github.com/gorilla-devs/ferium/releases/download/v$version/ferium-windows-msvc.zip"
             }
         },
-        "hash": "https://github.com/theRookieCoder/ferium/releases/download/v$version/ferium-windows-msvc.zip.sha256"
+        "hash": "https://github.com/gorilla-devs/ferium/releases/download/v$version/ferium-windows-msvc.zip.sha256"
     }
 }


### PR DESCRIPTION
The previous PR, #628 was broken because the URLs still used my username (the repo has been transferred to `gorilla-devs`) and the 'architecture' file still used the old 4.0.1 release which has been deleted