### PR TITLE
Add autoupdate hash URL

### DIFF
--- a/bucket/sameboy.json
+++ b/bucket/sameboy.json
@@ -32,6 +32,9 @@
         "github": "https://github.com/LIJI32/SameBoy"
     },
     "autoupdate": {
-        "url": "https://github.com/LIJI32/SameBoy/releases/download/v$version/sameboy_winsdl_v$version.zip"
+        "url": "https://github.com/LIJI32/SameBoy/releases/download/v$version/sameboy_winsdl_v$version.zip",
+        "hash": {
+            "url": "$baseurl/SHA2-256SUMS"
+        }
     }
 }


### PR DESCRIPTION
SameBoy now provides checksums with each release:
- https://github.com/LIJI32/SameBoy/issues/441
- https://github.com/LIJI32/SameBoy/releases