### PR TITLE
Switch for legacy

### DIFF
--- a/bucket/duckstation.json
+++ b/bucket/duckstation.json
@@ -11,8 +11,8 @@
         "Place the BIOS file in $persist_dir\\bios",
         "Learn more at: https://www.duckstation.org/wiki/BIOS"
     ],
-    "url": "https://github.com/stenzek/duckstation/releases/download/latest/duckstation-windows-x64-release.zip",
-    "hash": "e52140057eea1c4a4218a22a3ba52af1051cedc468a4eda9d218ccdc7bebddf4",
+    "url": "https://github.com/stenzek/duckstation/releases/download/legacy/duckstation-windows-x64-release.zip",
+    "hash": "486bab13e3bb6ac19bd9145558afda0486613898d41e559feb8c8963a76229b4",
     "installer": {
         "script": [
             "if (!(Test-Path \"$persist_dir\")) {",


### PR DESCRIPTION
The `latest` is actually a development build, that need a different manifest (this one doesn’t work: shim, persist, etc.).

Creating an additional manifest in `scoop-games` for `duckstation-preview` (or something like that) can be an option, if someone wants to do that.

OR

This manifest need to be reworked and `duckstation-legacy` created as an option.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
