### PR TITLE
romsorter: Add Release 5

### DIFF
--- a/bucket/romsorter.json
+++ b/bucket/romsorter.json
@@ -9,7 +9,7 @@
         "",
         "The .NET 6 runtime, also known as Microsoft Windows Desktop Runtime, is available in the Extras bucket.",
         "",
-        "Since the runtimes get installed globally, Sudo is needed, which is part of the Main bucket.",
+        "Since the runtime gets installed globally, Sudo is needed, which is part of the Main bucket.",
         "",
         "For example, with Sudo installed, you could execute the following to get the dependencies: scoop install extras/windowsdesktop-runtime-lts",
         ""

--- a/bucket/romsorter.json
+++ b/bucket/romsorter.json
@@ -1,0 +1,36 @@
+{
+    "version": "release5",
+    "description": "Compress, or uncompress ROMs, detect duplicates, catalog, manage CHD and DAT data, sort for Everdrive, or create 1G1R sets - all with one app",
+    "homepage": "https://github.com/drakewill-CRL/ROMSorter",
+    "license": "MIT",
+    "notes": [
+        "",
+        "ROMSorter depends on having the .NET 6 runtime installed.",
+        "",
+        "The .NET 6 runtime, also known as Microsoft Windows Desktop Runtime, is available in the Extras bucket.",
+        "",
+        "Since the runtimes get installed globally, Sudo is needed, which is part of the Main bucket.",
+        "",
+        "For example, with Sudo installed, you could execute the following to get the dependencies: scoop install extras/windowsdesktop-runtime-lts",
+        ""
+    ],
+    "suggest": {
+        "Sudo": "main/sudo",
+        ".NET6": "extras/windowsdesktop-runtime-lts"
+    },
+    "url": "https://github.com/drakewill-CRL/ROMSorter/releases/download/release5/ROMSorter.zip",
+    "hash": "1ba6738dc7c9bedb4736f5e00ed94516e1c1cb750a7bcdd0801ada2557ffac40",
+    "shortcuts": [
+        [
+            "ROMSorter.exe",
+            "ROMSorter"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/drakewill-CRL/ROMSorter",
+        "regex": "tag/(release\\d+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/drakewill-CRL/ROMSorter/releases/download/$version/ROMSorter.zip"
+    }
+}


### PR DESCRIPTION
Compress, or uncompress ROMs, detect duplicates, catalog, manage CHD and DAT data, sort for Everdrive, or create 1G1R sets - all with one app.

Closes #626

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] [autoupdate and checkver entry](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre-and-Post-install-and-uninstall-scripts) script to auto-enable portable mode (if needed)?
>   - [x] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [x] bin entry for main binary
>     - [x] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
