### PR TITLE
openttd: Update to version 13.0, add checkver and autoupdate

### DIFF
--- a/bucket/openttd.json
+++ b/bucket/openttd.json
@@ -46,5 +46,18 @@
             "openttd.exe",
             "OpenTTD"
         ]
-    ]
+    ],
+    "checkver": "Download stable \\(([\\d\\.]+)\\)",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cdn.openttd.org/openttd-releases/$version/openttd-$version-windows-win32.zip",
+                "extract_dir": "openttd-$version-windows-win32"
+            },
+            "32bit": {
+                "url": "https://cdn.openttd.org/openttd-releases/$version/openttd-$version-windows-win64.zip",
+                "extract_dir": "openttd-$version-windows-win64"
+            }
+        }
+    }
 }

--- a/bucket/openttd.json
+++ b/bucket/openttd.json
@@ -1,38 +1,38 @@
 {
-    "version": "12.2",
+    "version": "13.0",
     "description": "Simulation game based upon Transport Tycoon Deluxe",
     "homepage": "https://www.openttd.org/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "32bit": {
             "url": [
-                "https://cdn.openttd.org/openttd-releases/12.2/openttd-12.2-windows-win32.zip",
+                "https://cdn.openttd.org/openttd-releases/13.0/openttd-13.0-windows-win64.zip",
                 "https://cdn.openttd.org/opengfx-releases/7.1/opengfx-7.1-all.zip",
                 "https://cdn.openttd.org/opensfx-releases/1.0.3/opensfx-1.0.3-all.zip",
                 "https://cdn.openttd.org/openmsx-releases/0.4.2/openmsx-0.4.2-all.zip"
             ],
             "hash": [
-                "67cd412950080803be3e016f41ae6f369bfc4947f4e30fe694a36f05f43db922",
+                "c5d570de154cdec82521f43a72de270cbaeca518a3200442b8ac2fa14e045cd1",
                 "928fcf34efd0719a3560cbab6821d71ce686b6315e8825360fba87a7a94d7846",
                 "e0a218b7dd9438e701503b0f84c25a97c1c11b7c2f025323fb19d6db16ef3759",
                 "5a4277a2e62d87f2952ea5020dc20fb2f6ffafdccf9913fbf35ad45ee30ec762"
             ],
-            "extract_dir": "openttd-12.2-windows-win32"
+            "extract_dir": "openttd-13.0-windows-win64"
         },
         "64bit": {
             "url": [
-                "https://cdn.openttd.org/openttd-releases/12.2/openttd-12.2-windows-win64.zip",
+                "https://cdn.openttd.org/openttd-releases/13.0/openttd-13.0-windows-win32.zip",
                 "https://cdn.openttd.org/opengfx-releases/7.1/opengfx-7.1-all.zip",
                 "https://cdn.openttd.org/opensfx-releases/1.0.3/opensfx-1.0.3-all.zip",
                 "https://cdn.openttd.org/openmsx-releases/0.4.2/openmsx-0.4.2-all.zip"
             ],
             "hash": [
-                "73f7b6b23dc0c6242c9dbc219128fd49093384f6f09900be7dff00e15723454f",
+                "53abf0ee7816d33137b539d48779d0df1715b17c70d08d7bf708f38aa3a3cb69",
                 "928fcf34efd0719a3560cbab6821d71ce686b6315e8825360fba87a7a94d7846",
                 "e0a218b7dd9438e701503b0f84c25a97c1c11b7c2f025323fb19d6db16ef3759",
                 "5a4277a2e62d87f2952ea5020dc20fb2f6ffafdccf9913fbf35ad45ee30ec762"
             ],
-            "extract_dir": "openttd-12.2-windows-win64"
+            "extract_dir": "openttd-13.0-windows-win32"
         }
     },
     "pre_install": [


### PR DESCRIPTION
This adds `checkver` and `autoupdate` properties to the OpenTTD manifest.

I have also used the `checkver` tool to update the manifest to v13.0 (after my own changes).

Closes #817. Related to #413 from 2021 which has not been merged yet.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
