### PR TITLE
raine: Add version 0.93.5d

### DIFF
--- a/bucket/raine.json
+++ b/bucket/raine.json
@@ -1,0 +1,75 @@
+{
+    "version": "0.93.5d",
+    "description": "RAINE is an emulator for arcade games",
+    "homepage": "https://raine.1emulation.com/",
+    "license": "Artistic-2.0",
+    "notes": [
+        "",
+        "Download the corresponding DLLs from http://raine.1emulation.com/download/latest.html - basically for either 32-bit or 64-bit Windows operating systems.",
+        "",
+        "Once downloaded, extract all of them to the System32 dir under your Windows dir.",
+        ""
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "http://raine.1emulation.com/archive/raine64-0.93.5d.7z",
+            "hash": "0fa9cc45d7c2e62e6d273535f966b032c5265672743cd888367b42172c765a02",
+            "extract_dir": "raine64",
+            "bin": [
+                [
+                    "raine.exe",
+                    "RAINE"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "raine.exe",
+                    "RAINE"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "http://raine.1emulation.com/archive/raine32-0.93.5d.7z",
+            "hash": "76bd7ebc425b1dbd1aaca77dfa8ddb0e4f23fe6e30b0ffcf41b13025e9459018",
+            "extract_dir": "raine32",
+            "bin": [
+                [
+                    "raine32.exe",
+                    "RAINE"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "raine32.exe",
+                    "RAINE"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "artwork",
+        "blend",
+        "config",
+        "debug",
+        "demos",
+        "emudx",
+        "roms",
+        "savedata",
+        "savegame",
+        "screens"
+    ],
+    "checkver": {
+        "url": "https://raine.1emulation.com/download/latest.html",
+        "regex": "Available files for version ([\\d.]+[a-zA-Z]?)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://raine.1emulation.com/archive/raine64-$version.7z"
+            },
+            "32bit": {
+                "url": "http://raine.1emulation.com/archive/raine32-$version.7z"
+            }
+        }
+    }
+}

--- a/bucket/raine.json
+++ b/bucket/raine.json
@@ -28,7 +28,7 @@
             ]
         },
         "64bit": {
-            "url": [ 
+            "url": [
                 "https://raine.1emulation.com/archive/raine64-0.93.5d.7z",
                 "https://raine.1emulation.com/archive/dlls64-0.92x.7z"
             ],

--- a/bucket/raine.json
+++ b/bucket/raine.json
@@ -3,34 +3,16 @@
     "description": "RAINE is an emulator for arcade games",
     "homepage": "https://raine.1emulation.com/",
     "license": "Artistic-2.0",
-    "notes": [
-        "",
-        "Download the corresponding DLLs from http://raine.1emulation.com/download/latest.html - basically for either 32-bit or 64-bit Windows operating systems.",
-        "",
-        "Once downloaded, extract all of them to the System32 dir under your Windows dir.",
-        ""
-    ],
     "architecture": {
-        "64bit": {
-            "url": "http://raine.1emulation.com/archive/raine64-0.93.5d.7z",
-            "hash": "0fa9cc45d7c2e62e6d273535f966b032c5265672743cd888367b42172c765a02",
-            "extract_dir": "raine64",
-            "bin": [
-                [
-                    "raine.exe",
-                    "RAINE"
-                ]
-            ],
-            "shortcuts": [
-                [
-                    "raine.exe",
-                    "RAINE"
-                ]
-            ]
-        },
         "32bit": {
-            "url": "http://raine.1emulation.com/archive/raine32-0.93.5d.7z",
-            "hash": "76bd7ebc425b1dbd1aaca77dfa8ddb0e4f23fe6e30b0ffcf41b13025e9459018",
+            "url": [
+                "https://raine.1emulation.com/archive/raine32-0.93.5d.7z",
+                "https://raine.1emulation.com/archive/dlls32-0.92x.7z"
+            ],
+            "hash": [
+                "76bd7ebc425b1dbd1aaca77dfa8ddb0e4f23fe6e30b0ffcf41b13025e9459018",
+                "95e9c7613aa6f42c341a0c45d4863fd1c7b3c6eebc2542de98e4c826e22f4d56"
+            ],
             "extract_dir": "raine32",
             "bin": [
                 [
@@ -41,6 +23,29 @@
             "shortcuts": [
                 [
                     "raine32.exe",
+                    "RAINE"
+                ]
+            ]
+        },
+        "64bit": {
+            "url": [ 
+                "https://raine.1emulation.com/archive/raine64-0.93.5d.7z",
+                "https://raine.1emulation.com/archive/dlls64-0.92x.7z"
+            ],
+            "hash": [
+                "0fa9cc45d7c2e62e6d273535f966b032c5265672743cd888367b42172c765a02",
+                "903856890c586870e75ccb680d07a68b4aed710a1985b5d0adabe86c26b12773"
+            ],
+            "extract_dir": "raine64",
+            "bin": [
+                [
+                    "raine.exe",
+                    "RAINE"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "raine.exe",
                     "RAINE"
                 ]
             ]


### PR DESCRIPTION
RAINE is an emulator for arcade games.

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
