### PR TITLE
crewchief: Add version 4.16.3.5

### DIFF
--- a/bucket/crewchief.json
+++ b/bucket/crewchief.json
@@ -1,6 +1,6 @@
 {
     "version": "4.16.3.5",
-    "description": "A team radio engineer compatible with iRacing, Assetto Corsa, Project Cars, and other racing games.",
+    "description": "Team radio engineer compatible with iRacing, Assetto Corsa, Project Cars, and other racing games",
     "homepage": "https://mr_belowski.gitlab.io/CrewChiefV4/index.html",
     "license": "MIT",
     "url": "https://thecrewchief.org/downloads/CrewChiefV4.msi",

--- a/bucket/crewchief.json
+++ b/bucket/crewchief.json
@@ -1,0 +1,23 @@
+{
+    "version": "4.16.3.5",
+    "description": "A team radio engineer compatible with iRacing, Assetto Corsa, Project Cars, and other racing games.",
+    "homepage": "https://mr_belowski.gitlab.io/CrewChiefV4/index.html",
+    "license": "MIT",
+    "url": "https://thecrewchief.org/downloads/CrewChiefV4.msi",
+    "hash": "926c47f4e4861d20010b67c9beb38f999ebcd898122f4710c84a20e027b00342",
+    "extract_dir": "Britton IT Ltd/CrewChiefV4",
+    "bin": "CrewChiefV4.exe",
+    "shortcuts": [
+        [
+            "CrewChiefV4.exe",
+            "CrewChiefV4"
+        ]
+    ],
+    "checkver": {
+        "url": "https://thecrewchief.org/downloads/change_log_for_auto_updated.html",
+        "regex": "Version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://thecrewchief.org/downloads/CrewChiefV4.msi"
+    }
+}


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).

From my personal scoop bucket https://github.com/scowalt/scoop-apps/blob/main/bucket/crewchief.json

I've tested autoupdate. I've also installed and been running this from my personal bucket for a bit