### PR TITLE
raine@0.94.10: Fix hashes for dependencies

### DIFF
--- a/bucket/raine.json
+++ b/bucket/raine.json
@@ -11,7 +11,7 @@
             ],
             "hash": [
                 "acf526f900e37427fae1e855f907d0ac37f86f2839e105fb83e2780338e7d333",
-                "8289068505bb07b50863ff0a58fc7da7a3d9b51641c7420f9f5f2b5f5e00f072"
+                "f04dadf8dfb4e1b235baa4268e4d356756d7568efc2194ca35911d87d153fdcf"
             ],
             "extract_dir": "raine32",
             "bin": [
@@ -34,7 +34,7 @@
             ],
             "hash": [
                 "870936e521f97b422c37a9e5fb49821b53e92257a441746311bbe5955d6972b6",
-                "93e896789e0864dcebdb92bd5dcafd5eb214bff8e55957905099a2fa9ea611d2"
+                "0b312986da5acd806a0a247f5f8a6ba601cbfbb1e3671518b53d4fd5eb6754a4"
             ],
             "extract_dir": "raine64",
             "bin": [


### PR DESCRIPTION
The DLL packages were updated on the 5th and 6th of January 2023.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
