### PR TITLE
(chore): Fix git conflicts with line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-# retain windows line-endings in case checked out on mac or linux
-* text eol=crlf
+# Since Scoop is a Windows-only tool, we can safely use CRLF line endings for all text files.
+# If Git decides that the content is text, its line endings will be normalized to CRLF in the working tree on checkout.
+# In the Git index/repository the files will always be stored with LF line endings. This is fine.
+* text=auto eol=crlf


### PR DESCRIPTION
This avoids **git conflicts** due to inconsistant line endings (`LF`/`CRLF`), which will sometimes cause users unable to update the bucket.

The fix was applied to all buckets under `ScoopInstaller` org.

related:
https://github.com/ScoopInstaller/Extras/issues/7546
https://github.com/ScoopInstaller/Extras/pull/8285