### PR TITLE
Update ryujinx-ava.json

### DIFF
--- a/bucket/ryujinx-ava.json
+++ b/bucket/ryujinx-ava.json
@@ -27,10 +27,10 @@
         "   }",
         "}"
     ],
-    "bin": "Ryujinx.Ava.exe",
+    "bin": "Ryujinx.exe",
     "shortcuts": [
         [
-            "Ryujinx.Ava.exe",
+            "Ryujinx.exe",
             "Ryujinx"
         ]
     ],


### PR DESCRIPTION
Fixes the incorrect binary filename in ryujinx-ava's current manifest.

Closes #781

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
