### PR TITLE
Revert "polymc: Use portable version instead (#673)"

### DIFF
--- a/bucket/polymc.json
+++ b/bucket/polymc.json
@@ -3,36 +3,19 @@
     "description": "An Open Source Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability.",
     "homepage": "https://polymc.org/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/PolyMC/PolyMC/releases/download/1.4.1/PolyMC-Windows-Portable-1.4.1.zip",
-    "hash": "9f363ee10a880364c0010a9c996094ca304eb390c9b966a388990772fbca59ef",
+    "url": "https://github.com/PolyMC/PolyMC/releases/download/1.4.1/PolyMC-Windows-1.4.1.zip",
+    "hash": "702d833313318fe8e3dbafc9540d0db23b1a4c6f682283aaa6b302886c5f1aee",
     "bin": "PolyMC.exe",
-    "pre_install": [
-        "if (-not (Test-Path \"$dir\\accounts.json\")) { New-Item \"$dir\\accounts.json\" -ItemType File | Out-Null }",
-        "if (-not (Test-Path \"$dir\\polymc.cfg\")) { New-Item \"$dir\\polymc.cfg\" -ItemType File -Value \"Analytics=false`r`nAutoUpdate=false`r`nIconTheme=pe_colored\" | Out-Null }",
-        "if (-not (Test-Path \"$dir\\notifications.json\")) { New-Item \"$dir\\notifications.json\" -ItemType File | Out-Null }"
-    ],
     "shortcuts": [
         [
             "PolyMC.exe",
             "PolyMC"
         ]
     ],
-    "persist": [
-        "accounts",
-        "assets",
-        "instances",
-        "libraries",
-        "meta",
-        "themes",
-        "translations",
-        "accounts.json",
-        "polymc.cfg",
-        "notifications.json"
-    ],
     "checkver": {
         "github": "https://github.com/PolyMC/PolyMC"
     },
     "autoupdate": {
-        "url": "https://github.com/PolyMC/PolyMC/releases/download/$version/PolyMC-Windows-Portable-$version.zip"
+        "url": "https://github.com/PolyMC/PolyMC/releases/download/$version/PolyMC-Windows-$version.zip"
     }
 }


### PR DESCRIPTION
This reverts commit caae8a7bd9b54bb4ae39da696e26b0a9a0f6de66.

Useless, doesn't make any sense and people that used that package before that change won't see their instances anymore with that change in updates


<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that will follow the contribution guidelines. You agree to submit a fully featured working manifest that creates shortcuts, bin shims, persists data, enable portable mode, and auto updates.
-->

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [ ] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
> - [ ] properly named and capitalized shortcuts?
> - [ ] [autoupdate and checkver entry](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [ ] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [ ] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre-and-Post-install-and-uninstall-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [ ] license identifier and url
> - [ ] a short terse description matching existing style.
> - [ ] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [ ] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [ ] tested install, checked persist, no errors.
> - [ ] manifest is sorted to spec
> - [ ] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [ ] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [ ] I will maintain this manifest and promptly fix it in the event it breaks.
