### PR TITLE
gzdoom: Make Save and Screenshots persistent

### DIFF
--- a/bucket/gzdoom.json
+++ b/bucket/gzdoom.json
@@ -6,7 +6,7 @@
     "notes": [
         "Place WAD files (game data) in:",
         "",
-        "    $persist_dir\\WAD"
+        "    $persist_dir\\..\\_doom"
     ],
     "architecture": {
         "64bit": {
@@ -15,13 +15,11 @@
         }
     },
     "pre_install": [
-        "New-Item -Path \"$dir\" -Name gzdoom_portable.ini -ItemType File -ErrorAction Ignore | Out-Null",
-        "New-Item -Path \"$persist_dir\" -Name WAD -ItemType Directory -Force -ErrorAction Ignore | Out-Null",
-        "Copy-Item -Path \"$persist_dir\\..\\_doom\\*\" -Destination \"$persist_dir\\WAD\" -Recurse -ErrorAction Ignore | Out-Null",
-        "Remove-Item -Path \"$persist_dir\\..\\_doom\" -Force -Recurse -ErrorAction Ignore | Out-Null"
+        "New-Item -ItemType Directory -Force -Path $persist_dir\\..\\_doom | Out-Null",
+        "New-Item -Path $dir -Name gzdoom_portable.ini -ItemType File -ErrorAction Ignore | Out-Null"
     ],
     "env_set": {
-        "DOOMWADDIR": "$persist_dir\\WAD"
+        "DOOMWADDIR": "$persist_dir\\..\\_doom"
     },
     "bin": "gzdoom.exe",
     "shortcuts": [

--- a/bucket/gzdoom.json
+++ b/bucket/gzdoom.json
@@ -6,7 +6,7 @@
     "notes": [
         "Place WAD files (game data) in:",
         "",
-        "    $persist_dir\\..\\_doom"
+        "    $persist_dir\\WAD"
     ],
     "architecture": {
         "64bit": {
@@ -15,11 +15,13 @@
         }
     },
     "pre_install": [
-        "New-Item -ItemType Directory -Force -Path $persist_dir\\..\\_doom | Out-Null",
-        "New-Item -Path $dir -Name gzdoom_portable.ini -ItemType File -ErrorAction Ignore | Out-Null"
+        "New-Item -Path \"$dir\" -Name gzdoom_portable.ini -ItemType File -ErrorAction Ignore | Out-Null",
+        "New-Item -Path \"$persist_dir\" -Name WAD -ItemType Directory -Force -ErrorAction Ignore | Out-Null",
+        "Copy-Item -Path \"$persist_dir\\..\\_doom\\*\" -Destination \"$persist_dir\\WAD\" -Recurse -ErrorAction Ignore | Out-Null",
+        "Remove-Item -Path \"$persist_dir\\..\\_doom\" -Force -Recurse -ErrorAction Ignore | Out-Null"
     ],
     "env_set": {
-        "DOOMWADDIR": "$persist_dir\\..\\_doom"
+        "DOOMWADDIR": "$persist_dir\\WAD"
     },
     "bin": "gzdoom.exe",
     "shortcuts": [
@@ -28,7 +30,11 @@
             "GZDoom"
         ]
     ],
-    "persist": "gzdoom_portable.ini",
+    "persist": [
+        "gzdoom_portable.ini",
+        "Save",
+        "Screenshots"
+    ],
     "checkver": {
         "github": "https://github.com/coelckers/gzdoom",
         "regex": "/releases/tag/(?:g)?([\\w.]+)"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR makes the Save and Screenshots persistent, to allow the user to keep their savegames and screenshots between installs. 

<!--
  By opening this PR you confirm that will follow the contribution guidelines. You agree to submit a fully featured working manifest that creates shortcuts, bin shims, persists data, enable portable mode, and auto updates.
-->

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
> - [ ] properly named and capitalized shortcuts?
> - [ ] [autoupdate and checkver entry](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [x] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [ ] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre-and-Post-install-and-uninstall-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [ ] license identifier and url
> - [ ] a short terse description matching existing style.
> - [ ] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [ ] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [ ] manifest is sorted to spec
> - [ ] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [ ] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [ ] I will maintain this manifest and promptly fix it in the event it breaks.
