### PR TITLE
xenia-canary: Persist `patches` folder

### DIFF
--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -31,7 +31,8 @@
         "portable.txt",
         "xenia-canary.config.toml",
         "content",
-        "cache"
+        "cache",
+        "patches"
     ],
     "checkver": {
         "github": "https://github.com/xenia-canary/xenia-canary",


### PR DESCRIPTION
the patches folder is needed to keep created patches after a version is updated.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
