### PR TITLE
desmume: Add version 0.9.13

### DIFF
--- a/bucket/desmume.json
+++ b/bucket/desmume.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.9.13",
+    "description": "DeSmuME is a Nintendo DS emulator",
+    "homepage": "https://github.com/TASEmulators/desmume",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/TASEmulators/desmume/releases/download/release_0_9_13/desmume-0.9.13-win64.zip",
+            "hash": "cbf710b8e6b29f0904e289a9b9a895548a2d7c7af5a3145c8279b97a69a09276",
+            "shortcuts": [
+                [
+                    "DeSmuME_0.9.13_x64.exe",
+                    "DeSmuME"
+                ]
+            ]
+        }
+    },
+    "pre_install": "if (!(Test-Path \"$persist_dir\\desmume.ini\")) { New-Item \"$dir\\desmume.ini\" | Out-Null }",
+    "persist": "desmume.ini",
+    "checkver": {
+        "url": "https://api.github.com/repos/TASEmulators/desmume/releases",
+        "regex": "/desmume-([\\d.]+)-win64\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/TASEmulators/desmume/releases/download/release_$underscoreVersion/desmume-$version-win64.zip",
+                "shortcuts": [
+                    [
+                        "DeSmuME_$version_x64.exe",
+                        "DeSmuME"
+                    ]
+                ]
+            }
+        }
+    }
+}

--- a/bucket/desmume.json
+++ b/bucket/desmume.json
@@ -1,6 +1,6 @@
 {
     "version": "0.9.13",
-    "description": "DeSmuME is a Nintendo DS emulator",
+    "description": "Nintendo DS emulator",
     "homepage": "https://github.com/TASEmulators/desmume",
     "license": "GPL-2.0-or-later",
     "architecture": {


### PR DESCRIPTION
Closes #[7158 ](https://github.com/ScoopInstaller/Extras/issues/7158)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

> the sourceforge package is still 0.9.11 out of date