### PR TITLE
romsorter: Update URL/Autoupdate

### DIFF
--- a/bucket/romsorter.json
+++ b/bucket/romsorter.json
@@ -1,25 +1,25 @@
 {
-    "version": "release5",
-    "description": "Compress, or uncompress ROMs, detect duplicates, catalog, manage CHD and DAT data, sort for Everdrive, or create 1G1R sets - all with one app",
+    "version": "release6",
+    "description": "Compress, or uncompress ROMs. Detect duplicates, catalog, manage CHD and DAT data, sort for Everdrive, or create 1G1R sets. All with one app.",
     "homepage": "https://github.com/drakewill-CRL/ROMSorter",
     "license": "MIT",
     "notes": [
         "",
         "ROMSorter depends on having the .NET 6 runtime installed.",
         "",
-        "The .NET 6 runtime, also known as Microsoft Windows Desktop Runtime, is available in the Extras bucket.",
+        "The .NET 6 runtime, also known as the Microsoft Windows Desktop Runtime, is available in the Extras bucket.",
         "",
         "Since the runtime gets installed globally, Sudo is needed, which is part of the Main bucket.",
         "",
-        "For example, with Sudo installed, you could execute the following to get the dependencies: scoop install extras/windowsdesktop-runtime-lts",
+        "With Sudo installed, you could execute the following to get the dependencies installed: scoop install extras/windowsdesktop-runtime-lts",
         ""
     ],
     "suggest": {
         "Sudo": "main/sudo",
         ".NET6": "extras/windowsdesktop-runtime-lts"
     },
-    "url": "https://github.com/drakewill-CRL/ROMSorter/releases/download/release5/ROMSorter.zip",
-    "hash": "1ba6738dc7c9bedb4736f5e00ed94516e1c1cb750a7bcdd0801ada2557ffac40",
+    "url": "https://github.com/drakewill-CRL/ROMSorter/releases/download/release6/ROMSorter-Release6.zip",
+    "hash": "63b060b4b4aa16485cf3b56b0e91ca5e25cc43527e5dccdde81947ed6147142d",
     "shortcuts": [
         [
             "ROMSorter.exe",
@@ -31,6 +31,6 @@
         "regex": "tag/(release\\d+)"
     },
     "autoupdate": {
-        "url": "https://github.com/drakewill-CRL/ROMSorter/releases/download/$version/ROMSorter.zip"
+        "url": "https://github.com/drakewill-CRL/ROMSorter/releases/download/$version/ROMSorter-$version.zip"
     }
 }

--- a/bucket/romsorter.json
+++ b/bucket/romsorter.json
@@ -5,18 +5,18 @@
     "license": "MIT",
     "notes": [
         "",
-        "ROMSorter depends on having the .NET 6 runtime installed.",
+        "ROMSorter depends on having the .NET 6 runtime or later installed.",
         "",
-        "The .NET 6 runtime, also known as the Microsoft Windows Desktop Runtime, is available in the Extras bucket.",
+        "The .NET runtime, also known as the Microsoft Windows Desktop Runtime, is available in the Extras bucket.",
         "",
-        "Since the runtime gets installed globally, Sudo is needed, which is part of the Main bucket.",
+        "Since the runtime gets installed globally, sudo functionality is needed, which is part of the Main bucket.",
         "",
-        "With Sudo installed, you could execute the following to get the dependencies installed: scoop install extras/windowsdesktop-runtime-lts",
+        "With something like the 'gsudo' app installed, you could execute the following to get the dependencies: sudo scoop install extras/windowsdesktop-runtime-lts",
         ""
     ],
     "suggest": {
-        "Sudo": "main/sudo",
-        ".NET6": "extras/windowsdesktop-runtime-lts"
+        "Sudo": "main/gsudo",
+        ".NET runtime": "extras/windowsdesktop-runtime"
     },
     "url": "https://github.com/drakewill-CRL/ROMSorter/releases/download/release6/ROMSorter-Release6.zip",
     "hash": "63b060b4b4aa16485cf3b56b0e91ca5e25cc43527e5dccdde81947ed6147142d",


### PR DESCRIPTION
Also updates grammar and the like in the `description` and `notes`.

The latest download URL of the app uses its version at the tail end.

I've also created [an issue](https://github.com/drakewill-CRL/ROMSorter/issues/5) regarding portable mode, as the config of the app is currently created in **Local AppData**.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
