### PR TITLE
undertale-mod-tool: Fix persist

### DIFF
--- a/bucket/undertale-mod-tool.json
+++ b/bucket/undertale-mod-tool.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-only",
     "url": "https://github.com/krzys-h/UndertaleModTool/releases/download/0.4.0.4/UndertaleModTool_v0.4.0.4.zip",
     "hash": "499cb15977c9c14fe605662d14d08632d3a3b9f287e77ee9bd8ba7a6a0958ece",
-    "pre_install": "if (!(Test-Path \"$persist_dir\\UndertaleModTool.exe.config\")) { New-Item \"$dir\\UndertaleModTool.exe.config\" | Out-Null }"
+    "pre_install": "if (!(Test-Path \"$persist_dir\\UndertaleModTool.exe.config\")) { New-Item \"$dir\\UndertaleModTool.exe.config\" | Out-Null }",
     "bin": "UndertaleModTool.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
* Fixes #597

* `UndertaleModTool.exe.config` does not exist in the archive, causing *Scoop* to persist it as a **folder**, which causes the access error to happen.