### PR TITLE
bgb: Update to version 1.5.10

### DIFF
--- a/bucket/bgb.json
+++ b/bucket/bgb.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.5.9",
+    "version": "1.5.10",
     "description": "GameBoy emulator/debugger",
     "homepage": "http://bgb.bircd.org/",
     "license": "Freeware",
     "architecture": {
         "32bit": {
             "url": "http://bgb.bircd.org/bgb.zip",
-            "hash": "79357345b5fccf91b632e4987c0b5aa0549a70b563085f8caad86ea8c7ceacf9",
+            "hash": "f05a7a8c526f97f43a93f65b33605277f5677bc43d1ad1f2a752c7326618365b",
             "bin": "bgb.exe",
             "shortcuts": [
                 [
@@ -17,7 +17,7 @@
         },
         "64bit": {
             "url": "http://bgb.bircd.org/bgbw64.zip",
-            "hash": "8685fc9daf09ceb384330ce543d05471fcc1d427c65de0d68875a97a57532763",
+            "hash": "1d7cb896e1c3a8aa6b56227f7c43e19887035dc956e11f73e739252381eb045d",
             "bin": "bgb64.exe",
             "shortcuts": [
                 [


### PR DESCRIPTION
This commit updates the version number and required download checksums for the Game Boy emulator BGB to the latest version released on 2022-10-22

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
