### PR TITLE
Bloxstrap: Remove 32bit version and update to 2.3.0

### DIFF
--- a/bucket/bloxstrap.json
+++ b/bucket/bloxstrap.json
@@ -1,16 +1,12 @@
 {
-    "version": "2.2.0",
+    "version": "2.3.0",
     "homepage": "https://github.com/pizzaboxer/bloxstrap",
     "description": "Open-source, feature-packed alternative bootstrapper for Roblox",
     "license": "MIT",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/pizzaboxer/bloxstrap/releases/download/v2.2.0/Bloxstrap-v2.2.0-x86.exe#/setup.exe",
-            "hash": "95393dd1f6b2b4888fceabc57ed02ff08a78245fc83ceaf4e39475e14b841fcd"
-        },
         "64bit": {
-            "url": "https://github.com/pizzaboxer/bloxstrap/releases/download/v2.2.0/Bloxstrap-v2.2.0-x64.exe#/setup.exe",
-            "hash": "a295fb33e265d9d0b4e3da64e2f0b3e7123fc832cb3e4c0e3e7b5b03bcfcab6f"
+            "url": "https://github.com/pizzaboxer/bloxstrap/releases/download/v2.3.0/Bloxstrap-v2.3.0-x64.exe#/setup.exe",
+            "hash": "385f9ac853fcc9d165c8e9d6af751f2b9897da992e239d2f5be0177bafc0dcf8"
         }
     },
     "pre_install": [
@@ -26,9 +22,6 @@
     "checkver": "github",
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/pizzaboxer/bloxstrap/releases/download/v$version/Bloxstrap-v$version-x86.exe#/setup.exe"
-            },
             "64bit": {
                 "url": "https://github.com/pizzaboxer/bloxstrap/releases/download/v$version/Bloxstrap-v$version-x64.exe#/setup.exe"
             }


### PR DESCRIPTION
The developer no longer supports 32bit version, because the Roblox client is now 64bit.


- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
