### PR TITLE
jazz2-resurrection@2.5.0: Fix hash

### DIFF
--- a/bucket/jazz2-resurrection.json
+++ b/bucket/jazz2-resurrection.json
@@ -23,7 +23,7 @@
         ""
     ],
     "url": "https://github.com/deathkiller/jazz2/releases/download/2.5.0/Jazz2_2.5.0_Windows.zip",
-    "hash": "07738367220f0e7cf1d91207378cc1d3dd822585026ab0e1bbddfc51f4ce296d",
+    "hash": "8f3294e034cd6201142a7d5530a23cbdb3f08302af81994c4e7b93ecb1203ac9",
     "architecture": {
         "64bit": {
             "extract_dir": "x64"


### PR DESCRIPTION
- Manually downloaded through the same URL; hash checks out with what was reported as actual when attempting to update through Scoop.


- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
