### PR TITLE
undertale-mod-tool@0.5.0.0: Fix shim

### DIFF
--- a/bucket/undertale-mod-tool.json
+++ b/bucket/undertale-mod-tool.json
@@ -5,6 +5,7 @@
     "license": "GPL-3.0-only",
     "url": "https://github.com/krzys-h/UndertaleModTool/releases/download/0.5.0.0/UndertaleModTool_v0.5.0.0.zip",
     "hash": "4a4a8ea6e87227d00d094ca49d1b7ac99d04f4b25aaf28edded00a715a2e0c9c",
+    "extract_dir": "UndertaleModTool_v0.5.0.0",
     "pre_install": "if (!(Test-Path \"$persist_dir\\UndertaleModTool.exe.config\")) { New-Item \"$dir\\UndertaleModTool.exe.config\" | Out-Null }",
     "bin": "UndertaleModTool.exe",
     "shortcuts": [
@@ -16,6 +17,7 @@
     "persist": "UndertaleModTool.exe.config",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/krzys-h/UndertaleModTool/releases/download/$version/UndertaleModTool_v$version.zip"
+        "url": "https://github.com/krzys-h/UndertaleModTool/releases/download/$version/UndertaleModTool_v$version.zip",
+        "extract_dir": "UndertaleModTool_v$version"
     }
 }


### PR DESCRIPTION
Fix for `Can't shim 'UndertaleModTool.exe': File doesn't exist.`

Closes #808

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
