### PR TITLE
Update PathOfBuilding-Community to v2.40.1 & fix autoupdate

### DIFF
--- a/bucket/pathofbuilding-community.json
+++ b/bucket/pathofbuilding-community.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.30.1",
+    "version": "2.40.1",
     "description": "Offline build planner for Path of Exile, Community Fork",
     "homepage": "https://github.com/PathOfBuildingCommunity/PathOfBuilding",
     "license": "MIT",
-    "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/download/v2.30.1/PathOfBuildingCommunity-Portable-2.30.1.zip",
-    "hash": "a10b4bd661de55773f26306a2e8613457c7d79a619b70d08c8e5f88a8dae5569",
+    "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/download/v2.40.1/PathOfBuildingCommunity-Portable.zip",
+    "hash": "df13f295da55ce8ea9b9f390af54a8074aab9c33ea097cc8c99f5bb1545795c8",
     "pre_install": [
         "if(!(Test-Path \"$dir\\Settings.xml\")) {",
         "    Set-Content \"$dir\\Settings.xml\" -Value '<?xml version=\"1.0\" encoding=\"UTF-8\"?><PathOfBuilding></PathOfBuilding>' -Encoding ascii",
@@ -28,6 +28,6 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/download/v$version/PathOfBuildingCommunity-Portable-$version.zip"
+        "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/download/v$version/PathOfBuildingCommunity-Portable.zip"
     }
 }


### PR DESCRIPTION
Update PathOfBuilding-Community version to the latest available.

And fix the autoupdate URL, as they removed the version part of the downloaded file.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
