### PR TITLE
amulet-map-editor: Fix version and website URL

### DIFF
--- a/bucket/amulet-map-editor.json
+++ b/bucket/amulet-map-editor.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.10.3",
+    "version": "0.10.2",
     "description": "Minecraft world editor and converter that supports all versions since Java 1.12 and Bedrock 1.7",
-    "homepage": "https://www.amulet-editor.com",
+    "homepage": "https://www.amuletmc.com",
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Amulet-Team/Amulet-Map-Editor/releases/download/0.10.3/Amulet-v0.10.3-windows-x64.zip",
-            "hash": "946efa9c41b3c69a140870770b7b489adbe09ffb037dfb0600246fb992494143",
+            "url": "https://github.com/Amulet-Team/Amulet-Map-Editor/releases/download/0.10.2/Amulet-v0.10.2-Windows-x64.zip",
+            "hash": "4444ddf856e054dc045806f5edb0ea25ae54d748017ac9e8edecd87af0fdca57",
             "extract_dir": "Amulet"
         }
     },
@@ -24,6 +24,6 @@
         "github": "https://github.com/Amulet-Team/Amulet-Map-Editor"
     },
     "autoupdate": {
-        "url": "https://github.com/Amulet-Team/Amulet-Map-Editor/releases/download/$version/Amulet-v$version-windows-x64.zip"
+        "url": "https://github.com/Amulet-Team/Amulet-Map-Editor/releases/download/$version/Amulet-v$version-Windows-x64.zip"
     }
 }


### PR DESCRIPTION
Roll back to v0.10.2 (v0.10.3 does not exist).
Fix homepage URI.

Closes #730 and closes #731.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
