### PR TITLE
polymc: Use portable configuration

### DIFF
--- a/bucket/polymc.json
+++ b/bucket/polymc.json
@@ -30,8 +30,7 @@
         "themes",
         "translations",
         "accounts.json",
-        "polymc.cfg",
-        "notifications.json"
+        "polymc.cfg"
     ],
     "checkver": {
         "github": "https://github.com/PolyMC/PolyMC"

--- a/bucket/polymc.json
+++ b/bucket/polymc.json
@@ -3,8 +3,13 @@
     "description": "An Open Source Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability.",
     "homepage": "https://polymc.org/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/PolyMC/PolyMC/releases/download/1.4.1/PolyMC-Windows-1.4.1.zip",
-    "hash": "702d833313318fe8e3dbafc9540d0db23b1a4c6f682283aaa6b302886c5f1aee",
+    "url": "https://github.com/PolyMC/PolyMC/releases/download/1.4.1/PolyMC-Windows-Portable-1.4.1.zip",
+    "hash": "9f363ee10a880364c0010a9c996094ca304eb390c9b966a388990772fbca59ef",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\accounts.json\")) { New-Item \"$dir\\accounts.json\" | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\polymc.cfg\")) { New-Item \"$dir\\polymc.cfg\" -Value \"Analytics=false`r`nAutoUpdate=false`r`nIconTheme=pe_colored\" | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\notifications.json\")) { New-Item \"$dir\\notifications.json\" | Out-Null }"
+    ],
     "bin": "PolyMC.exe",
     "shortcuts": [
         [
@@ -12,10 +17,22 @@
             "PolyMC"
         ]
     ],
+    "persist": [
+        "accounts",
+        "assets",
+        "instances",
+        "libraries",
+        "meta",
+        "themes",
+        "translations",
+        "accounts.json",
+        "polymc.cfg",
+        "notifications.json"
+    ],
     "checkver": {
         "github": "https://github.com/PolyMC/PolyMC"
     },
     "autoupdate": {
-        "url": "https://github.com/PolyMC/PolyMC/releases/download/$version/PolyMC-Windows-$version.zip"
+        "url": "https://github.com/PolyMC/PolyMC/releases/download/$version/PolyMC-Windows-Portable-$version.zip"
     }
 }

--- a/bucket/polymc.json
+++ b/bucket/polymc.json
@@ -3,12 +3,16 @@
     "description": "An Open Source Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability.",
     "homepage": "https://polymc.org/",
     "license": "GPL-3.0-only",
+    "notes": "Run '$dir\\migrate.ps1' to migrate your PolyMC configuration to Scoop.",
     "url": "https://github.com/PolyMC/PolyMC/releases/download/1.4.1/PolyMC-Windows-Portable-1.4.1.zip",
     "hash": "9f363ee10a880364c0010a9c996094ca304eb390c9b966a388990772fbca59ef",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\accounts.json\")) { New-Item \"$dir\\accounts.json\" | Out-Null }",
         "if (!(Test-Path \"$persist_dir\\polymc.cfg\")) { New-Item \"$dir\\polymc.cfg\" -Value \"Analytics=false`r`nAutoUpdate=false`r`nIconTheme=pe_colored\" | Out-Null }",
-        "if (!(Test-Path \"$persist_dir\\notifications.json\")) { New-Item \"$dir\\notifications.json\" | Out-Null }"
+        "if (!(Test-Path \"$persist_dir\\notifications.json\")) { New-Item \"$dir\\notifications.json\" | Out-Null }",
+        "",
+        "# Migration script",
+        "Copy-Item \"$bucketsdir\\games\\scripts\\polymc\\migrate.ps1\" \"$dir\" | Out-Null"
     ],
     "bin": "PolyMC.exe",
     "shortcuts": [

--- a/scripts/polymc/migrate.ps1
+++ b/scripts/polymc/migrate.ps1
@@ -7,7 +7,7 @@ $files = @(
     "themes",
     "translations",
     "accounts.json",
-    "polymc.cfg",
+    "polymc.cfg"
 )
 
 $options =

--- a/scripts/polymc/migrate.ps1
+++ b/scripts/polymc/migrate.ps1
@@ -1,0 +1,28 @@
+$files = @(
+    "accounts",
+    "assets",
+    "instances",
+    "libraries",
+    "meta",
+    "themes",
+    "translations",
+    "accounts.json",
+    "polymc.cfg",
+    "notifications.json"
+)
+
+$options =
+    (New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", "Continue"),
+    (New-Object System.Management.Automation.Host.ChoiceDescription "&No", "Exit")
+$decision = $Host.UI.PromptForChoice("Migrate PolyMC config to Scoop",
+    "This will overwrite your current configuration. Do you want to continue?",
+    $options, 0)
+
+if ($decision -eq 0) {
+    foreach ($file in $files) {
+        $source = "$env:APPDATA\PolyMC\$file"
+        if (Test-Path $source) {
+            Copy-Item -Path $source -Destination $PSScriptRoot\$file -Recurse -Force
+        }
+    }
+}

--- a/scripts/polymc/migrate.ps1
+++ b/scripts/polymc/migrate.ps1
@@ -8,7 +8,6 @@ $files = @(
     "translations",
     "accounts.json",
     "polymc.cfg",
-    "notifications.json"
 )
 
 $options =


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Reverts #674.

By principle, Scoop should use portable versions if possible. Otherwise, they should be in the [Nonportable](https://github.com/ScoopInstaller/Nonportable) bucket. This has already been applied to the other official buckets (https://github.com/ScoopInstaller/Extras/pull/7573), the games bucket should follow too.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
