### PR TITLE
cemu: Fix persist

### DIFF
--- a/bucket/cemu.json
+++ b/bucket/cemu.json
@@ -8,7 +8,7 @@
     },
     "suggest": {
         "cemuhook": "cemuhook",
-        "vcredist": "extras/vcredist2015"
+        "vcredist2015-2022": "extras/vcredist2022"
     },
     "architecture": {
         "64bit": {
@@ -46,7 +46,6 @@
         ]
     ],
     "persist": [
-        "settings.xml",
         "controllerProfiles",
         "gameProfiles",
         "graphicPacks",


### PR DESCRIPTION
* Fixes #623

* In #598, `Setting.xml` is **manually** persisted, but it was not removed from the `persist` field, causing *Scoop* to persist twice and resulting in the file access error.

* Update suggestion of *VCRedist* ([the 2022 version is compatible with 2015-2022](https://docs.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170))