### PR TITLE
citra.json: Fix `extract_dir`

### DIFF
--- a/bucket/citra.json
+++ b/bucket/citra.json
@@ -8,7 +8,7 @@
     },
     "url": "https://github.com/citra-emu/citra-nightly/releases/download/nightly-1975/citra-windows-msvc-20230820-cf54210.7z",
     "hash": "2fca5bcdc523ad318e27f5fef4e73cbd492c385dbc706e9c35b69f1517c28ffb",
-    "extract_dir": "nightly-mingw",
+    "extract_dir": "nightly",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\user\")) {",
         "   New-Item -Path \"$persist_dir\" -Name \"user\" -ItemType \"directory\" | Out-Null",


### PR DESCRIPTION
Should fix `Could not find 'nightly-mingw'! (error 16)` for Citra 1975-20230820.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
