### PR TITLE
Cemu: Update and change release source

### DIFF
--- a/bucket/cemu-dev.json
+++ b/bucket/cemu-dev.json
@@ -1,11 +1,10 @@
 {
     "version": "2.0-2",
-    "description": "Experimental software to emulate Wii U applications on PC",
+    "description": "A Nintendo WiiU emulator capable of online play (development version)",
     "homepage": "https://cemu.info/",
     "license": "MPL-2.0",
     "suggest": {
-        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022",
-        "cemuhook": "cemuhook"
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
     },
     "architecture": {
         "64bit": {
@@ -16,11 +15,6 @@
     "extract_dir": "Cemu_2.0-2",
     "installer": {
         "script": [
-            "'cemuhook.dll', 'keystone.dll' | ForEach-Object {",
-            "   if (Test-Path \"$(versiondir 'cemuhook' 'current' $global)\\$_\") {",
-            "       Copy-Item \"$(versiondir 'cemuhook' 'current' $global)\\$_\" \"$dir\"",
-            "   }",
-            "}",
             "if (!(Test-Path \"$persist_dir\\keys.txt\")) {",
             "    New-Item \"$dir\\keys.txt\" -Type File | Out-Null",
             "}"

--- a/bucket/cemu-dev.json
+++ b/bucket/cemu-dev.json
@@ -1,23 +1,19 @@
 {
-    "version": "2.0",
-    "description": "Nintendo Wii U emulator",
+    "version": "2.0-2",
+    "description": "Experimental software to emulate Wii U applications on PC",
     "homepage": "https://cemu.info/",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://cemu.info"
-    },
+    "license": "MPL-2.0",
     "suggest": {
-        "cemuhook": "cemuhook",
-        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022",
+        "cemuhook": "cemuhook"
     },
     "architecture": {
         "64bit": {
-            "url": "https://cemu.info/releases/cemu_2.0.zip",
-            "hash": "660a5461333c9eecad3065c4c3e891e6c362f6df05c5e18fc4c36e3d806b6ca4"
+            "url": "https://github.com/cemu-project/Cemu/releases/download/v2.0-2/cemu-2.0-2-windows-x64.zip",
+            "hash": "eb445e62a38bad9748754eb3900b5a079a733c516daa1850cde6956b484fd007"
         }
     },
-    "extract_dir": "cemu_2.0",
-    "pre_install": "if (!(Test-Path \"$persist_dir\\keys.txt\")) { New-Item \"$dir\\keys.txt\" -Type File | Out-Null }",
+    "extract_dir": "Cemu_2.0-2",
     "installer": {
         "script": [
             "'cemuhook.dll', 'keystone.dll' | ForEach-Object {",
@@ -63,14 +59,16 @@
         ]
     },
     "checkver": {
-        "regex": "Download latest experimental version \\(v((?<version>[\\d.]+)[\\w]*?),"
+        "url": "https://github.com/cemu-project/Cemu/releases",
+        "regex": "Cemu (?<ver>\\d+\\.\\d+-\\d+) \\(Experimental\\)",
+        "replace": "${1}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cemu.info/releases/cemu_$matchVersion.zip"
+                "url": "https://github.com/cemu-project/Cemu/releases/download/v$matchVer/cemu-$matchVer-windows-x64.zip"
             }
         },
-        "extract_dir": "cemu_$matchVersion"
+        "extract_dir": "Cemu_$matchVer"
     }
 }

--- a/bucket/cemu-dev.json
+++ b/bucket/cemu-dev.json
@@ -29,11 +29,16 @@
         "   }",
         "}"
     ],
-    "bin": "Cemu.exe",
+    "bin": [
+        [
+            "Cemu.exe",
+            "cemu-dev"
+        ]
+    ],
     "shortcuts": [
         [
-            "cemu.exe",
-            "Cemu"
+            "Cemu.exe",
+            "Cemu (Development)"
         ]
     ],
     "persist": [

--- a/bucket/cemu.json
+++ b/bucket/cemu.json
@@ -1,11 +1,10 @@
 {
     "version": "2.0",
-    "description": "Experimental software to emulate Wii U applications on PC",
+    "description": "A Nintendo WiiU emulator capable of online play",
     "homepage": "https://cemu.info/",
     "license": "MPL-2.0",
     "suggest": {
-        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022",
-        "cemuhook": "cemuhook"
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
     },
     "architecture": {
         "64bit": {
@@ -16,11 +15,6 @@
     "extract_dir": "Cemu_2.0",
     "installer": {
         "script": [
-            "'cemuhook.dll', 'keystone.dll' | ForEach-Object {",
-            "   if (Test-Path \"$(versiondir 'cemuhook' 'current' $global)\\$_\") {",
-            "       Copy-Item \"$(versiondir 'cemuhook' 'current' $global)\\$_\" \"$dir\"",
-            "   }",
-            "}",
             "if (!(Test-Path \"$persist_dir\\keys.txt\")) {",
             "    New-Item \"$dir\\keys.txt\" -Type File | Out-Null",
             "}"

--- a/bucket/cemu.json
+++ b/bucket/cemu.json
@@ -29,10 +29,15 @@
         "   }",
         "}"
     ],
-    "bin": "Cemu.exe",
+    "bin": [
+        [
+            "Cemu.exe",
+            "cemu"
+        ]
+    ],
     "shortcuts": [
         [
-            "cemu.exe",
+            "Cemu.exe",
             "Cemu"
         ]
     ],

--- a/bucket/cemu.json
+++ b/bucket/cemu.json
@@ -1,22 +1,19 @@
 {
-    "version": "1.26.2f",
+    "version": "2.0",
     "description": "Experimental software to emulate Wii U applications on PC",
     "homepage": "https://cemu.info/",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://cemu.info"
-    },
+    "license": "MPL-2.0",
     "suggest": {
-        "cemuhook": "cemuhook",
-        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022",
+        "cemuhook": "cemuhook"
     },
     "architecture": {
         "64bit": {
-            "url": "https://cemu.info/releases/cemu_1.26.2.zip",
-            "hash": "b0e3abf5048f78e352b42c3e1660a2c6e85d6905cd9f60d06ca2f2318fa3152c"
+            "url": "https://github.com/cemu-project/Cemu/releases/download/v2.0/cemu-2.0-windows-x64.zip",
+            "hash": "660a5461333c9eecad3065c4c3e891e6c362f6df05c5e18fc4c36e3d806b6ca4"
         }
     },
-    "extract_dir": "cemu_1.26.2",
+    "extract_dir": "Cemu_2.0",
     "installer": {
         "script": [
             "'cemuhook.dll', 'keystone.dll' | ForEach-Object {",
@@ -62,14 +59,14 @@
         ]
     },
     "checkver": {
-        "regex": "Download latest stable version \\(v((?<version>[\\d.]+)[\\w]*?),"
+        "github": "https://github.com/cemu-project/Cemu"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cemu.info/releases/cemu_$matchVersion.zip"
+                "url": "https://github.com/cemu-project/Cemu/releases/download/v$version/cemu-$version-windows-x64.zip"
             }
         },
-        "extract_dir": "cemu_$matchVersion"
+        "extract_dir": "Cemu_$version"
     }
 }


### PR DESCRIPTION
The promised day hath come, cemu is now open source.     
Leaving this a draft for now, until the release structure straightens out. A stable and dev version are list on the main page, but the github releases show 2.0 as latest and 2.0-2 as latest dev.