### PR TITLE
pegasus: Fix `checkver` to be more reliable for version checking

### DIFF
--- a/bucket/pegasus.json
+++ b/bucket/pegasus.json
@@ -6,7 +6,7 @@
     "notes": "Application settings are stored in the \"%LOCALAPPDATA%\\pegasus-frontend\" directory, or the \"config\" folder inside the app directory.",
     "url": "https://github.com/mmatyas/pegasus-frontend/releases/download/weekly_2022w30/pegasus-fe_alpha16-42-g996720eb_win-mingw-static.zip",
     "hash": "667F67373F4F89943D303E66D16177A54C9BE29CDD32549FB62186F13DBFB8D8",
-    "pre_install": "if (!(Test-Path \"$dir\\portable.txt\")) {New-Item \"$dir\\portable.txt\" -ItemType 'File' | Out-Null}",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\portable.txt\")) { New-Item \"$dir\\portable.txt\" -ItemType 'File' | Out-Null }",
     "bin": "pegasus-fe.exe",
     "shortcuts": [
         [
@@ -15,10 +15,14 @@
             "--portable"
         ]
     ],
-    "persist": "config",
+    "persist": [
+        "config",
+        "portable.txt"
+    ],
     "checkver": {
-        "url": "https://github.com/mmatyas/pegasus-frontend/releases",
-        "regex": "(?<Release>[\\w_]+)/pegasus-fe_([\\w-]+)_win-mingw-static.zip"
+        "url": "https://api.github.com/repos/mmatyas/pegasus-frontend/releases/latest",
+        "jsonpath": "$.assets..browser_download_url",
+        "regex": "(?<Release>[\\w_]+)/pegasus-fe_([\\w-]+)_win-mingw-static\\.zip"
     },
     "autoupdate": {
         "url": "https://github.com/mmatyas/pegasus-frontend/releases/download/$matchRelease/pegasus-fe_$version_win-mingw-static.zip"


### PR DESCRIPTION
Reason: In my testing on my computer: The previous checkver in this manifest did not always get the right version, or returned a regex error. This new checkver is always consistent, and it returns the correct version every time,

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
