### PR TITLE
cnc-ddraw: Add version 4.4.7.0

### DIFF
--- a/bucket/cnc-ddraw.json
+++ b/bucket/cnc-ddraw.json
@@ -1,0 +1,19 @@
+{
+    "version": "4.4.7.0",
+    "description": "cnc-ddraw can fix compatibility issues with older games, such as black screen, bad performance, crashes, or defective Alt+Tab. It does this by wrapping DirectDraw to renderers like GDI, OpenGL, or Direct3D 9",
+    "homepage": "https://github.com/CnCNet/cnc-ddraw",
+    "license": "MIT",
+    "notes": [
+        "",
+        "To use the tool, copy the contents to the game dir of your choice, which utilizes DirectDraw for its rendering.",
+        "",
+        "If you want to customize the rendering, use 'cnc-ddraw config.exe'",
+        ""
+    ],
+    "url": "https://github.com/CnCNet/cnc-ddraw/releases/download/v4.4.7.0/cnc-ddraw.zip",
+    "hash": "a430450204b34f676f4436870cbad7a0015e9451045f8999b8f1bfaff9531cf1",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/CnCNet/cnc-ddraw/releases/download/v$version/cnc-ddraw.zip"
+    }
+}


### PR DESCRIPTION
cnc-ddraw can fix compatibility issues with older games, such as black screen, bad performance, crashes, or defective Alt+Tab. It does this by wrapping DirectDraw to renderers like GDI, OpenGL, or Direct3D 9.


## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] [autoupdate and checkver entry](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre-and-Post-install-and-uninstall-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
