### PR TITLE
rmg; Rosalie's Mupen GUI: Add version 0.4.0

### DIFF
--- a/bucket/rmg.json
+++ b/bucket/rmg.json
@@ -21,6 +21,6 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Rosalie241/RMG/releases/download/v$version/RMG-Portable-Windows64-v$version.7z"
+        "url": "https://github.com/Rosalie241/RMG/releases/download/v$version/RMG-Portable-Windows64-v$version.zip"
     }
 }

--- a/bucket/rmg.json
+++ b/bucket/rmg.json
@@ -1,6 +1,6 @@
 {
     "version": "0.4.0",
-    "description": "Rosalie's Mupen GUI is a free and open-source mupen64plus GUI",
+    "description": "Rosalie's Mupen GUI is a free and open source mupen64plus GUI",
     "homepage": "https://github.com/Rosalie241/RMG",
     "license": "GPL-3.0-only",
     "url": "https://github.com/Rosalie241/RMG/releases/download/v0.4.0/RMG-Portable-Windows64-v0.4.0.zip",

--- a/bucket/rmg.json
+++ b/bucket/rmg.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.4.0",
+    "description": "Rosalie's Mupen GUI is a free and open-source mupen64plus GUI written in C++.",
+    "homepage": "https://github.com/Rosalie241/RMG",
+    "license": "GPL-3.0-only",
+    "url": "https://github.com/Rosalie241/RMG/releases/download/v0.4.0/RMG-Portable-Windows64-v0.4.0.zip",
+    "hash": "1db16d9ba413959da186776ade1b69d553daaaa718a6c6b47aecfb0a29884aa7",
+    "bin": "RMG.exe",
+    "shortcuts": [
+        [
+            "RMG.exe",
+            "Rosalie's Mupen GUI"
+        ]
+    ],
+    "persist": [
+        "Cache",
+        "Config",
+        "Data",
+        "Save",
+        "Screenshots"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/Rosalie241/RMG/releases/download/v$version/RMG-Portable-Windows64-v$version.7z"
+    }
+}

--- a/bucket/rmg.json
+++ b/bucket/rmg.json
@@ -1,6 +1,6 @@
 {
     "version": "0.4.0",
-    "description": "Rosalie's Mupen GUI is a free and open-source mupen64plus GUI written in C++.",
+    "description": "Rosalie's Mupen GUI is a free and open-source mupen64plus GUI",
     "homepage": "https://github.com/Rosalie241/RMG",
     "license": "GPL-3.0-only",
     "url": "https://github.com/Rosalie241/RMG/releases/download/v0.4.0/RMG-Portable-Windows64-v0.4.0.zip",


### PR DESCRIPTION
Rosalie's Mupen GUI is a free and open-source mupen64plus GUI written in C++.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
