### PR TITLE
gzdoom: Update GitHub URLs

### DIFF
--- a/bucket/gzdoom.json
+++ b/bucket/gzdoom.json
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/coelckers/gzdoom/releases/download/g4.11.3/gzdoom-4-11-3-Windows-64bit.zip",
-            "hash": "64b7248e6638fe7699135812cb4a7b7d7b9cd818cc6ad6ae677e39f4aef795b4"
+            "url": "https://github.com/ZDoom/gzdoom/releases/download/g4.11.3/gzdoom-4-11-3.a.-Windows-64bit.zip",
+            "hash": "9ba87f54b7da13d65ef295404480441f727479b44efb65a51dae54691e2786b7"
         }
     },
     "pre_install": [
@@ -34,13 +34,13 @@
         "Screenshots"
     ],
     "checkver": {
-        "github": "https://github.com/coelckers/gzdoom",
+        "github": "https://github.com/ZDoom/gzdoom",
         "regex": "/releases/tag/(?:g)?([\\w.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/coelckers/gzdoom/releases/download/g$version/gzdoom-$dashVersion-Windows-64bit.zip"
+                "url": "https://github.com/ZDoom/gzdoom/releases/download/g$version/gzdoom-$dashVersion-Windows-64bit.zip"
             }
         }
     }


### PR DESCRIPTION
Relates to #1051

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).

GZDoom moved from https://github.com/coelckers/gzdoom -> https://github.com/ZDoom/gzdoom.

This corrects those URLs and the links to the correct download.

Note it doesn't necessarily close #1051, as there are two other issues there:
1. The autoupdate bot didn't detect download failure in this case, according to the issue.
2. The Windows artifact for release 4.11.3 changed from `gzdoom-4-11-3-Windows-64bit.zip` -> `gzdoom-4-11-3.a.-Windows-64bit.zip`. Hash is also different. This pull request reflects the changed name, but I don't think the autoupdate mechanism could handle such a manual change.