### PR TITLE
chore(ci): switch to `pull_request_target` trigger

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened ]
 name: Pull Requests
 jobs:


### PR DESCRIPTION
benefit from https://github.com/ScoopInstaller/GithubActions/pull/39

<!-- Provide a general summary of your changes in the title above -->

I forgot this bucket not under the ScoopInstaller org. xD

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
