### PR TITLE
dxvk: Add extract_dir property

### DIFF
--- a/bucket/dxvk.json
+++ b/bucket/dxvk.json
@@ -16,8 +16,10 @@
     ],
     "url": "https://github.com/doitsujin/dxvk/releases/download/v2.3/dxvk-2.3.tar.gz",
     "hash": "8059c06fc84a864122cc572426f780f35921eb4e3678dc337e9fd79ee5a427c0",
+    "extract_dir": "dxvk-2.3",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/doitsujin/dxvk/releases/download/v$version/dxvk-$version.tar.gz"
+        "url": "https://github.com/doitsujin/dxvk/releases/download/v$version/dxvk-$version.tar.gz",
+        "extract_dir": "dxvk-$version"
     }
 }


### PR DESCRIPTION
This makes sure that the dirs for the different architectures are what you see when entering the root folder for the software – rather than just another dir with the software name and the current version appended, which is simply redundant.


Closes #1018


- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
