### PR TITLE
itch: Add version 25.5.1

### DIFF
--- a/bucket/itch.json
+++ b/bucket/itch.json
@@ -4,13 +4,13 @@
     "homepage": "https://itch.io/app",
     "license": "MIT",
     "architecture": {
-        "64bit": {
-            "url": "https://broth.itch.ovh/itch/windows-amd64/25.5.1/archive/default#/dl.zip",
-            "hash": "b5c656082e6fcd33537f3c9d20ad7b5d4fd7dbbb1850097ea1038b0f17350a35"
-        },
         "32bit": {
             "url": "https://broth.itch.ovh/itch/windows-386/25.5.1/archive/default#/dl.zip",
             "hash": "fd77f8a1caffea8cd73747c4e8b0442094530f12a3a6ec98b449d84b68fb6295"
+        },
+        "64bit": {
+            "url": "https://broth.itch.ovh/itch/windows-amd64/25.5.1/archive/default#/dl.zip",
+            "hash": "b5c656082e6fcd33537f3c9d20ad7b5d4fd7dbbb1850097ea1038b0f17350a35"
         }
     },
     "shortcuts": [
@@ -24,11 +24,11 @@
     },
     "autoupdate": {
         "architecture": {
-            "64bit": {
-                "url": "https://broth.itch.ovh/itch/windows-amd64/$version/archive/default#/dl.zip"
-            },
             "32bit": {
                 "url": "https://broth.itch.ovh/itch/windows-386/$version/archive/default#/dl.zip"
+            },
+            "64bit": {
+                "url": "https://broth.itch.ovh/itch/windows-amd64/$version/archive/default#/dl.zip"
             }
         }
     }

--- a/bucket/itch.json
+++ b/bucket/itch.json
@@ -1,0 +1,35 @@
+{
+    "version": "25.5.1",
+    "description": "Desktop app for itch.io, an indie game online store.",
+    "homepage": "https://itch.io/app",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://broth.itch.ovh/itch/windows-amd64/25.5.1/archive/default#/dl.zip",
+            "hash": "b5c656082e6fcd33537f3c9d20ad7b5d4fd7dbbb1850097ea1038b0f17350a35"
+        },
+        "32bit": {
+            "url": "https://broth.itch.ovh/itch/windows-386/25.5.1/archive/default#/dl.zip",
+            "hash": "fd77f8a1caffea8cd73747c4e8b0442094530f12a3a6ec98b449d84b68fb6295"
+        }
+    },
+    "shortcuts": [
+        [
+            "itch.exe",
+            "itch"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/itchio/itch"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://broth.itch.ovh/itch/windows-amd64/$version/archive/default#/dl.zip"
+            },
+            "32bit": {
+                "url": "https://broth.itch.ovh/itch/windows-386/$version/archive/default#/dl.zip"
+            }
+        }
+    }
+}

--- a/bucket/itch.json
+++ b/bucket/itch.json
@@ -1,6 +1,6 @@
 {
     "version": "25.5.1",
-    "description": "Desktop app for itch.io, an indie game online store.",
+    "description": "Desktop app for itch.io, an indie game online store",
     "homepage": "https://itch.io/app",
     "license": "MIT",
     "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that will follow the contribution guidelines. You agree to submit a fully featured working manifest that creates shortcuts, bin shims, persists data, enable portable mode, and auto updates.
-->

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] [autoupdate and checkver entry](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [ ] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?

Data are saved to `$env:APPDATA` on default.

> - [ ] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre-and-Post-install-and-uninstall-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)

Not applicable.

> - [x] license identifier and url
> - [x] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)

Not applicable.

> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [x] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [x] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [x] I will maintain this manifest and promptly fix it in the event it breaks.
