### PR TITLE
duckstation: Fix persist

### DIFF
--- a/bucket/duckstation-preview.json
+++ b/bucket/duckstation-preview.json
@@ -15,10 +15,15 @@
     "hash": "fd70fefebe4033c0ae7078079d832406afb6e69a076d01e4f712c079d7c8e0ef",
     "installer": {
         "script": [
+            "New-item \"$dir\\portable.txt\" -ItemType File | Out-Null",
             "if (!(Test-Path \"$persist_dir\")) {",
-            "   '[Main]', 'SettingsVersion = 3', '[AutoUpdater]', 'CheckAtStartup = false' | Set-Content \"$dir\\settings.ini\"",
-            "   New-item \"$dir\\portable.txt\" -ItemType File | Out-Null",
+            "  '[Main]', 'SettingsVersion = 3', '[AutoUpdater]', 'CheckAtStartup = false' | Set-Content \"$dir\\settings.ini\"",
             "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Copy-Item \"$dir\\settings.ini\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
         ]
     },
     "shortcuts": [
@@ -32,17 +37,14 @@
         "cache",
         "cheats",
         "covers",
-        "database\\chtdb.txt",
-        "database\\gamecontrollerdb.txt",
-        "database\\gamesettings.ini",
         "dump",
+        "gamesettings",
         "inputprofiles",
         "memcards",
         "savestates",
         "screenshots",
         "shaders",
         "textures",
-        "portable.txt",
         "settings.ini"
     ],
     "checkver": {

--- a/bucket/duckstation.json
+++ b/bucket/duckstation.json
@@ -15,10 +15,15 @@
     "hash": "be682525515184c7cd829836014ea06569ea215930c4d796a25fd0b33cf06de9",
     "installer": {
         "script": [
+            "New-item \"$dir\\portable.txt\" -ItemType File | Out-Null",
             "if (!(Test-Path \"$persist_dir\")) {",
-            "   '[Main]', 'SettingsVersion = 3', '[AutoUpdater]', 'CheckAtStartup = false' | Set-Content \"$dir\\settings.ini\"",
-            "   New-item \"$dir\\portable.txt\" -ItemType File | Out-Null",
+            "  '[Main]', 'SettingsVersion = 3', '[AutoUpdater]', 'CheckAtStartup = false' | Set-Content \"$dir\\settings.ini\"",
             "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Copy-Item \"$dir\\settings.ini\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
         ]
     },
     "shortcuts": [
@@ -32,17 +37,14 @@
         "cache",
         "cheats",
         "covers",
-        "database\\chtdb.txt",
-        "database\\gamecontrollerdb.txt",
-        "database\\gamesettings.ini",
         "dump",
+        "gamesettings",
         "inputprofiles",
         "memcards",
         "savestates",
         "screenshots",
         "shaders",
         "textures",
-        "portable.txt",
         "settings.ini"
     ],
     "checkver": {


### PR DESCRIPTION
Duckstation updated their config directories around a year ago. Update to be aligned with those changes and properly persist settings on update.

[Config Definitions](https://github.com/stenzek/duckstation/blame/2d78b3f26a18600cbeb1f7add97f345d7345deeb/src/core/settings.cpp#L1309)
[Relevant Commit](https://github.com/stenzek/duckstation/commit/b42b5501f69329a6b808e939c1e26918e3d59a96#diff-a476025c9c14eb09c2b1798d364d676742cd7ea831e5b749b292ad383c490cbcR1150)


- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
