### PR TITLE
prismlauncher/prismlauncher-qt5: Update to v6.0, add associations

### DIFF
--- a/bucket/prismlauncher-qt5.json
+++ b/bucket/prismlauncher-qt5.json
@@ -1,10 +1,21 @@
 {
-    "version": "5.2",
-    "description": "An Open Source Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability. Qt 5 build that still supports legacy Windows like 8.1 and 7.",
+    "version": "6.0",
+    "description": "An open sourced Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability. Qt 5 build that still supports legacy Windows like 8.1 and 7.",
     "homepage": "https://prismlauncher.org/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/5.2/PrismLauncher-Windows-Legacy-5.2.zip",
-    "hash": "74b1154c64b206f5a64bf965e9383a606461605ee92a609192aa0f67d8a6efd3",
+    "notes": "To add Prism Launcher file association options for .ZIPs and .MRPACKS, run this: \"$dir\\install-associations.reg\"",
+    "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/6.0/PrismLauncher-Windows-MSVC-Legacy-6.0.zip",
+    "hash": "68b8ea5211c3cb6041b5f4dffb4a95bae80a649ab04d7b58b0bb8648b6e7204f",
+    "post_install": [
+        "'install-associations', 'uninstall-associations' | ForEach-Object {",
+        "    if (Test-Path \"$bucketsdir\\scoop-games\\scripts\\prismlauncher-qt5\\$_.reg\") {",
+        "        $exePath = \"$dir\\prismlauncher.exe\".Replace('\\', '\\\\')",
+        "        $content = (Get-Content \"$bucketsdir\\extras\\scripts\\prismlauncher-qt5\\$_.reg\").Replace('$EXEPATH', $exePath)",
+        "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
+        "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
+        "    }",
+        "}"
+    ],
     "bin": "prismlauncher.exe",
     "shortcuts": [
         [
@@ -16,6 +27,6 @@
         "github": "https://github.com/PrismLauncher/PrismLauncher"
     },
     "autoupdate": {
-        "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/$version/PrismLauncher-Windows-Legacy-$version.zip"
+        "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/$version/PrismLauncher-Windows-MSVC-Legacy-$version.zip"
     }
 }

--- a/bucket/prismlauncher-qt5.json
+++ b/bucket/prismlauncher-qt5.json
@@ -1,11 +1,14 @@
 {
     "version": "6.0",
-    "description": "An open sourced Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability. Qt 5 build that still supports legacy Windows like 8.1 and 7.",
+    "description": "An open source Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability. Qt 5 build that still supports legacy Windows like 8.1 and 7.",
     "homepage": "https://prismlauncher.org/",
     "license": "GPL-3.0-only",
     "notes": "To add Prism Launcher file association options for .ZIPs and .MRPACKS, run this: \"$dir\\install-associations.reg\"",
     "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/6.0/PrismLauncher-Windows-MSVC-Legacy-6.0.zip",
     "hash": "68b8ea5211c3cb6041b5f4dffb4a95bae80a649ab04d7b58b0bb8648b6e7204f",
+    "suggest": {
+        "Microsoft Visual C++ Redistributables": "extras/vcredist2022"
+    },
     "post_install": [
         "'install-associations', 'uninstall-associations' | ForEach-Object {",
         "    if (Test-Path \"$bucketsdir\\games\\scripts\\prismlauncher-qt5\\$_.reg\") {",

--- a/bucket/prismlauncher-qt5.json
+++ b/bucket/prismlauncher-qt5.json
@@ -10,7 +10,7 @@
         "'install-associations', 'uninstall-associations' | ForEach-Object {",
         "    if (Test-Path \"$bucketsdir\\games\\scripts\\prismlauncher-qt5\\$_.reg\") {",
         "        $exePath = \"$dir\\prismlauncher.exe\".Replace('\\', '\\\\')",
-        "        $content = (Get-Content \"$bucketsdir\\extras\\scripts\\prismlauncher-qt5\\$_.reg\").Replace('$EXEPATH', $exePath)",
+        "        $content = (Get-Content \"$bucketsdir\\games\\scripts\\prismlauncher-qt5\\$_.reg\").Replace('$EXEPATH', $exePath)",
         "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
         "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
         "    }",

--- a/bucket/prismlauncher-qt5.json
+++ b/bucket/prismlauncher-qt5.json
@@ -8,7 +8,7 @@
     "hash": "68b8ea5211c3cb6041b5f4dffb4a95bae80a649ab04d7b58b0bb8648b6e7204f",
     "post_install": [
         "'install-associations', 'uninstall-associations' | ForEach-Object {",
-        "    if (Test-Path \"$bucketsdir\\scoop-games\\scripts\\prismlauncher-qt5\\$_.reg\") {",
+        "    if (Test-Path \"$bucketsdir\\games\\scripts\\prismlauncher-qt5\\$_.reg\") {",
         "        $exePath = \"$dir\\prismlauncher.exe\".Replace('\\', '\\\\')",
         "        $content = (Get-Content \"$bucketsdir\\extras\\scripts\\prismlauncher-qt5\\$_.reg\").Replace('$EXEPATH', $exePath)",
         "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",

--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -14,7 +14,7 @@
         "'install-associations', 'uninstall-associations' | ForEach-Object {",
         "    if (Test-Path \"$bucketsdir\\games\\scripts\\prismlauncher\\$_.reg\") {",
         "        $exePath = \"$dir\\prismlauncher.exe\".Replace('\\', '\\\\')",
-        "        $content = (Get-Content \"$bucketsdir\\extras\\scripts\\prismlauncher\\$_.reg\").Replace('$EXEPATH', $exePath)",
+        "        $content = (Get-Content \"$bucketsdir\\games\\scripts\\prismlauncher\\$_.reg\").Replace('$EXEPATH', $exePath)",
         "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
         "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
         "    }",

--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -4,8 +4,12 @@
     "homepage": "https://prismlauncher.org/",
     "license": "GPL-3.0-only",
     "notes": "To add Prism Launcher file association options for .ZIPs and .MRPACKS, run this: \"$dir\\install-associations.reg\"",
-    "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/6.0/PrismLauncher-Windows-MSVC-6.0.zip",
-    "hash": "6fa4dc49866c5cd4bbc69ccd84d009b5fb67a83bda8945cab540c849b6ddb680",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/6.0/PrismLauncher-Windows-MSVC-6.0.zip",
+            "hash": "6fa4dc49866c5cd4bbc69ccd84d009b5fb67a83bda8945cab540c849b6ddb680"
+        }
+    },
     "post_install": [
         "'install-associations', 'uninstall-associations' | ForEach-Object {",
         "    if (Test-Path \"$bucketsdir\\scoop-games\\scripts\\prismlauncher\\$_.reg\") {",
@@ -27,6 +31,10 @@
         "github": "https://github.com/PrismLauncher/PrismLauncher"
     },
     "autoupdate": {
-        "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/$version/PrismLauncher-Windows-MSVC-$version.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/$version/PrismLauncher-Windows-MSVC-$version.zip"
+            }
+        }
     }
 }

