### PR TITLE
ironwail: Add version 0.6.0

### DIFF
--- a/bucket/ironwail.json
+++ b/bucket/ironwail.json
@@ -1,0 +1,87 @@
+{
+    "version": "0.6.0",
+    "description": "A fork of the popular GLQuake descendant QuakeSpasm with a focus on high performance instead of maximum compatibility, with a few extra features sprinkled on top.",
+    "homepage": "https://github.com/andrei-drexler/ironwail",
+    "license": "GPL-2.0-only",
+    "notes": [
+        "",
+        "Place game data files (such as pak0.pak and pak1.pak) in:",
+        "",
+        "- Quake:",
+        "    $persist_dir\\id1\\",
+        "",
+        "- Quake Mission Pack 1 - Scourge of Armagon:",
+        "    $persist_dir\\hipnotic\\",
+        "",
+        "- Quake Mission Pack 2 - Dissolution of Eternity:",
+        "    $persist_dir\\rogue\\",
+        "",
+        "- Quake Mission Pack 3 - Abyss of Pandemonium:",
+        "    $persist_dir\\abyss\\",
+        "",
+        "- Quake - Arcane Dimensions (https://www.moddb.com/mods/arcane-dimensions):",
+        "    $persist_dir\\ad\\",
+        ""
+    ],
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/andrei-drexler/ironwail/releases/download/v0.6.0/ironwail-0.6.0-win32.zip",
+            "hash": "b583cae60f34ded30af768efd4a615b9076bb3459c8b323632f47f0331c0f326"
+        },
+        "64bit": {
+            "url": "https://github.com/andrei-drexler/ironwail/releases/download/v0.6.0/ironwail-0.6.0-win64.zip",
+            "hash": "f4ea5d9019df71b06f341d1419fedcc3f67c040f1be068a617137a5f734f9aa0"
+        }
+    },
+    "bin": [
+        [
+            "ironwail.exe",
+            "Ironwail",
+            "-basedir $persist_dir"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "ironwail.exe",
+            "Ironwail"
+        ],
+        [
+            "ironwail.exe",
+            "Ironwail (Scourge of Armagon)",
+            "-game hipnotic"
+        ],
+        [
+            "ironwail.exe",
+            "Ironwail (Dissolution of Eternity)",
+            "-game rogue"
+        ],
+        [
+            "ironwail.exe",
+            "Ironwail (Abyss of Pandemonium)",
+            "-game abyss"
+        ],
+        [
+            "ironwail.exe",
+            "Ironwail (Arcane Dimensions)",
+            "-game ad"
+        ]
+    ],
+    "persist": [
+        "id1",
+        "hipnotic",
+        "rogue",
+        "abyss",
+        "ad"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/andrei-drexler/ironwail/releases/download/v$version/ironwail-$version-win32.zip"
+            },
+            "64bit": {
+                "url": "https://github.com/andrei-drexler/ironwail/releases/download/v$version/ironwail-$version-win64.zip"
+            }
+        }
+    }
+}

--- a/bucket/ironwail.json
+++ b/bucket/ironwail.json
@@ -1,6 +1,6 @@
 {
     "version": "0.6.0",
-    "description": "A fork of the popular GLQuake descendant QuakeSpasm with a focus on high performance instead of maximum compatibility, with a few extra features sprinkled on top.",
+    "description": "Fork of QuakeSpasm with a focus on high performance instead of maximum compatibility, with a few extra features sprinkled on top",
     "homepage": "https://github.com/andrei-drexler/ironwail",
     "license": "GPL-2.0-only",
     "notes": [

--- a/bucket/ironwail.json
+++ b/bucket/ironwail.json
@@ -2,7 +2,7 @@
     "version": "0.6.0",
     "description": "Fork of QuakeSpasm with a focus on high performance instead of maximum compatibility, with a few extra features sprinkled on top",
     "homepage": "https://github.com/andrei-drexler/ironwail",
-    "license": "GPL-2.0-only",
+    "license": "GPL-2.0-or-later",
     "notes": [
         "",
         "Place game data files (such as pak0.pak and pak1.pak) in:",


### PR DESCRIPTION
A fork of the popular GLQuake descendant QuakeSpasm with a focus on high performance instead of maximum compatibility, with a few extra features sprinkled on top.

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
