### PR TITLE
game-backup-monitor: Add version 1.3.1

### DIFF
--- a/bucket/game-backup-monitor.json
+++ b/bucket/game-backup-monitor.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.3.1",
+    "description": "Automatically backup your saved games with optional cloud support",
+    "homepage": "https://mikemaximus.github.io/gbm-web/",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/MikeMaximus/gbm/blob/master/LICENSE"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/MikeMaximus/gbm/releases/download/v1.3.1/GBM.v1.3.1.64-bit.7z",
+            "hash": "963c0daa839ae76a9833ebc4eb99539db963c5f22ecdb870d402b8be84040c47"
+        },
+        "32bit": {
+            "url": "https://github.com/MikeMaximus/gbm/releases/download/v1.3.1/GBM.v1.3.1.32-bit.7z",
+            "hash": "287338bf44617ef8fb15fe7811b2b3aef6a8793ca56969726cec4084ad89441a"
+        }
+    },
+    "shortcuts": [
+        [
+            "GBM.exe",
+            "Game Backup Monitor (GBM)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/MikeMaximus/gbm"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/MikeMaximus/gbm/releases/download/v$version/GBM.v$version.64-bit.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/MikeMaximus/gbm/releases/download/v$version/GBM.v$version.32-bit.7z"
+            }
+        }
+    }
+}

--- a/bucket/game-backup-monitor.json
+++ b/bucket/game-backup-monitor.json
@@ -1,6 +1,6 @@
 {
     "version": "1.3.1",
-    "description": "Automatically backup your saved games with optional cloud support",
+    "description": "Game save data backup tool with optional cloud support",
     "homepage": "https://mikemaximus.github.io/gbm-web/",
     "license": {
         "identifier": "GPL-3.0-or-later",


### PR DESCRIPTION
Game Backup Monitor: A tool which automatically backs up your saved games. 

https://github.com/MikeMaximus/gbm
https://mikemaximus.github.io/gbm-web/index.html

As a side note, the link to CONTRIBUTING.md doesn't work in the issue template. Same for the pre_install link.

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [ ] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [ ] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [ ] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [ ] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [ ] I will maintain this manifest and promptly fix it in the event it breaks.