### PR TITLE
openmw-nightly: Fix checkver

### DIFF
--- a/bucket/openmw-nightly.json
+++ b/bucket/openmw-nightly.json
@@ -1,17 +1,17 @@
 {
-    "version": "20220608-d4a44c84",
+    "version": "20220610-38ca20fa",
     "description": "An open-source open-world RPG game engine that supports playing Morrowind. (nightly version)",
     "homepage": "http://openmw.org/",
     "license": "GPL-3.0-or-later",
     "notes": "Please run the OpenMW Launcher in the start menu to configure the game data path. Otherwise, OpenMW won't start correctly.",
     "architecture": {
         "64bit": {
-            "url": "https://gitlab.com/OpenMW/openmw/-/jobs/2559544301/artifacts/download#/dl.7z",
-            "hash": "799c5dfd81d42c20abf7501a097b26f3a258a2cfb34af631be9ce8df9704a2cb"
+            "url": "https://gitlab.com/OpenMW/openmw/-/jobs/2576395923/artifacts/download#/dl.7z",
+            "hash": "b2037b8658d11e607ae1cefdcedb3619c5bc938b678727d33ddbad21c7e2416c"
         }
     },
-    "pre_install": "Expand-ZipArchive \"$dir\\OpenMW_MSVC2019_64_Engine_Release_*.zip\" \"$dir\"",
-    "post_install": "Remove-Item \"$dir\\MSVC2019_64_Ninja\", \"$dir\\chocolatey.log\", \"$dir\\OpenMW_MSVC2019_64_Engine_Release_*.zip\" -Force -Recurse",
+    "pre_install": "Expand-ZipArchive \"$dir\\OpenMW_MSVC2019_64_Engine_RelWithDebInfo_*.zip\" \"$dir\"",
+    "post_install": "Remove-Item \"$dir\\MSVC2019_64\", \"$dir\\chocolatey.log\", \"$dir\\OpenMW_MSVC2019_64_Engine_RelWithDebInfo_*.zip\" -Force -Recurse",
     "bin": [
         "openmw.exe",
         "openmw-launcher.exe",
@@ -36,7 +36,7 @@
     ],
     "checkver": {
         "url": "https://gitlab.com/OpenMW/openmw/-/jobs",
-        "regex": "\\/commit\\/[0-9a-f]{40}\">(?<commit>[0-9a-f]{8})<\\/a>(?:.*\\n){21}.*datetime=\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})(?:.*\\n){16}passed(?:.*\\n){4}.*(?<job>[0-9]{10})\">Windows_Ninja_Engine_Release",
+        "regex": "\\/commit\\/[0-9a-f]{40}\">(?<commit>[0-9a-f]{8})<\\/a>(?:.*\\n){21}.*datetime=\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})(?:.*\\n){16}passed(?:.*\\n){4}.*(?<job>[0-9]{10})\">Windows_MSBuild_Engine_RelWithDebInfo(?:.*\\n){7}.*>master<",
         "replace": "${year}${month}${day}-${commit}"
     },
     "autoupdate": {


### PR DESCRIPTION
A fix for openmw-nightly because the automatic builds were changed. I added a new check in the regex to only update if the commit was on the master branch.