### PR TITLE
fix infraarcana install

### DIFF
--- a/bucket/infraarcana.json
+++ b/bucket/infraarcana.json
@@ -11,7 +11,7 @@
         "64bit": {
             "url": "https://gitlab.com/martin-tornqvist/ia/-/jobs/2306331827/artifacts/download#/dl.zip",
             "hash": "a897f0c3ba1ae7590fbc70e1a7a9611e92bff4dcb4b9ca1e56c5c0477bb01110",
-            "extract_dir": "ia windows x64 3aee05d9 2022-04-07"
+            "extract_dir": "ia-windows-x64-v21.0.1-3aee05d9-2022-04-07"
         }
     },
     "shortcuts": [
@@ -33,7 +33,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://gitlab.com/martin-tornqvist/ia/-/jobs/$matchJob/artifacts/download#/dl.zip",
-                "extract_dir": "ia windows x64 $matchCommit $matchYear-$matchMonth-$matchDay"
+                "extract_dir": "ia-windows-x64-v21.0.1-$matchCommit-$matchYear-$matchMonth-$matchDay"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1056

Note that this is likely not a real final fix but opening it as a draft - the real final fix is probably something like:

```
ia-windows-x64-v21.0.1-$matchCommit-$matchYear-$matchMonth-$matchDay
```

But I don't know how to test that. According to https://github.com/ScoopInstaller/Scoop/issues/2263#issuecomment-389853826 the ext_dir variables are substituted in the auto_update

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