--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -12,7 +12,7 @@
     },
     "post_install": [
         "'install-associations', 'uninstall-associations' | ForEach-Object {",
-        "    if (Test-Path \"$bucketsdir\\scoop-games\\scripts\\prismlauncher\\$_.reg\") {",
+        "    if (Test-Path \"$bucketsdir\\games\\scripts\\prismlauncher\\$_.reg\") {",
         "        $exePath = \"$dir\\prismlauncher.exe\".Replace('\\', '\\\\')",
         "        $content = (Get-Content \"$bucketsdir\\extras\\scripts\\prismlauncher\\$_.reg\").Replace('$EXEPATH', $exePath)",
         "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",

--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -1,6 +1,6 @@
 {
     "version": "6.0",
-    "description": "An open sourced Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability.",
+    "description": "An open source Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability.",
     "homepage": "https://prismlauncher.org/",
     "license": "GPL-3.0-only",
     "notes": "To add Prism Launcher file association options for .ZIPs and .MRPACKS, run this: \"$dir\\install-associations.reg\"",
@@ -9,6 +9,9 @@
             "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/6.0/PrismLauncher-Windows-MSVC-6.0.zip",
             "hash": "6fa4dc49866c5cd4bbc69ccd84d009b5fb67a83bda8945cab540c849b6ddb680"
         }
+    },
+    "suggest": {
+        "Microsoft Visual C++ Redistributables": "extras/vcredist2022"
     },
     "post_install": [
         "'install-associations', 'uninstall-associations' | ForEach-Object {",

--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -1,14 +1,21 @@
 {
-    "version": "5.2",
-    "description": "An Open Source Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability.",
+    "version": "6.0",
+    "description": "An open sourced Minecraft launcher with the ability to manage multiple instances, accounts and mods. Focused on user freedom and free redistributability.",
     "homepage": "https://prismlauncher.org/",
     "license": "GPL-3.0-only",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/5.2/PrismLauncher-Windows-5.2.zip",
-            "hash": "b4e1bf1cbcfc162a13703f0dec930137c7b3de750801cceebe5e24e8d5f70b54"
-        }
-    },
+    "notes": "To add Prism Launcher file association options for .ZIPs and .MRPACKS, run this: \"$dir\\install-associations.reg\"",
+    "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/6.0/PrismLauncher-Windows-MSVC-6.0.zip",
+    "hash": "6fa4dc49866c5cd4bbc69ccd84d009b5fb67a83bda8945cab540c849b6ddb680",
+    "post_install": [
+        "'install-associations', 'uninstall-associations' | ForEach-Object {",
+        "    if (Test-Path \"$bucketsdir\\scoop-games\\scripts\\prismlauncher\\$_.reg\") {",
+        "        $exePath = \"$dir\\prismlauncher.exe\".Replace('\\', '\\\\')",
+        "        $content = (Get-Content \"$bucketsdir\\extras\\scripts\\prismlauncher\\$_.reg\").Replace('$EXEPATH', $exePath)",
+        "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
+        "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
+        "    }",
+        "}"
+    ],
     "bin": "prismlauncher.exe",
     "shortcuts": [
         [
@@ -20,10 +27,6 @@
         "github": "https://github.com/PrismLauncher/PrismLauncher"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/$version/PrismLauncher-Windows-$version.zip"
-            }
-        }
+        "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/$version/PrismLauncher-Windows-MSVC-$version.zip"
     }
 }

