### PR TITLE
yquake2-ref-vk: Add version 1.0.2

### DIFF
--- a/bucket/yquake2-ref-vk.json
+++ b/bucket/yquake2-ref-vk.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.2",
-    "description": "This is the vkQuake2 vulkan renderer library ported to Yamagi Quake II",
+    "description": "vkQuake2's Vulkan renderer library ported for use with Yamagi Quake II",
     "homepage": "https://github.com/yquake2/ref_vk",
     "license": "https://github.com/yquake2/ref_vk/blob/master/LICENSE",
     "depends": "yquake2",

--- a/bucket/yquake2-ref-vk.json
+++ b/bucket/yquake2-ref-vk.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.0.2",
+    "description": "This is the vkQuake2 vulkan renderer library ported to Yamagi Quake II",
+    "homepage": "https://github.com/yquake2/ref_vk",
+    "license": "https://github.com/yquake2/ref_vk/blob/master/LICENSE",
+    "depends": "yquake2",
+    "url": "https://github.com/yquake2/ref_vk/releases/download/v1.0.2/ref_vk-1.0.2.zip",
+    "hash": "d5b1a40bce4ba90fcc90c64797dc4a3a83ec99b4100d3cba9915f9c47b12a266",
+    "extract_dir": "ref_vk-1.0.2",
+    "installer": {
+        "script": "Copy-Item \"$dir\\ref_vk.dll\" \"$(versiondir 'yquake2' 'current' $global)\" -Force"
+    },
+    "uninstaller": {
+        "script": [
+            "'ref_vk.dll' | ForEach-Object {",
+            "   if (Test-Path \"$(versiondir 'yquake2' 'current' $global)\\$_\") {",
+            "       Remove-Item \"$(versiondir 'yquake2' 'current' $global)\\$_\"",
+            "   }",
+            "}"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/yquake2/ref_vk/releases/download/v$version/ref_vk-$version.zip",
+        "extract_dir": "ref_vk-$version"
+    }
+}


### PR DESCRIPTION
This is the vkQuake2 vulkan renderer library ported to Yamagi Quake II.

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
