### PR TITLE
yquake2: Add suggestion for yquake2-ref-vk

### DIFF
--- a/bucket/yquake2.json
+++ b/bucket/yquake2.json
@@ -30,7 +30,9 @@
         "Tip: Create a soft symbolic link to the music directory if you want to save space.",
         ""
     ],
-    "suggest": "yquake2-ref-vk",
+    "suggest": {
+        "Vulkan renderer": "yquake2-ref-vk"
+    },
     "url": "https://deponie.yamagi.org/quake2/windows/quake2-8.10.zip",
     "hash": "eba9fd8db8050bde3cea231f620c2ad28930629095adc48fec38f7289181ae94",
     "extract_dir": "quake2-8.10",

--- a/bucket/yquake2.json
+++ b/bucket/yquake2.json
@@ -30,6 +30,7 @@
         "Tip: Create a soft symbolic link to the music directory if you want to save space.",
         ""
     ],
+    "suggest": "yquake2-ref-vk",
     "url": "https://deponie.yamagi.org/quake2/windows/quake2-8.10.zip",
     "hash": "eba9fd8db8050bde3cea231f620c2ad28930629095adc48fec38f7289181ae94",
     "extract_dir": "quake2-8.10",


### PR DESCRIPTION
This adds the suggestion to install the Vulkan renderer specifically made for Yamagi Quake II.

It's been ported from [vkQuake2](https://github.com/kondrak/vkQuake2) by the Yamagi team.

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