--- a/scripts/prismlauncher-qt5/install-associations.reg
+++ b/scripts/prismlauncher-qt5/install-associations.reg
@@ -1,0 +1,46 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe]
+@="Minecraft Mod-Pack"
+
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe\DefaultIcon]
+@="$EXEPATH,0"
+
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe\shell]
+@="open"  
+ 
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe\shell\open]
+@="Import into Prism Launcher"
+
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe\shell\open\command]
+@="$EXEPATH"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe\shell\open\command]
+@="$EXEPATH -I \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe]
+"FriendlyAppName"= "Prism Launcher"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe\Capabilities]
+"ApplicationDescription"="Minecraft Mod-Pack"
+
+[HKEY_CURRENT_USER\Software\RegisteredApplications]
+"Prism Launcher"="Software\Classes\Applications\prismlauncher.exe\Capabilities"
+
+[HKEY_CURRENT_USER\Software\Classes\.zip\OpenWithList]
+"prismlauncher.exe"=""
+
+[HKEY_CURRENT_USER\Software\Classes\.zip\OpenWithProgids]
+"prismlauncher.exe"=""
+
+[HKEY_CURRENT_USER\Software\Classes\.mrpack\OpenWithList]
+"prismlauncher.exe"=""
+
+[HKEY_CURRENT_USER\Software\Classes\.mrpack\OpenWithProgids]
+"prismlauncher.exe"=""
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe\Capabilities\FileAssociations]
+".mrpack"="prismlauncher.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe\Capabilities\FileAssociations]
+".zip"="prismlauncher.exe"

