### PR TITLE
ps3-system-software: fix autoupdate

### DIFF
--- a/bucket/ps3-system-software.json
+++ b/bucket/ps3-system-software.json
@@ -1,16 +1,16 @@
 {
-    "version": "4.90",
+    "version": "4.91",
     "description": "Sony PlayStation 3 system software",
     "homepage": "https://www.playstation.com/en-us/support/hardware/ps3/system-software/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://doc.dl.playstation.net/doc/ps3-eula/ps3_eula_en.html"
     },
-    "url": "http://dus01.ps3.update.playstation.net/update/ps3/image/us/2023_0228_05fe32f5dc8c78acbcd84d36ee7fdc5b/PS3UPDAT.PUP",
-    "hash": "69070A95780F59FC9E0D82BCF53EB9B28FD4ED4A7D54D0A40045F80422FD98D6",
+    "url": "http://dus01.ps3.update.playstation.net/update/ps3/image/us/2024_0227_3694eb3fb8d9915c112e6ab41a60c69f/PS3UPDAT.PUP",
+    "hash": "bc94bd849036b596735d1ea577562baa1562c5bfe40bfc59397e33a1ad0380f7",
     "checkver": {
         "url": "https://www.playstation.com/en-us/support/hardware/ps3/system-software/",
-        "regex": "(?sm)PS3 System Software Update ((?:\\d+)?(?:\\.?\\d*)).*?ps3/image/us/(?<time>[\\w_]+)/PS3UPDAT.PUP"
+        "regex": "(?smi)ps3 system software update ((?:\\d+)?(?:\\.?\\d*)).*?ps3/image/us/(?<time>[\\w_]+)/ps3updat\\.pup"
     },
     "autoupdate": {
         "url": "http://dus01.ps3.update.playstation.net/update/ps3/image/us/$matchTime/PS3UPDAT.PUP"


### PR DESCRIPTION
Current regex missed latest [4.91](https://www.playstation.com/en-us/support/hardware/ps3/system-software/) update because of different case in title, added case-insensitive flag to prevent that in future.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
