### PR TITLE
tf2-hud-editor: Update to version 3.1, fix `extract_dir`

### DIFF
--- a/bucket/tf2-hud-editor.json
+++ b/bucket/tf2-hud-editor.json
@@ -7,12 +7,12 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.1/tf2hud-editor-x64.zip",
-            "hash": "e23d8af67f952249e8ba28d1dc29332fadf587df3060cd6bcdfef5caeac54899",
+            "hash": "21bc402868be88a2976a4eec78ce3ba7c34662b0b0f7f0144790abbe02967d84",
             "extract_dir": "tf2hud-editor"
         },
         "32bit": {
             "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.1/tf2hud-editor-x86.zip",
-            "hash": "ed6cf2724d11b82bcd010b10f6b4d9b058846168622f3ef09dec6cc090f2cdaf",
+            "hash": "4f0546d692cdafe4253be5e92bba5460d5fc3497b0ea14d0a2dd51504289c4b5",
             "extract_dir": "tf2hud-editor"
         }
     },
@@ -28,10 +28,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/$version/tf2-hud-editor-x64.zip"
+                "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/$version/tf2hud-editor-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/$version/tf2-hud-editor-x86.zip"
+                "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/$version/tf2hud-editor-x86.zip"
             }
         }
     }

--- a/bucket/tf2-hud-editor.json
+++ b/bucket/tf2-hud-editor.json
@@ -6,12 +6,12 @@
     "notes": ".NET 7.0 Runtime is required.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.1/tf2-hud-editor-x64.zip",
+            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.1/tf2hud-editor-x64.zip",
             "hash": "e23d8af67f952249e8ba28d1dc29332fadf587df3060cd6bcdfef5caeac54899",
             "extract_dir": "tf2hud-editor"
         },
         "32bit": {
-            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.1/tf2-hud-editor-x86.zip",
+            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.1/tf2hud-editor-x86.zip",
             "hash": "ed6cf2724d11b82bcd010b10f6b4d9b058846168622f3ef09dec6cc090f2cdaf",
             "extract_dir": "tf2hud-editor"
         }

--- a/bucket/tf2-hud-editor.json
+++ b/bucket/tf2-hud-editor.json
@@ -1,19 +1,19 @@
 {
-    "version": "3.0",
+    "version": "3.1",
     "description": "Install and customize your favorite custom Team Fortress 2 HUDs",
     "homepage": "https://criticalflaw.ca/TF2HUD.Editor",
     "license": "MIT",
-    "notes": ".NET 6.0 Runtime is required.",
+    "notes": ".NET 7.0 Runtime is required.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.0/tf2-hud-editor-x64.zip",
+            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.1/tf2-hud-editor-x64.zip",
             "hash": "e23d8af67f952249e8ba28d1dc29332fadf587df3060cd6bcdfef5caeac54899",
-            "extract_dir": "tf2-hud-editor"
+            "extract_dir": "tf2hud-editor"
         },
         "32bit": {
-            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.0/tf2-hud-editor-x86.zip",
+            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.1/tf2-hud-editor-x86.zip",
             "hash": "ed6cf2724d11b82bcd010b10f6b4d9b058846168622f3ef09dec6cc090f2cdaf",
-            "extract_dir": "tf2-hud-editor"
+            "extract_dir": "tf2hud-editor"
         }
     },
     "shortcuts": [


### PR DESCRIPTION

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).