--- a/scripts/prismlauncher-qt5/uninstall-associations.reg
+++ b/scripts/prismlauncher-qt5/uninstall-associations.reg
@@ -1,0 +1,20 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe]
+
+[-HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe]
+
+[HKEY_CURRENT_USER\Software\RegisteredApplications]
+"Prism Launcher"=-
+
+[HKEY_CURRENT_USER\Software\Classes\.zip\OpenWithList]
+"prismlauncher.exe"=-
+
+[HKEY_CURRENT_USER\Software\Classes\.zip\OpenWithProgids]
+"prismlauncher.exe"=-
+
+[HKEY_CURRENT_USER\Software\Classes\.mrpack\OpenWithList]
+"prismlauncher.exe"=-
+
+[HKEY_CURRENT_USER\Software\Classes\.mrpack\OpenWithProgids]
+"prismlauncher.exe"=-

--- a/scripts/prismlauncher/install-associations.reg
+++ b/scripts/prismlauncher/install-associations.reg
@@ -1,0 +1,46 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe]
+@="Minecraft Mod-Pack"
+
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe\DefaultIcon]
+@="$EXEPATH,0"
+
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe\shell]
+@="open"  
+ 
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe\shell\open]
+@="Import into Prism Launcher"
+
+[HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe\shell\open\command]
+@="$EXEPATH"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe\shell\open\command]
+@="$EXEPATH -I \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe]
+"FriendlyAppName"= "Prism Launcher"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe\Capabilities]
+"ApplicationDescription"="Minecraft Mod-Pack"
+
+[HKEY_CURRENT_USER\Software\RegisteredApplications]
+"Prism Launcher"="Software\Classes\Applications\prismlauncher.exe\Capabilities"
+
+[HKEY_CURRENT_USER\Software\Classes\.zip\OpenWithList]
+"prismlauncher.exe"=""
+
+[HKEY_CURRENT_USER\Software\Classes\.zip\OpenWithProgids]
+"prismlauncher.exe"=""
+
+[HKEY_CURRENT_USER\Software\Classes\.mrpack\OpenWithList]
+"prismlauncher.exe"=""
+
+[HKEY_CURRENT_USER\Software\Classes\.mrpack\OpenWithProgids]
+"prismlauncher.exe"=""
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe\Capabilities\FileAssociations]
+".mrpack"="prismlauncher.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe\Capabilities\FileAssociations]
+".zip"="prismlauncher.exe"

--- a/scripts/prismlauncher/uninstall-associations.reg
+++ b/scripts/prismlauncher/uninstall-associations.reg
@@ -1,0 +1,20 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Classes\prismlauncher.exe]
+
+[-HKEY_CURRENT_USER\Software\Classes\Applications\prismlauncher.exe]
+
+[HKEY_CURRENT_USER\Software\RegisteredApplications]
+"Prism Launcher"=-
+
+[HKEY_CURRENT_USER\Software\Classes\.zip\OpenWithList]
+"prismlauncher.exe"=-
+
+[HKEY_CURRENT_USER\Software\Classes\.zip\OpenWithProgids]
+"prismlauncher.exe"=-
+
+[HKEY_CURRENT_USER\Software\Classes\.mrpack\OpenWithList]
+"prismlauncher.exe"=-
+
+[HKEY_CURRENT_USER\Software\Classes\.mrpack\OpenWithProgids]
+"prismlauncher.exe"=-


### PR DESCRIPTION
Adds an optional associations registry file that supports the new feature to import mod-packs from the command line. https://github.com/PrismLauncher/PrismLauncher/pull/266

This also updates the launcher to v6.0 and switches to MSVC, as recommended by Scrumplex (a developer).

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
