### PR TITLE
doom-retro@4.7: Fix hash

### DIFF
--- a/bucket/doom-retro.json
+++ b/bucket/doom-retro.json
@@ -23,11 +23,11 @@
     "architecture": {
         "32bit": {
             "url": "https://github.com/bradharding/doomretro/releases/download/v4.7/doomretro-4.7-win32.zip",
-            "hash": "76f539d3453b069fa9280051e05554a964ec67c6dfb9126283df97c3a06003b1"
+            "hash": "bc53084baff238d911b96e532cd53be075406cf56b65bc77c909e5bce6f5b312"
         },
         "64bit": {
             "url": "https://github.com/bradharding/doomretro/releases/download/v4.7/doomretro-4.7-win64.zip",
-            "hash": "c4affdd1b643ba2c5d29c328f228c6c51fbd38986dc589b05d9e041c7df9c2ff"
+            "hash": "f9ca76fe696a814bc5964a3fe7132b0accd5d90bdd66e4770c9f4379eb2a9234"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Fixes hash for this version.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
