### PR TITLE
raine: Use HTTPS for autoupdate

### DIFF
--- a/bucket/raine.json
+++ b/bucket/raine.json
@@ -70,10 +70,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://raine.1emulation.com/archive/raine64-$version.7z"
+                "url": "https://raine.1emulation.com/archive/raine64-$version.7z"
             },
             "32bit": {
-                "url": "http://raine.1emulation.com/archive/raine32-$version.7z"
+                "url": "https://raine.1emulation.com/archive/raine32-$version.7z"
             }
         }
     }


### PR DESCRIPTION
Noticed that the autoupdate section used HTTP instead of HTTPS.