### PR TITLE
prismlauncher@8.0: disable built-in updater

### DIFF
--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -37,7 +37,8 @@
         "        New-Item -Type File $dir/$_ | Out-Null",
         "    }",
         "}",
-        "Add-Content $dir/metacache '{}'"
+        "Add-Content $dir/metacache '{}'",
+        "Remove-Item $original_dir/prismlauncher_updater.exe"
     ],
     "post_install": [
         "'install-associations', 'uninstall-associations' | ForEach-Object {",


### PR DESCRIPTION
this disables the builtin updater introduced in 8.0, allowing scoop to continue to manage prism by itself.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
