### PR TITLE
ironwail: Add info about automatic detection of the Steam release

### DIFF
--- a/bucket/ironwail.json
+++ b/bucket/ironwail.json
@@ -21,6 +21,10 @@
         "",
         "- Quake - Arcane Dimensions (https://www.moddb.com/mods/arcane-dimensions):",
         "    $persist_dir\\ad\\",
+        "",
+        "Ironwail also detects the Steam release, so if you have that installed, no additional setup is required - just start the app and you will be presented with the option of running the Remastered or Original version",
+        "",
+        "Any mods present as subdirs in the corresponding directories of the Steam release are accessible in the source port's Mods menu once the game has started.",
         ""
     ],
     "architecture": {

--- a/bucket/ironwail.json
+++ b/bucket/ironwail.json
@@ -22,9 +22,9 @@
         "- Quake - Arcane Dimensions (https://www.moddb.com/mods/arcane-dimensions):",
         "    $persist_dir\\ad\\",
         "",
-        "Ironwail also detects the Steam release, so if you have that installed, no additional setup is required - just start the app and you will be presented with the option of running the Remastered or Original version",
+        "Ironwail also detects the Steam release. If you have that installed, no additional setup is required. Just start the app and you will be presented with the option of running the Remastered or Original version.",
         "",
-        "Any mods present as subdirs in the corresponding directories of the Steam release are accessible in the source port's Mods menu once the game has started.",
+        "Any mods present as subdirectories in the corresponding directories of the Steam release are accessible in the source port's Mods menu once the game has started.",
         ""
     ],
     "architecture": {


### PR DESCRIPTION
If the user has the Steam release installed, no additional setup is required and the source port can be started as-is.

This updates the `Notes` section with that information.

The corresponding information is found on the Github page for the project [here](https://github.com/andrei-drexler/ironwail#bonus-features).
