### PR TITLE
epic-games-launcher: Change `pre_install` to `post_install`

### DIFF
--- a/bucket/epic-games-launcher.json
+++ b/bucket/epic-games-launcher.json
@@ -8,7 +8,7 @@
     },
     "url": "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Win32/EpicInstaller-14.2.1.msi#/setup.msi_",
     "hash": "a60db9fc0b290f4bea8bc5729b6878d97392156979c1a47498bb27269e16915a",
-    "pre_install": [
+    "post_install": [
         "if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
         "Start-Process 'msiexec' -Wait -Verb 'RunAs' -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn', \"INSTALLDIR=$dir\", \"TARGETDIR=$dir\")",
         "Stop-Service -Name 'EpicOnlineServices' -Force -ErrorAction 'SilentlyContinue'; Stop-Process -Name 'EpicGamesLauncher' -Force -ErrorAction 'SilentlyContinue'"


### PR DESCRIPTION
This was done to allow the shortcut created by the installer to always point towards the 'current' directory instead of the version number '14.2.1'.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
