### PR TITLE
bsnes-mt: Add version 1.3.4

### DIFF
--- a/bucket/bsnes-mt.json
+++ b/bucket/bsnes-mt.json
@@ -3,6 +3,7 @@
     "description": "bsnes-mt is a fork of bsnes that adds video features like pixel-perfect, integer-ratio scaling, as well as the aspect ratio that corresponds to that of the SNES console",
     "homepage": "https://tanalin.com/en/projects/bsnes-mt/",
     "license": {
+        "identifier": "GPL-3.0-or-later",
         "url": "https://github.com/Marat-Tanalin/bsnes-mt/blob/master/LICENSE.txt"
     },
     "url": "https://github.com/Marat-Tanalin/bsnes-mt/releases/download/1.3.4/bsnes-mt-1.3.4.7z",

--- a/bucket/bsnes-mt.json
+++ b/bucket/bsnes-mt.json
@@ -8,13 +8,11 @@
     },
     "url": "https://github.com/Marat-Tanalin/bsnes-mt/releases/download/1.3.4/bsnes-mt-1.3.4.7z",
     "hash": "a19fd3a46f1e9d6c2483ce96a2f1294813bd85dfc0866d66f1ab428047c11f01",
-    "installer": {
-        "script": [
-            "if (!(Test-Path \"$persist_dir\\bsnes-mt-settings.bml\")) {",
-            "   New-Item -ItemType File \"$dir\\bsnes-mt-settings.bml\" | Out-Null",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\bsnes-mt-settings.bml\")) {",
+        "   New-Item -ItemType File \"$dir\\bsnes-mt-settings.bml\" | Out-Null",
         "}"
-        ]
-    },
+    ],
     "bin": [
         [
             "bsnes-mt.exe",

--- a/bucket/bsnes-mt.json
+++ b/bucket/bsnes-mt.json
@@ -1,0 +1,39 @@
+{
+    "version": "1.3.4",
+    "description": "bsnes-mt is a fork of bsnes that adds video features like pixel-perfect, integer-ratio scaling, as well as the aspect ratio that corresponds to that of the SNES console",
+    "homepage": "https://tanalin.com/en/projects/bsnes-mt/",
+    "license": {
+        "url": "https://github.com/Marat-Tanalin/bsnes-mt/blob/master/LICENSE.txt"
+    },
+    "url": "https://github.com/Marat-Tanalin/bsnes-mt/releases/download/1.3.4/bsnes-mt-1.3.4.7z",
+    "hash": "a19fd3a46f1e9d6c2483ce96a2f1294813bd85dfc0866d66f1ab428047c11f01",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\bsnes-mt-settings.bml\")) {",
+        "   New-Item -ItemType File \"$dir\\bsnes-mt-settings.bml\" | Out-Null",
+        "}"
+    ],
+    "bin": [
+        [
+            "bsnes-mt.exe",
+            "bsnes-mt"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "bsnes-mt.exe",
+            "bsnes-mt"
+        ]
+    ],
+    "persist": [
+        "Database",
+        "Firmware",
+        "Shaders",
+        "bsnes-mt-settings.bml"
+    ],
+    "checkver": {
+        "github": "https://github.com/Marat-Tanalin/bsnes-mt",
+    },
+    "autoupdate": {
+        "url": "https://github.com/Marat-Tanalin/bsnes-mt/releases/download/$version/bsnes-mt-$version.7z"
+    }
+}

--- a/bucket/bsnes-mt.json
+++ b/bucket/bsnes-mt.json
@@ -32,7 +32,7 @@
         "bsnes-mt-settings.bml"
     ],
     "checkver": {
-        "github": "https://github.com/Marat-Tanalin/bsnes-mt",
+        "github": "https://github.com/Marat-Tanalin/bsnes-mt"
     },
     "autoupdate": {
         "url": "https://github.com/Marat-Tanalin/bsnes-mt/releases/download/$version/bsnes-mt-$version.7z"

--- a/bucket/bsnes-mt.json
+++ b/bucket/bsnes-mt.json
@@ -3,16 +3,18 @@
     "description": "bsnes-mt is a fork of bsnes that adds video features like pixel-perfect, integer-ratio scaling, as well as the aspect ratio that corresponds to that of the SNES console",
     "homepage": "https://tanalin.com/en/projects/bsnes-mt/",
     "license": {
-        "identifier": "GPL-3.0-or-later",
+        "identifier": "MIT|GPL-3.0-or-later",
         "url": "https://github.com/Marat-Tanalin/bsnes-mt/blob/master/LICENSE.txt"
     },
     "url": "https://github.com/Marat-Tanalin/bsnes-mt/releases/download/1.3.4/bsnes-mt-1.3.4.7z",
     "hash": "a19fd3a46f1e9d6c2483ce96a2f1294813bd85dfc0866d66f1ab428047c11f01",
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\bsnes-mt-settings.bml\")) {",
-        "   New-Item -ItemType File \"$dir\\bsnes-mt-settings.bml\" | Out-Null",
+    "installer": {
+        "script": [
+            "if (!(Test-Path \"$persist_dir\\bsnes-mt-settings.bml\")) {",
+            "   New-Item -ItemType File \"$dir\\bsnes-mt-settings.bml\" | Out-Null",
         "}"
-    ],
+        ]
+    },
     "bin": [
         [
             "bsnes-mt.exe",


### PR DESCRIPTION
bsnes-mt is a fork of bsnes that adds video features like pixel-perfect, integer-ratio scaling, as well as the aspect ratio that corresponds to that of the SNES console.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
