### PR TITLE
ppsspp(-dev): Remove extract_dir, bin, Add 32bit arch

### DIFF
--- a/bucket/ppsspp-dev.json
+++ b/bucket/ppsspp-dev.json
@@ -7,12 +7,6 @@
         "64bit": {
             "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.14.4-253-g03f64a021&platform=windows-amd64#/dl.zip",
             "hash": "71b76c6da2631df240a4f10248110213b09be77ea8988646663f4bbc85ec47b4",
-            "bin": [
-                [
-                    "PPSSPPWindows64.exe",
-                    "ppsspp-dev"
-                ]
-            ],
             "shortcuts": [
                 [
                     "PPSSPPWindows64.exe",
@@ -23,12 +17,6 @@
         "32bit": {
             "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.14.4-253-g03f64a021&platform=windows-x86#/dl.zip",
             "hash": "278208aed92284d70d9a0ffe3974f7137233e1b55a363be0dae26a154168817e",
-            "bin": [
-                [
-                    "PPSSPPWindows.exe",
-                    "ppsspp-dev"
-                ]
-            ],
             "shortcuts": [
                 [
                     "PPSSPPWindows.exe",

--- a/bucket/ppsspp.json
+++ b/bucket/ppsspp.json
@@ -7,12 +7,6 @@
         "64bit": {
             "url": "https://ppsspp.org/files/1_14_4/ppsspp_win.zip",
             "hash": "f4401ce34aae6233c0d3a163903ca035700bf3122eef2030dfc4d79b3e58055d",
-            "bin": [
-                [
-                    "PPSSPPWindows64.exe",
-                    "ppsspp"
-                ]
-            ],
             "shortcuts": [
                 [
                     "PPSSPPWindows64.exe",
@@ -20,15 +14,19 @@
                 ]
             ]
         },
+        "32bit": {
+            "url": "https://ppsspp.org/files/1_14_4/ppsspp_win.zip",
+            "hash": "f4401ce34aae6233c0d3a163903ca035700bf3122eef2030dfc4d79b3e58055d",
+            "shortcuts": [
+                [
+                    "PPSSPPWindows.exe",
+                    "PPSSPP"
+                ]
+            ]
+        },
         "arm64": {
             "url": "https://ppsspp.org/files/1_14_4/PPSSPPWindowsARM64.zip",
             "hash": "3190a21ce6fb63fd0e683c145916b760d7dcfdf432b443c8eeb7c88f23c2ef55",
-            "bin": [
-                [
-                    "PPSSPPWindowsARM64.exe",
-                    "ppsspp"
-                ]
-            ],
             "shortcuts": [
                 [
                     "PPSSPPWindowsARM64.exe",
@@ -37,7 +35,6 @@
             ]
         }
     },
-    "extract_dir": "ppsspp",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-item \"$persist_dir\" -ItemType Directory | Out-Null",
@@ -56,6 +53,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
+                "url": "https://ppsspp.org/files/$underscoreVersion/ppsspp_win.zip"
+            },
+            "32bit": {
                 "url": "https://ppsspp.org/files/$underscoreVersion/ppsspp_win.zip"
             },
             "arm64": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Remove `extract_dir`. Fixes #794 
- Remove `bin` as application is not a command-line app
- Add 32bit arch for `ppsspp`

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
