### PR TITLE
flycast: Update to version 2.1

### DIFF
--- a/bucket/flycast.json
+++ b/bucket/flycast.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0",
+    "version": "2.1",
     "description": "Flycast is a multi-platform Sega Dreamcast, Naomi and Atomiswave emulator derived from reicast",
     "homepage": "https://github.com/flyinghead/flycast",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/flyinghead/flycast/releases/download/v2.0/flycast-win64-2.0.zip",
-            "hash": "8b3f3f5aa7a4fa0ff06d88465206382fae101f6b0c6f8d1d509211aa09c6ddfc"
+            "url": "https://github.com/flyinghead/flycast/releases/download/V2.1/flycast-win64-2.1.zip",
+            "hash": "bc12e2a145c09ba982a6be0096b56a063a58e8b2b0aa6dfe01297ef7e4106099"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\emu.cfg\")) { New-Item -ItemType File \"$dir\\emu.cfg\" | Out-Null }",


### PR DESCRIPTION
Version 2.1 uses a capitalized V in the version tag, unlike previous releases. This caused autoupdate to fail.

I changed the autoupdate url to use a capital V, ran checkver, then reverted it to an uncapitalized v, since I assume this was a one-time mistake, and future releases will use the uncapitalized letter again.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
