### PR TITLE
loot: Update to version 0.20.0

### DIFF
--- a/bucket/loot.json
+++ b/bucket/loot.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.19.1",
+    "version": "0.20.0",
     "description": "Plugin load order optimisation tool for The Elder Scrolls and Fallout series",
     "homepage": "https://loot.github.io",
     "license": "GPL-3.0-or-later",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/loot/loot/releases/download/0.19.1/loot_0.19.1-win64.7z",
-            "hash": "bf9f2a3bc5ac381a3def7c1673a721115160e3a4ffbdcb197947c1dbd3bd1365"
+            "url": "https://github.com/loot/loot/releases/download/0.20.0/loot_0.20.0-win64.7z",
+            "hash": "171c7f17684c917cb8ada65d90f204ad5134aac353b63f1c35c6274aa67aee6c"
         }
     },
     "pre_install": [

--- a/bucket/loot.json
+++ b/bucket/loot.json
@@ -10,10 +10,6 @@
         "64bit": {
             "url": "https://github.com/loot/loot/releases/download/0.19.1/loot_0.19.1-win64.7z",
             "hash": "bf9f2a3bc5ac381a3def7c1673a721115160e3a4ffbdcb197947c1dbd3bd1365"
-        },
-        "32bit": {
-            "url": "https://github.com/loot/loot/releases/download/0.19.1/loot_0.19.1-win32.7z",
-            "hash": "41a0f4edace68acae4ce63a69944f39aceeac905ba4b6233bcfb6b51fff71d70"
         }
     },
     "pre_install": [
@@ -34,9 +30,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/loot/loot/releases/download/$version/loot_$version-win64.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/loot/loot/releases/download/$version/loot_$version-win32.7z"
             }
         }
     }

--- a/bucket/loot.json
+++ b/bucket/loot.json
@@ -4,7 +4,7 @@
     "homepage": "https://loot.github.io",
     "license": "GPL-3.0-or-later",
     "suggest": {
-        "Visual C++ Redistributable 2019": "extras/vcredist2019"
+        "vcredist": "extras/vcredist2022"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fixed autoupdate since 32-bit support was dropped.

https://loot.readthedocs.io/en/latest/app/changelog.html

>Removed
>Support for Windows 7 and 8.1, and 32-bit Windows 10. LOOT now requires 64-bit Windows 10 or 11.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
