### PR TITLE
steam: Add nightly version

### DIFF
--- a/bucket/steam.json
+++ b/bucket/steam.json
@@ -1,0 +1,27 @@
+{
+    "version": "nightly",
+    "description": "The digital hardware and software store by Valve Corporation.",
+    "homepage": "https://store.steampowered.com/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://store.steampowered.com/legal/"
+    },
+    "url": "https://steamcdn-a.akamaihd.net/client/installer/SteamSetup.exe#/dl.7z",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
+    "uninstaller": {
+        "file": "uninstall.exe",
+        "args": "/S"
+    },
+    "bin": "Steam.exe",
+    "shortcuts": [
+        [
+            "Steam.exe",
+            "Steam"
+        ]
+    ],
+    "persist": [
+        "skins",
+        "steamapps",
+        "userdata"
+    ]
+}

--- a/bucket/steam.json
+++ b/bucket/steam.json
@@ -1,6 +1,6 @@
 {
     "version": "nightly",
-    "description": "The digital hardware and software store by Valve Corporation.",
+    "description": "The gaming hardware and software store by Valve Corporation.",
     "homepage": "https://store.steampowered.com/",
     "license": {
         "identifier": "Freeware",

--- a/bucket/steam.json
+++ b/bucket/steam.json
@@ -1,6 +1,6 @@
 {
     "version": "nightly",
-    "description": "The gaming hardware and software store by Valve Corporation.",
+    "description": "Gaming hardware and software store by Valve Corporation",
     "homepage": "https://store.steampowered.com/",
     "license": {
         "identifier": "Freeware",


### PR DESCRIPTION
Since other stores like Epic Games, GOG and Battle.net are in place, it only makes sense to add the most popular one as well.

Credit goes to the original author @rashil2000 over on the [versions bucket](https://github.com/ScoopInstaller/Versions).

I made smaller adjustments as I saw fit, mainly omitting the mention of creating a separate library folder (worded as “HIGHLY recommended”), as that option is presented every time you install a game.

I also removed the _-dev_ argument from the shortcut since any arguments should be up to the individual user – not applied by default, at least not something that's not necessarily universally desired. ([Reference](https://developer.valvesoftware.com/wiki/Command_line_options#Command-Line_Parameters))

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
