### PR TITLE
opensupaplex: Add version 7.1.2

### DIFF
--- a/bucket/opensupaplex.json
+++ b/bucket/opensupaplex.json
@@ -1,0 +1,22 @@
+{
+    "version": "7.1.2",
+    "description": "Reverse engineering Supaplex",
+    "homepage": "https://github.com/sergiou87/open-supaplex",
+    "license": "Freeware",
+    "url": "https://github.com/sergiou87/open-supaplex/releases/download/v7.1.2/OpenSupaplex-windows-x86_64-v7.1.2.zip",
+    "hash": "7824632735cf608d98ca502aaabb453b0766510f4ccdb09cd5f9e80c192cde7c",
+    "extract_dir": "OpenSupaplex",
+    "shortcuts": [
+        [
+            "OpenSupaplex.exe",
+            "Open Supaplex"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/sergiou87/open-supaplex"
+    },
+    "autoupdate": {
+        "url": "https://github.com/sergiou87/open-supaplex/releases/download/v$version/OpenSupaplex-windows-x86_64-v$version.zip",
+        "extract_dir": "OpenSupaplex"
+    }
+}

--- a/bucket/opensupaplex.json
+++ b/bucket/opensupaplex.json
@@ -1,6 +1,6 @@
 {
     "version": "7.1.2",
-  "description": "Reimplementation of Supaplex, a 2D puzzle game inspired by BoulderDash",
+    "description": "Reimplementation of Supaplex, a 2D puzzle game inspired by BoulderDash",
     "homepage": "https://github.com/sergiou87/open-supaplex",
     "license": "MIT",
     "url": "https://github.com/sergiou87/open-supaplex/releases/download/v7.1.2/OpenSupaplex-windows-x86_64-v7.1.2.zip",

--- a/bucket/opensupaplex.json
+++ b/bucket/opensupaplex.json
@@ -1,8 +1,8 @@
 {
     "version": "7.1.2",
-    "description": "Reverse engineering Supaplex",
+  "description": "Reimplementation of Supaplex, a 2D puzzle game inspired by BoulderDash",
     "homepage": "https://github.com/sergiou87/open-supaplex",
-    "license": "Freeware",
+    "license": "MIT",
     "url": "https://github.com/sergiou87/open-supaplex/releases/download/v7.1.2/OpenSupaplex-windows-x86_64-v7.1.2.zip",
     "hash": "7824632735cf608d98ca502aaabb453b0766510f4ccdb09cd5f9e80c192cde7c",
     "extract_dir": "OpenSupaplex",


### PR DESCRIPTION
OpenSupaplex is a reverse engineered version of Supaplex for a lot of platforms including handhelds

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
