### PR TITLE
Fix ares update

### DIFF
--- a/bucket/ares.json
+++ b/bucket/ares.json
@@ -10,7 +10,7 @@
             "hash": "0ea4ae1df7031f524cc184509924a0b87fba199d236cd0687bba24327069b549"
         }
     },
-    "extract_dir": "ares-v127",
+    "extract_dir": "ares-v128",
     "post_install": [
         "if (!(Test-Path \"$persist_dir\\settings.bml.bak\")) {",
         "   New-Item -ItemType File \"$dir\\settings.bml\" | Out-Null",


### PR DESCRIPTION
ares: Update to version 128 is not working. I guess you simply have to change line to "extract_dir": "ares-v128"

https://github.com/Calinou/scoop-games/issues/635
