### PR TITLE
vita3k: Remove `lang`, `shaders-builtin`, `data` persist

### DIFF
--- a/bucket/vita3k.json
+++ b/bucket/vita3k.json
@@ -25,9 +25,7 @@
         ]
     ],
     "persist": [
-        "data",
-        "lang",
-        "shaders-builtin",
+        "cache",
         "config.yml"
     ],
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

They are not config files. Persist `cache` folder instead.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
