### PR TITLE
freeorion 0.5.0.1: Fix `url`

### DIFF
--- a/bucket/freeorion.json
+++ b/bucket/freeorion.json
@@ -3,7 +3,7 @@
     "description": "Turn-based space empire and galactic conquest (4X) game",
     "homepage": "https://freeorion.org/",
     "license": "GPL-2.0",
-    "url": "https://github.com/freeorion/freeorion/releases/download/v0.5.0.1/FreeOrion_v0.5.0.1_Win32_Setup.exe",
+    "url": "https://github.com/freeorion/freeorion/releases/download/v0.5.0.1/FreeOrion_v0.5.0.1_Win32_Setup.exe#/dl.zip",
     "hash": "754aff7b80e07156908d5d739fc558f4b20cc11522783352b412f6f3c33d03af",
     "shortcuts": [
         [
@@ -20,6 +20,6 @@
         "github": "https://github.com/freeorion/freeorion"
     },
     "autoupdate": {
-        "url": "https://github.com/freeorion/freeorion/releases/download/v$version/FreeOrion_v$version_Win32_Setup.exe"
+        "url": "https://github.com/freeorion/freeorion/releases/download/v$version/FreeOrion_v$version_Win32_Setup.exe#/dl.zip"
     }
 }


### PR DESCRIPTION
Adding the #/dl.zip back to the autoupdate and base url

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
