### PR TITLE
ppsspp(-dev): Fix manifests, Update `test.ps1` to Pester 5

### DIFF
--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -1,5 +1,15 @@
-#Requires -Modules @{ ModuleName = 'Pester'; MaximumVersion = '4.99' }
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'BuildHelpers'; ModuleVersion = '2.0.1' }
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.2.0' }
 
-if(!$env:SCOOP_HOME) { $env:SCOOP_HOME = Convert-Path (scoop prefix scoop) }
-$result = Invoke-Pester "$PSScriptRoot\.." -PassThru
+$pesterConfig = New-PesterConfiguration -Hashtable @{
+    Run    = @{
+        Path     = "$PSScriptRoot/.."
+        PassThru = $true
+    }
+    Output = @{
+        Verbosity = 'Detailed'
+    }
+}
+$result = Invoke-Pester -Configuration $pesterConfig
 exit $result.FailedCount

--- a/bucket/ppsspp-dev.json
+++ b/bucket/ppsspp-dev.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.13.2-1944-g3e481634a",
+    "version": "1.14.1-8-gd4f5bff36",
     "description": "Sony PlayStation Portable (PSP) emulator. Development build",
     "homepage": "https://www.ppsspp.org",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.13.2-1944-g3e481634a&platform=windows-amd64#/dl.zip",
