### PR TITLE
dgvoodoo2: Add shorcut

### DIFF
--- a/bucket/dgvoodoo2.json
+++ b/bucket/dgvoodoo2.json
@@ -16,6 +16,12 @@
         "Some advanced features are not available through the dgVoodooCpl app, but can be set manually in the dgVoodoo.conf file.",
         ""
     ],
+      "shortcuts": [
+      [
+          "dgVoodooCpl.exe",
+          "dgVoodoo"
+      ]
+  ],
     "url": "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.79.3/dgVoodoo2_79_3.zip",
     "hash": "67e5ff5f647555f5cd39c6cee9ffa2ecadcd7c9f4fe3b75e33c17486223e2d41",
     "checkver": "github",


### PR DESCRIPTION
You can use one Control Panel to configure all the games you are using dgVoodoo2 with. So having a shortcut to it make sense.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
