### PR TITLE
jazz2-resurrection: Add version 0.7.3

### DIFF
--- a/bucket/jazz2-resurrection.json
+++ b/bucket/jazz2-resurrection.json
@@ -1,0 +1,48 @@
+{
+    "version": "0.7.3",
+    "description": "Jazz² Resurrection is an open-source remaster of the game Jazz Jackrabbit 2",
+    "homepage": "http://deat.tk/jazz2/",
+    "license": "GPL-3.0-or-later",
+    "notes": [
+        "",
+        "First you need to import some form of game data.",
+        "",
+        "You can run 'Import.exe' in the app dir and choose to download the Shareware version, however it's recommended to buy the full version on GOG here: https://www.gog.com/game/jazz_jackrabbit_2_collection",
+        "",
+        "See the instructions when running 'Import.exe' which describes how to import the files of the full version.",
+        "",
+        "Either that, or simply drag 'Jazz2.exe' from your installation of the full version and drop it onto 'Import.exe' (video tutorial: https://www.youtube.com/watch?v=ibUn20raRMo).",
+        "",
+        "IMPORTANT: Currently, game data has to imported every time the app is updated.",
+        "",
+        "Tip regarding the full version:",
+        "",
+        "1. First install The Secret Files release.",
+        "2. Install The Christmas Chronicles release in a separate dir.",
+        "3. Copy the files from The Christmas Chronicles dir to the dir of the The Secret Files release - and do NOT overwrite any files.",
+        "",
+        "Now you've a complete edition to import to Jazz² Resurrection.",
+        ""
+    ],
+    "url": "https://github.com/deathkiller/jazz2/releases/download/0.7.3/Jazz2_0.7.3_Desktop.zip",
+    "hash": "d632139360781a534fc8d10ac17ca3370ef5bf846069f098f88220f0c98fc9c4",
+    "extract_dir": "Jazz2",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\Jazz2.settings\")) {",
+        "   New-Item -ItemType File \"$dir\\Jazz2.settings\" | Out-Null",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "Jazz2.exe",
+            "Jazz² Resurrection"
+        ]
+    ],
+    "persist": "Jazz2.settings",
+    "checkver": {
+        "github": "https://github.com/deathkiller/jazz2"
+    },
+    "autoupdate": {
+        "url": "https://github.com/deathkiller/jazz2/releases/download/$version/Jazz2_$version_Desktop.zip"
+    }
+}

--- a/bucket/jazz2-resurrection.json
+++ b/bucket/jazz2-resurrection.json
@@ -1,6 +1,6 @@
 {
     "version": "0.7.3",
-    "description": "Jazz² Resurrection is an open-source remaster of the game Jazz Jackrabbit 2",
+    "description": "Open source reimplementation of the game Jazz Jackrabbit 2",
     "homepage": "http://deat.tk/jazz2/",
     "license": "GPL-3.0-or-later",
     "notes": [


### PR DESCRIPTION
Jazz² Resurrection is an open-source reimplementation of the game Jazz Jackrabbit 2.

**Author's note regarding the mandatory repetition of the import-process upon every update:**

I successfully persisted the corresponding folders that end up containing all the game data, but upon simulating an update through Scoop, and then running Jazz² Resurrection again, it still ended up showing the message "Installation is corrupted!", hence why the `Notes` and `Persist` sections are as they are.

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] [autoupdate and checkver entry](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre-and-Post-install-and-uninstall-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
