### PR TITLE
demulshooter: Update to version 12

### DIFF
--- a/bucket/demulshooter.json
+++ b/bucket/demulshooter.json
@@ -1,5 +1,5 @@
 {
-    "version": "11.7",
+    "version": "12",
     "description": "Hook into (mostly) emulators to allow playing rail shooter games with up to 4 lightguns or HID devices",
     "homepage": "https://github.com/argonlefou/DemulShooter",
     "license": "Unknown",
@@ -8,8 +8,8 @@
         "The usage instructions for the app can be found here: https://github.com/argonlefou/DemulShooter/wiki/Usage",
         ""
     ],
-    "url": "https://github.com/argonlefou/DemulShooter/releases/download/v11.7/DemulShooter_v11.7.zip",
-    "hash": "f894524c327b98038f96444ed5df82101af1da43e83bc77bd6c57694b21c33e7",
+    "url": "https://github.com/argonlefou/DemulShooter/releases/download/v12.0/DemulShooter_v12.zip",
+    "hash": "a4c6e2f2647c0fff97d0579d09845ab81cecb1b16bd662dc5a3d7c3cfd248bb0",
     "pre_install": "if (!(Test-Path \"$persist_dir\\config.ini\")) { New-Item -ItemType File \"$dir\\config.ini\" | Out-Null }",
     "shortcuts": [
         [


### PR DESCRIPTION
Manual update to version 12; the `autoupdate` section would need `$cleanVersion` at the end, while more likely than not, `$version` will continue to work going forward, since everything points to the next version being called 12.1, with the URL following that.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
