### PR TITLE
Update slade to install with latest vcredist

### DIFF
--- a/bucket/slade.json
+++ b/bucket/slade.json
@@ -3,7 +3,7 @@
     "description": "Level and resource editor for Doom engine games",
     "homepage": "http://slade.mancubus.net/",
     "license": "GPL-2.0-or-later",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "url": "http://slade.mancubus.net/files/3.2.3/slade_3.2.3.7z",
     "hash": "6a08975773ad237869ff08e8c9febb7fc4db07a0fd3f22348b1b23a305e0f4ac",
     "bin": "SLADE.exe",


### PR DESCRIPTION
Currently receive a "Couldn't find manifest for 'vcredist2015'." when attempting to upgrade as older vcredists were removed as part of this PR: https://github.com/ScoopInstaller/Extras/pull/11357



- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
