### PR TITLE
racelab@3.7.2: Fix trailing whitespace

### DIFF
--- a/bucket/racelab.json
+++ b/bucket/racelab.json
@@ -5,9 +5,7 @@
     "homepage": "https://racelab.app",
     "url": "https://update.racelab.app/RacelabApps-3.7.2%20Setup.exe",
     "hash": "be8da8f2349f591963f5baacc9d5270fc00b2f3660c4bee1f0ad1e5792f2cf0b",
-    "installer": {
-        
-    },
+    "installer": {},
     "uninstaller": {
         "script": "Invoke-Expression -Command \"$env:LOCALAPPDATA\\RacelabApps\\Update.exe --uninstall\""
     },


### PR DESCRIPTION
For some reason, the bot is producing invalid JSON manifests, namely with trailing whitespaces.

I used VSCodium to format this back to something that should be valid hopefully, let's see.

Hopefully someone with a programming mind is able to fix the bot's wrongdoings.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
