### PR TITLE
pcsx2-dev: Update to version 1.7.4436

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -106,7 +106,8 @@
         "autoupdate"
     ],
     "[json]": {
-        "editor.defaultFormatter": "vscode.json-language-features"
+        "editor.defaultFormatter": "vscode.json-language-features",
+        "files.insertFinalNewline": true
     },
     "editor.defaultFormatter": "richie5um2.vscode-sort-json",
     "editor.formatOnSave": true,

--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.7.4287",
+    "version": "1.7.4436",
     "description": "A feature rich FOSS PlayStation 2 emulator (development version)",
     "homepage": "https://pcsx2.net/",
     "license": {
@@ -16,8 +16,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/PCSX2/pcsx2/releases/download/v1.7.4287/pcsx2-v1.7.4287-windows-64bit-AVX2-Qt.7z",
-            "hash": "26df67fc53b69cd3aef54abaf200c2d2ac97cc681b917a80d19153943fe8f687"
+            "url": "https://github.com/PCSX2/pcsx2/releases/download/v1.7.4436/pcsx2-v1.7.4436-windows-64bit-Qt.7z",
+            "hash": "64a3760ba09f454dc74f23d79812acafe5d2ca4b66bb03b166b96c9ef294bb64"
         }
     },
     "pre_install": [

--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -36,13 +36,13 @@
     ],
     "bin": [
         [
-            "pcsx2-qtx64-avx2.exe",
+            "pcsx2-qt.exe",
             "pcsx2-dev"
         ]
     ],
     "shortcuts": [
         [
-            "pcsx2-qtx64-avx2.exe",
+            "pcsx2-qt.exe",
             "PCSX2 (dev)"
         ]
     ],

--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -14,8 +14,12 @@
     "suggest": {
         "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
     },
-    "url": "https://github.com/PCSX2/pcsx2/releases/download/v1.7.4287/pcsx2-v1.7.4287-windows-64bit-AVX2-Qt.7z",
-    "hash": "26df67fc53b69cd3aef54abaf200c2d2ac97cc681b917a80d19153943fe8f687",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PCSX2/pcsx2/releases/download/v1.7.4287/pcsx2-v1.7.4287-windows-64bit-AVX2-Qt.7z",
+            "hash": "26df67fc53b69cd3aef54abaf200c2d2ac97cc681b917a80d19153943fe8f687"
+        }
+    },
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
@@ -62,6 +66,10 @@
         "replace": "${basever}.${build}"
     },
     "autoupdate": {
-        "url": "https://github.com/PCSX2/pcsx2/releases/download/v$version/pcsx2-v$version-windows-64bit-Qt.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PCSX2/pcsx2/releases/download/v$version/pcsx2-v$version-windows-64bit-Qt.7z"
+            }
+        }
     }
 }

--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -62,6 +62,6 @@
         "replace": "${basever}.${build}"
     },
     "autoupdate": {
-        "url": "https://github.com/PCSX2/pcsx2/releases/download/v$version/pcsx2-v$version-windows-64bit-AVX2-Qt.7z"
+        "url": "https://github.com/PCSX2/pcsx2/releases/download/v$version/pcsx2-v$version-windows-64bit-Qt.7z"
     }
 }

--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -61,9 +61,9 @@
         "textures"
     ],
     "checkver": {
-        "url": "https://github.com/PCSX2/pcsx2/releases.atom",
-        "regex": "v(?<basever>\\d+\\.\\d+)\\.(?<build>\\d+)",
-        "replace": "${basever}.${build}"
+        "url": "https://api.github.com/repos/PCSX2/pcsx2/releases?per_page=1",
+        "jsonpath": "$[?(@.prerelease == true)].tag_name",
+        "regex": "v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
https://github.com/PCSX2/pcsx2/releases/tag/v1.7.4288 dropped AVX2 builds which broke autoupdate.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
