### PR TITLE
raine@0.96.4: Fix dependency URLs

### DIFF
--- a/bucket/raine.json
+++ b/bucket/raine.json
@@ -7,11 +7,11 @@
         "32bit": {
             "url": [
                 "https://raine.1emulation.com/archive/raine32-0.96.4.7z",
-                "https://raine.1emulation.com/archive/dlls32-0.95.7z"
+                "https://raine.1emulation.com/archive/dlls32-0.96.7z"
             ],
             "hash": [
                 "edec58ed1521551b2326030ece4cc4c446c9447f459591370f81ca6776004028",
-                "6623542ffc992d7a481c9f44dcb9a39a265712ba6407b0a3680ff85caceb1f0b"
+                "50001a8768ee57134403cda1fb7c87141dfed3e1b19ab36ec9278eae2a9667dd"
             ],
             "extract_dir": "raine32",
             "bin": [
@@ -30,11 +30,11 @@
         "64bit": {
             "url": [
                 "https://raine.1emulation.com/archive/raine64-0.96.4.7z",
-                "https://raine.1emulation.com/archive/dlls64-0.95.7z"
+                "https://raine.1emulation.com/archive/dlls64-0.96.7z"
             ],
             "hash": [
                 "9a9e6fa4ca71fbd960063d4908ffdddcf774a33049c3999edb08f801d0aab591",
-                "c5078df325870e325993c8d8d16dd16e1c2b94ef6f9467e0e41c9b7b367b4828"
+                "643abad5850d3e5a73c6d61fe3563162403d81238d8c8ac47f9e700a75a34f0c"
             ],
             "extract_dir": "raine64",
             "bin": [


### PR DESCRIPTION
Obviously, both the URLs and the files' corresponding hashes.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
