### PR TITLE
vkquake: Persist for the Arcane Dimensions mod

### DIFF
--- a/bucket/vkquake.json
+++ b/bucket/vkquake.json
@@ -4,6 +4,7 @@
     "homepage": "https://github.com/Novum/vkQuake",
     "license": "GPL-2.0-or-later",
     "notes": [
+        "",
         "Place game data files (such as pak0.pak and pak1.pak) in:",
         "",
         "- Quake:",
@@ -16,7 +17,11 @@
         "    $persist_dir\\rogue\\",
         "",
         "- Quake Mission Pack 3 - Abyss of Pandemonium:",
-        "    $persist_dir\\abyss\\"
+        "    $persist_dir\\abyss\\",
+        "",
+        "- Quake - Arcane Dimensions (https://www.moddb.com/mods/arcane-dimensions):",
+        "    $persist_dir\\ad\\",
+        ""
     ],
     "suggest": {
         "vcredist": "extras/vcredist2019"
@@ -59,13 +64,19 @@
             "vkQuake.exe",
             "vkQuake (Abyss of Pandemonium)",
             "-game abyss"
+        ],
+        [
+            "vkQuake.exe",
+            "vkQuake (Arcane Dimensions)",
+            "-game ad"
         ]
     ],
     "persist": [
         "id1",
         "hipnotic",
         "rogue",
-        "abyss"
+        "abyss",
+        "ad"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
Many including myself consider the mod Arcane Dimensions for Quake as good, if not far greater than the base contents of the game.

This change persists the dir for the mod according to the instructions on its homepage; dir 'ad'.


## What package release type is this?

> - [x] stable

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
