### PR TITLE
pcsx2-dev: Remove unnecessary persist entry

### DIFF
--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -52,7 +52,6 @@
         "logs",
         "memcards",
         "portable.ini",
-        "shaders\\GS_FX_Settings.ini",
         "snaps",
         "sstates",
         "textures"


### PR DESCRIPTION
It looks like PCSX2 has stopped using the `shaders\GS_FX_Settings.ini` file to store settings, causing an empty file to be created there when scoop installs the program. I believe the configuration has been moved to `inis\GS.ini` which is already persisted due to the entry for the `inis` directory.

Removing this line stops the unnecessary file from being created.