-            "hash": "8b7382eeead26d7dbfb043a9a7418054714013e7f29d675f7f1d676ed4c0f696",
+            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.14.1-8-gd4f5bff36&platform=windows-amd64#/dl.zip",
+            "hash": "48d28f5ea1005acf6efde9610b8dc7c12dd7aa29e271bb1614480e651896765b",
             "bin": [
                 [
                     "PPSSPPWindows64.exe",
@@ -21,8 +21,8 @@
             ]
         },
         "32bit": {
-            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.13.2-1944-g3e481634a&platform=windows-x86#/dl.zip",
-            "hash": "f1ac5da67beb2f88256e6121bb28be57c99dfca71b8aac6b7c667c96faa4ed85",
+            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.14.1-8-gd4f5bff36&platform=windows-x86#/dl.zip",
+            "hash": "e5ed902a922cc7d3726c186f51da4ca2d86e46b759056c68f53766c4b2db2718",
             "bin": [
                 [
                     "PPSSPPWindows.exe",

--- a/bucket/ppsspp-dev.json
+++ b/bucket/ppsspp-dev.json
@@ -1,41 +1,38 @@
 {
-    "version": "1.12.3-1469",
-    "description": "Sony PSP emulator (Development)",
+    "version": "1.13.2-1944-g3e481634a",
+    "description": "Sony PlayStation Portable (PSP) emulator. Development build",
     "homepage": "https://www.ppsspp.org",
-    "license": {
-        "identifier": "GPL 2.0 or later",
-        "url": "https://github.com/hrydgard/ppsspp/blob/master/LICENSE.TXT"
-    },
+    "license": "GPL-2.0-or-later",
     "architecture": {
-        "32bit": {
-            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.12.3-1469-$commit&platform=windows-x86#/dl.7z",
-            "hash": "555938fd48cf5ae34afc0511f986834a91c24ec885fbb66114d24af223d36d7b",
+        "64bit": {
+            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.13.2-1944-g3e481634a&platform=windows-amd64#/dl.zip",
+            "hash": "8b7382eeead26d7dbfb043a9a7418054714013e7f29d675f7f1d676ed4c0f696",
             "bin": [
                 [
-                    "PPSSPPWindows.exe",
+                    "PPSSPPWindows64.exe",
                     "ppsspp-dev"
                 ]
             ],
             "shortcuts": [
                 [
-                    "PPSSPPWindows.exe",
-                    "PPSSPP (development)"
+                    "PPSSPPWindows64.exe",
+                    "PPSSPP (Development)"
                 ]
             ]
         },
-        "64bit": {
-            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.12.3-1469-$commit&platform=windows-amd64#/dl.7z",
-            "hash": "c273e1fb85c565cccc33754c6afc461528cede61b997b9523ca92d3848b2de93",
+        "32bit": {
+            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.13.2-1944-g3e481634a&platform=windows-x86#/dl.zip",
+            "hash": "f1ac5da67beb2f88256e6121bb28be57c99dfca71b8aac6b7c667c96faa4ed85",
             "bin": [
                 [
-                    "PPSSPPWindows64.exe",
+                    "PPSSPPWindows.exe",
                     "ppsspp-dev"
                 ]
             ],
             "shortcuts": [
                 [
-                    "PPSSPPWindows64.exe",
-                    "PPSSPP (development)"
+                    "PPSSPPWindows.exe",
+                    "PPSSPP (Development)"
                 ]
             ]
         }
@@ -54,16 +51,16 @@
     ],
     "checkver": {
         "url": "https://buildbot.orphis.net/ppsspp/index.php",
-        "regex": "v(?<basever>\\d{1,2}\\.\\d{1,2}\\.\\d{1,2})-(?<build>\\d{1,4})-g(?<commit>[a-f0-9]{9})",
-        "replace": "${basever}-${build}"
+        "regex": "rev=v(?<version>[\\d.]+)-(?<build>[\\d]+)-g(?<commit>[\\da-fA-F]+)&(?:amp;)platform=windows-amd64",
+        "replace": "${version}-${build}-g${commit}"
     },
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v$matchBasever-$matchBuild-$commit&platform=windows-x86#/dl.7z"
-            },
             "64bit": {
-                "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v$matchBasever-$matchBuild-$commit&platform=windows-amd64#/dl.7z"
+                "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v$matchVersion-$matchBuild-g$matchCommit&platform=windows-amd64#/dl.zip"
+            },
+            "32bit": {
+                "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v$matchVersion-$matchBuild-g$matchCommit&platform=windows-x86#/dl.zip"
             }
         }
     }

--- a/bucket/ppsspp-dev.json
+++ b/bucket/ppsspp-dev.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.14.1-27",
-    "description": "Sony PSP emulator (Development)",
+    "version": "1.14.1-26-gc730ba765",
+    "description": "Sony PlayStation Portable (PSP) emulator. Development build",
     "homepage": "https://www.ppsspp.org",
     "license": "GPL-2.0-or-later",
     "architecture": {
-        "32bit": {
-            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.14.1-27-$commit&platform=windows-x86#/dl.7z",
-            "hash": "c10b5c15f5e5c84069eb3d694c53737272858ab81f72eda39e9438430b2da8d5",
+        "64bit": {
+            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.14.1-26-gc730ba765&platform=windows-amd64#/dl.zip",
+            "hash": "bae34be5e898e8a55f07c92edc5f39cbaf1f6a1be77b7d5f75ddb2e28a4e1737",
             "bin": [
                 [
                     "PPSSPPWindows64.exe",
@@ -20,9 +20,9 @@
                 ]
             ]
         },
-        "64bit": {
-            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.14.1-27-$commit&platform=windows-amd64#/dl.7z",
-            "hash": "5d31103fe9e469920c0ce57c87660a4e2b3f81e6b665d6bfad29a7e3088a6c82",
+        "32bit": {
+            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.14.1-26-gc730ba765&platform=windows-x86#/dl.zip",
+            "hash": "1a49d45b53d99ed8028d779dd1fa8668e40e6e5536d1b0097511646fb3cfb9a7",
             "bin": [
                 [
                     "PPSSPPWindows.exe",

--- a/bucket/ppsspp.json
+++ b/bucket/ppsspp.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.13.2",
+    "version": "1.14.1",
     "description": "Sony PlayStation Portable (PSP) emulator",
     "homepage": "https://www.ppsspp.org",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://ppsspp.org/files/1_13_2/ppsspp_win.zip",
-            "hash": "e73c5d639bdf7c39edb1263830f49a84d6061bd64810cd69994911e10faaeb20",
+            "url": "https://ppsspp.org/files/1_14_1/ppsspp_win.zip",
+            "hash": "55d0ed4fa4eb44f6e6afffe74205ba396ddd080c31bfb61dfa55a1e9367674c4",
             "bin": [
                 [
                     "PPSSPPWindows64.exe",
@@ -21,8 +21,8 @@
             ]
         },
         "arm64": {
-            "url": "https://ppsspp.org/files/1_13_2/PPSSPPWindowsARM64.zip",
-            "hash": "98b964a82464ddacc0abe1830f29ffb2094825df6b20c608426c3455f2b9eff8",
+            "url": "https://ppsspp.org/files/1_14_1/PPSSPPWindowsARM64.zip",
+            "hash": "79b30b1f8152382560797b7059e94fc2a5ddf277092894c76fac3f1102539ef9",
             "bin": [
                 [
                     "PPSSPPWindowsARM64.exe",

--- a/bucket/ppsspp.json
+++ b/bucket/ppsspp.json
@@ -1,19 +1,12 @@
 {
-    "version": "1.12.3",
-    "description": "Sony PSP emulator",
+    "version": "1.13.2",
+    "description": "Sony PlayStation Portable (PSP) emulator",
     "homepage": "https://www.ppsspp.org",
-    "license": {
-        "identifier": "GPL 2.0 or later",
-        "url": "https://github.com/hrydgard/ppsspp/blob/master/LICENSE.TXT"
-    },
-    "url": "https://ppsspp.org/files/1_12_3/ppsspp_win.zip",
-    "hash": "f909ae76b63984cd88f8c3e8ff56fd6e6bd7de98dd1ee441b5290ddce3fe7d94",
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\")) {",
-        "   New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
-        "   New-Item \"$persist_dir\\memstick\" -ItemType Directory | Out-Null",
-        "}"
-    ],
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://ppsspp.org/files/1_13_2/ppsspp_win.zip",
+            "hash": "e73c5d639bdf7c39edb1263830f49a84d6061bd64810cd69994911e10faaeb20",
             "bin": [
                 [
                     "PPSSPPWindows64.exe",
@@ -25,6 +18,31 @@
                     "PPSSPPWindows64.exe",
                     "PPSSPP"
                 ]
+            ]
+        },
+        "arm64": {
+            "url": "https://ppsspp.org/files/1_13_2/PPSSPPWindowsARM64.zip",
+            "hash": "98b964a82464ddacc0abe1830f29ffb2094825df6b20c608426c3455f2b9eff8",
+            "bin": [
+                [
+                    "PPSSPPWindowsARM64.exe",
+                    "ppsspp"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "PPSSPPWindowsARM64.exe",
+                    "PPSSPP"
+                ]
+            ]
+        }
+    },
+    "extract_dir": "ppsspp",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\")) {",
+        "   New-item \"$persist_dir\" -ItemType Directory | Out-Null",
+        "   New-item \"$persist_dir\\memstick\" -ItemType Directory | Out-Null",
+        "}"
     ],
     "persist": [
         "assets",
@@ -33,10 +51,16 @@
     ],
     "checkver": {
         "url": "https://www.ppsspp.org/downloads.html",
-        "regex": "Download ((?<major>\\d)\\.(?<minor>\\d{1,3})\\.(?<patch>\\d{1,3})) zip",
-        "replace": "${major}.${minor}.${patch}"
+        "regex": "Download ([\\d.]+) zip"
     },
     "autoupdate": {
-            "url": "https://ppsspp.org/files/${major}_${minor}_${patch}/ppsspp_win.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://ppsspp.org/files/$underscoreVersion/ppsspp_win.zip"
+            },
+            "arm64": {
+                "url": "https://ppsspp.org/files/$underscoreVersion/PPSSPPWindowsARM64.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Fix outdated `ppsspp(-dev)` manifests
- Update to Pester 5, See https://github.com/ScoopInstaller/Scoop/releases/tag/v0.3.1:
>### BREAKING CHANGES
>
>- **pester:** Update to Pester 5 (https://github.com/ScoopInstaller/Scoop/pull/5222)
>
>#### IMPORTANT FOR BUCKET MAINTAINERS
>
>- Pester 5 is used in this release. To make sure your bucket's CI works properly, please update `bin\test.ps1` from Pester 4 to Pester 5.
>- You can use `test.ps1` attached in the release files.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
