### PR TITLE
kindandfair: Add version 1.5.2

### DIFF
--- a/bucket/kindandfair.json
+++ b/bucket/kindandfair.json
@@ -1,15 +1,15 @@
 {
-    "version": "1.5.2",
+    "version": "1.5.3",
     "description": "Tool to mod the balance of retro Castlevania games, including randomization options",
     "homepage": "https://github.com/Lakifume/SotnKindAndFair",
-    "license": "Unknown",
+    "license": "MIT",
     "notes": [
         "",
         "You can apply other patches as well in the process by placing them in the '$persist_dir\\Data\\<name of the game>\\Patches' dir.",
         ""
     ],
-    "url": "https://github.com/Lakifume/SotnKindAndFair/releases/download/1.5.2/KindAndFair.zip",
-    "hash": "3f0b57285ad5b6ef0ca75321b88a88d55fa98aa4df2c83e890f59d33c217729a",
+    "url": "https://github.com/Lakifume/SotnKindAndFair/releases/download/1.5.3/KindAndFair.zip",
+    "hash": "372b1a22cbadca03d6ecd89b8f3b342e95b2d74c59b1b07b5781550929ea20b7",
     "shortcuts": [
         [
             "kindandfair.exe",

--- a/bucket/kindandfair.json
+++ b/bucket/kindandfair.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.5.2",
+    "description": "This is a tool to mod the balance of retro Castlevania games, including randomization options",
+    "homepage": "https://github.com/Lakifume/SotnKindAndFair",
+    "license": "Unknown",
+    "notes": [
+        "",
+        "You can apply other patches as well in the process by placing them in the '$persist_dir\\Data\\<name of the game>\\Patches' dir.",
+        ""
+    ],
+    "url": "https://github.com/Lakifume/SotnKindAndFair/releases/download/1.5.2/KindAndFair.zip",
+    "hash": "3f0b57285ad5b6ef0ca75321b88a88d55fa98aa4df2c83e890f59d33c217729a",
+    "shortcuts": [
+        [
+            "kindandfair.exe",
+            "KindAndFair"
+        ]
+    ],
+    "persist": [
+        "Shaders",
+        "Data\\config.ini",
+        "Data\\Dissonance\\Patches",
+        "Data\\Symphony\\Patches"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/Lakifume/SotnKindAndFair/releases/download/$version/KindAndFair.zip"
+    }
+}

--- a/bucket/kindandfair.json
+++ b/bucket/kindandfair.json
@@ -1,6 +1,6 @@
 {
     "version": "1.5.2",
-    "description": "This is a tool to mod the balance of retro Castlevania games, including randomization options",
+    "description": "Tool to mod the balance of retro Castlevania games, including randomization options",
     "homepage": "https://github.com/Lakifume/SotnKindAndFair",
     "license": "Unknown",
     "notes": [


### PR DESCRIPTION
This is a tool to mod the balance of retro Castlevania games, including randomization options.

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
