### PR TITLE
cnc-ddraw@4.4.9.0: Fix hash

### DIFF
--- a/bucket/cnc-ddraw.json
+++ b/bucket/cnc-ddraw.json
@@ -11,7 +11,7 @@
         ""
     ],
     "url": "https://github.com/CnCNet/cnc-ddraw/releases/download/v4.4.9.0/cnc-ddraw.zip",
-    "hash": "6fbf428524ecfc6993c2622202788d84eb27b8beb17922864c0605ba425d05bd",
+    "hash": "81af9199eb1c2b0d178129b8574563435750a10135a087c3a3c7acf49a225f3a",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/CnCNet/cnc-ddraw/releases/download/v$version/cnc-ddraw.zip"


### PR DESCRIPTION
Downloaded multiple times to confirm it doesn't change; would be indicative of malware activity.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
