### PR TITLE
cemu-dev: Removes deprecated features - updates every property to what's current

### DIFF
--- a/bucket/cemu-dev.json
+++ b/bucket/cemu-dev.json
@@ -1,30 +1,20 @@
 {
-    "version": "2.0",
+    "version": "2.0-2",
     "description": "Nintendo Wii U emulator",
     "homepage": "https://cemu.info/",
     "license": {
-        "identifier": "Freeware",
-        "url": "https://cemu.info"
+        "identifier": "MPL-2.0",
+        "url": "https://github.com/cemu-project/Cemu/blob/main/LICENSE.txt"
     },
     "suggest": {
-        "cemuhook": "cemuhook",
         "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
     },
-    "architecture": {
-        "64bit": {
-            "url": "https://cemu.info/releases/cemu_2.0.zip",
-            "hash": "660a5461333c9eecad3065c4c3e891e6c362f6df05c5e18fc4c36e3d806b6ca4"
-        }
-    },
-    "extract_dir": "cemu_2.0",
+    "url": "https://github.com/cemu-project/Cemu/releases/download/v2.0-2/cemu-2.0-2-windows-x64.zip",
+    "hash": "eb445e62a38bad9748754eb3900b5a079a733c516daa1850cde6956b484fd007",
+    "extract_dir": "Cemu_2.0-2",
     "pre_install": "if (!(Test-Path \"$persist_dir\\keys.txt\")) { New-Item \"$dir\\keys.txt\" -Type File | Out-Null }",
     "installer": {
         "script": [
-            "'cemuhook.dll', 'keystone.dll' | ForEach-Object {",
-            "   if (Test-Path \"$(versiondir 'cemuhook' 'current' $global)\\$_\") {",
-            "       Copy-Item \"$(versiondir 'cemuhook' 'current' $global)\\$_\" \"$dir\"",
-            "   }",
-            "}",
             "if (!(Test-Path \"$persist_dir\\keys.txt\")) {",
             "    New-Item \"$dir\\keys.txt\" -Type File | Out-Null",
             "}"
@@ -39,7 +29,12 @@
         "   }",
         "}"
     ],
-    "bin": "Cemu.exe",
+    "bin":  [
+        [
+            "cemu.exe",
+            "Cemu"
+        ]
+    ],
     "shortcuts": [
         [
             "cemu.exe",
@@ -63,14 +58,11 @@
         ]
     },
     "checkver": {
-        "regex": "Download latest experimental version \\(v((?<version>[\\d.]+)[\\w]*?),"
+        "url": "https://github.com/cemu-project/Cemu/releases",
+        "regex": "Cemu (?<version>([\\d.]+)(-[\\d.]+)?)"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://cemu.info/releases/cemu_$matchVersion.zip"
-            }
-        },
-        "extract_dir": "cemu_$matchVersion"
+        "url": "https://github.com/cemu-project/Cemu/releases/download/v$matchVersion/cemu-$matchVersion-windows-x64.zip",
+        "extract_dir": "Cemu_$matchVersion"
     }
 }


### PR DESCRIPTION
As per the information by the [Cemuhook author](https://cemuhook.sshnuke.net/), the tool is neither compatible anymore, nor should it be used since Cemu has gone open-source.

Also, when installing 'cemuhook', the tool will rather look for – and install – the _old_ version of Cemu if it isn't installed.

The corresponding code is therefore removed from `suggest` and `installer > script`.

---

Other changes:

* As per the [license](https://github.com/cemu-project/Cemu/blob/main/LICENSE.txt) on the emulator's repository, the `license` property is updated to reflect its usage of the _Mozilla Public License Version 2.0_.
* Since the `architecture` property [should only be used when there are both 32- and 64-bit versions available](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifests#optional-properties), the manifest is now using `url` only, as intended.
* Adds alias for `bin`.
* Updates the `checkver` URL to the one used by the authors of Cemu - along with the corresponding `regex` string.
* `autoupdate` is updated to reflect these changes.

---

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
