### PR TITLE
Rename `package-request` label to `new package` in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-request.yml
+++ b/.github/ISSUE_TEMPLATE/package-request.yml
@@ -1,7 +1,7 @@
 name: 📦 Package Request
 description: Open an issue about a missing package.
 title: "[Request]: "
-labels: ["package-request"]
+labels: ["new package"]
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Just noticed the label in this repo is `new package`

Related to #796

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
