### PR TITLE
nethack: update to 3.6.7 and use official site for download, add hash checking

### DIFF
--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -24,7 +24,8 @@
     "autoupdate": {
         "url": "https://www.nethack.org/download/$version/nethack-$cleanVersion-win-x86.zip",
         "hash": {
-            "url": "$url.sha256sum"
+            "url": "$url.sha256sum",
+            "regex": "\\n$sha256"
         }
     }
 }

--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -24,8 +24,7 @@
     "autoupdate": {
         "url": "https://www.nethack.org/download/$version/nethack-$cleanVersion-win-x86.zip",
         "hash": {
-            "url": "$url.sha256sum",
-            "regex": "^[a-fA-F0-9]{64}$"
+            "url": "$url.sha256sum"
         }
     }
 }

--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -19,12 +19,13 @@
     ],
     "checkver": {
         "url": "https://www.nethack.org/download/",
-        "regex": "Version ([\\d\\.]+)"
+        "regex": "([\\d\\.]+)"
     },
     "autoupdate": {
         "url": "https://www.nethack.org/download/$version/nethack-$cleanVersion-win-x86.zip",
         "hash": {
-            "url": "$baseurl.sha256sum"
+            "url": "$url.sha256sum",
+            "regex": "^[a-fA-F0-9]{64}$"
         }
     }
 }

--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -18,8 +18,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.nethack.org/download/",
-        "regex": "([\\d.]+)"
+        "github": "https://github.com/NetHack/NetHack",
+        "regex": "Release build of NetHack ([\\d\\.]+)"
     },
     "autoupdate": {
         "url": "https://www.nethack.org/download/$version/nethack-$cleanVersion-win-x86.zip",

--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -23,6 +23,8 @@
     },
     "autoupdate": {
         "url": "https://www.nethack.org/download/$version/nethack-$cleanVersion-win-x86.zip",
-        "hash": "$baseurl.sha256sum"
+        "hash": {
+            "url": "$baseurl.sha256sum"
+        }
     }
 }

--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -19,7 +19,7 @@
     ],
     "checkver": {
         "url": "https://www.nethack.org/download/",
-        "regex": "([\\d\\.]+)"
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://www.nethack.org/download/$version/nethack-$cleanVersion-win-x86.zip",

--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -1,10 +1,10 @@
 {
-    "version": "3.6.6",
+    "version": "3.6.7",
     "description": "Single player rogue-like videogame",
     "homepage": "https://www.nethack.org",
     "license": "NGPL",
-    "url": "https://github.com/NetHack/NetHack/releases/download/NetHack-3.6.6_Released/NetHack-3.6.6_Released.x86.zip",
-    "hash": "681799e42d7527621f27a30aee7efa5c2d61cd8ae97a9b7105460ea4c238b978",
+    "url": "https://www.nethack.org/download/3.6.7/nethack-367-win-x86.zip",
+    "hash": "eed14e4a8f2cdc5bed6d220602b1649bcf9f89c3916330b298ef947d2539cb69",
     "post_install": "nethack --showpaths",
     "bin": "NetHack.exe",
     "shortcuts": [
@@ -18,10 +18,13 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/NetHack/NetHack",
-        "regex": "Release build of NetHack ([\\d\\.]+)"
+        "url": "https://www.nethack.org/download/",
+        "regex": "Version ([\\d\\.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/NetHack/NetHack/releases/download/NetHack-$version_Released/NetHack-$version_Released.x86.zip"
+        "url": "https://www.nethack.org/download/$version/nethack-$cleanVersion-win-x86.zip"
+    },
+        "hash": {
+            "url": "$baseurl.sha256sum"
     }
 }

--- a/bucket/nethack.json
+++ b/bucket/nethack.json
@@ -22,9 +22,7 @@
         "regex": "Version ([\\d\\.]+)"
     },
     "autoupdate": {
-        "url": "https://www.nethack.org/download/$version/nethack-$cleanVersion-win-x86.zip"
-    },
-        "hash": {
-            "url": "$baseurl.sha256sum"
+        "url": "https://www.nethack.org/download/$version/nethack-$cleanVersion-win-x86.zip",
+        "hash": "$baseurl.sha256sum"
     }
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The developers have stopped uploading releases to Github. This PR changes the download url to the nethack site, and introduces hash checking.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
