### PR TITLE
ares: Fix autoupdate

### DIFF
--- a/bucket/ares.json
+++ b/bucket/ares.json
@@ -10,7 +10,7 @@
             "hash": "6e8fec912d33bfadc08f41bab3a653c7c698e1e874fe0d935b247f995f7d565f"
         }
     },
-    "extract_dir": "ares-v128",
+    "extract_dir": "ares-v129",
     "post_install": [
         "if (!(Test-Path \"$persist_dir\\settings.bml.bak\")) {",
         "   New-Item -ItemType File \"$dir\\settings.bml\" | Out-Null",
@@ -48,9 +48,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ares-emulator/ares/releases/download/v$cleanVersion/ares-windows.zip",
-                "extract_dir": "ares-v$cleanVersion"
+                "url": "https://github.com/ares-emulator/ares/releases/download/v$cleanVersion/ares-windows.zip"
             }
-        }
+        },
+        "extract_dir": "ares-v$cleanVersion"
     }
 }


### PR DESCRIPTION
This fixes the problem of "extract_dir is not being updated".

closes #637
closes #635