### PR TITLE
Fix PolyMC auto-update (and update it to 1.4.0)

### DIFF
--- a/bucket/polymc.json
+++ b/bucket/polymc.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.3.2",
+    "version": "1.4.0",
     "description": "An Open Source Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability.",
     "homepage": "https://polymc.org/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/PolyMC/PolyMC/releases/download/1.3.2/PolyMC-Windows-x86_64-1.3.2.zip",
-            "hash": "a186ed232cb51100c4a7ddb01d5e77c31fc188ba48b9ac20fac38975bc168483"
+            "url": "https://github.com/PolyMC/PolyMC/releases/download/1.4.0/PolyMC-Windows-Portable-1.4.0.zip",
+            "hash": "7bf9dbc9cd2afb3f7da0d48c393b70c875de2b53f01181a82fbf1b6b14de5b3c"
         },
         "32bit": {
-            "url": "https://github.com/PolyMC/PolyMC/releases/download/1.3.2/PolyMC-Windows-i686-1.3.2.zip",
-            "hash": "c7a605f32e7a06e6e95f020624996f8cc82fa736cbea81b829e829e060cc4f20"
+            "url": "https://github.com/PolyMC/PolyMC/releases/download/1.4.0/PolyMC-Windows-Legacy-Portable-1.4.0.zip",
+            "hash": "c47d128b7bf7abee5ebc1549e2fdaf007893128592b9f54f7ce9aa690d6e8400"
         }
     },
     "bin": "PolyMC.exe",
@@ -26,10 +26,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/PolyMC/PolyMC/releases/download/$version/PolyMC-Windows-x86_64-$version.zip"
+                "url": "https://github.com/PolyMC/PolyMC/releases/download/$version/PolyMC-Windows-Portable-$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/PolyMC/PolyMC/releases/download/$version/PolyMC-Windows-i686-$version.zip"
+                "url": "https://github.com/PolyMC/PolyMC/releases/download/$version/PolyMC-Windows-Legacy-Portable-$version.zip"
             }
         }
     }


### PR DESCRIPTION
The PolyMC URL scheme changed today, and this PR fixes this. It also updates PolyMC to 1.4.0! :)