### PR TITLE
(chore): Ensure vscode saves newlines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -106,7 +106,8 @@
         "autoupdate"
     ],
     "[json]": {
-        "editor.defaultFormatter": "vscode.json-language-features"
+        "editor.defaultFormatter": "vscode.json-language-features",
+        "files.insertFinalNewline": true
     },
     "editor.defaultFormatter": "richie5um2.vscode-sort-json",
     "editor.formatOnSave": true,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Without this option, vscode removes newlines which causes tests to fail.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
