### PR TITLE
dreamm: Add version 2.1.2

### DIFF
--- a/bucket/dreamm.json
+++ b/bucket/dreamm.json
@@ -16,18 +16,6 @@
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\config.json\")) {",
         "   New-Item -Path \"$dir\" -Name \"config.json\" -ItemType File | Out-Null",
-        "}",
-        "if (!(Test-Path \"$persist_dir\\install\")) {",
-        "   New-Item -Path \"$dir\" -Name \"install\" -ItemType Directory | Out-Null",
-        "}",
-        "if (!(Test-Path \"$persist_dir\\gamefiles\")) {",
-        "   New-Item -Path \"$dir\" -Name \"gamefiles\" -ItemType Directory | Out-Null",
-        "}",
-        "if (!(Test-Path \"$persist_dir\\sounddata\")) {",
-        "   New-Item -Path \"$dir\" -Name \"sounddata\" -ItemType Directory | Out-Null",
-        "}",
-        "if (!(Test-Path \"$persist_dir\\screenshots\")) {",
-        "   New-Item -Path \"$dir\" -Name \"screenshots\" -ItemType Directory | Out-Null",
         "}"
     ],
     "shortcuts": [

--- a/bucket/dreamm.json
+++ b/bucket/dreamm.json
@@ -1,0 +1,50 @@
+{
+    "version": "2.1.2",
+    "description": "A Windows-based emulator for classic LucasArts SCUMM adventure games, from Maniac Mansion through The Curse of Monkey Island and everything in-between.",
+    "homepage": "https://aarongiles.com/dreamm/",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://aarongiles.com/dreamm/releases/dreamm-2.1.2-win32-x64.zip",
+            "hash": "000b44c9c51a1dbc013af4f46c8847b5776b999def54a8918ba0d1ccfc15edbe"
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\config.json\")) {",
+        "   New-Item -Path \"$dir\" -Name \"config.json\" -ItemType File | Out-Null",
+        "}",
+        "if (!(Test-Path \"$persist_dir\\install\")) {",
+        "   New-Item -Path \"$dir\" -Name \"install\" -ItemType Directory | Out-Null",
+        "}",
+        "if (!(Test-Path \"$persist_dir\\gamefiles\")) {",
+        "   New-Item -Path \"$dir\" -Name \"gamefiles\" -ItemType Directory | Out-Null",
+        "}",
+        "if (!(Test-Path \"$persist_dir\\sounddata\")) {",
+        "   New-Item -Path \"$dir\" -Name \"sounddata\" -ItemType Directory | Out-Null",
+        "}",
+        "if (!(Test-Path \"$persist_dir\\screenshots\")) {",
+        "   New-Item -Path \"$dir\" -Name \"screenshots\" -ItemType Directory | Out-Null",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "dreamm.exe",
+            "DREAMM"
+        ]
+    ],
+    "persist": [
+        "config.json",
+        "install",
+        "gamefiles",
+        "sounddata",
+        "screenshots"
+    ],
+    "checkver": "Current Release: ([\\d.]+)",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://aarongiles.com/dreamm/releases/dreamm-$version-win32-x64.zip"
+            }
+        }
+    }
+}

--- a/bucket/dreamm.json
+++ b/bucket/dreamm.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://aarongiles.com/dreamm/releases/dreamm-2.1.2-win32-x64.zip",
             "hash": "000b44c9c51a1dbc013af4f46c8847b5776b999def54a8918ba0d1ccfc15edbe"
+        },
+        "arm64": {
+            "url": "https://aarongiles.com/dreamm/releases/dreamm-2.1.2-win32-arm64.zip",
+            "hash": "5e3aba873ba943ae504fcc2409f560f5b1549a71882094cf3a1227f08500c211"
         }
     },
     "pre_install": [
@@ -44,6 +48,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://aarongiles.com/dreamm/releases/dreamm-$version-win32-x64.zip"
+            },
+            "arm64": {
+                "url": "https://aarongiles.com/dreamm/releases/dreamm-$version-win32-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Add manifest for [DREAMM](https://aarongiles.com/dreamm/).

Description borrowed from official website:

> DREAMM is a specialized emulator for playing many of your original DOS, Windows, and FM-Towns LucasArts games with full fidelity to the original.

App supports [portable mode](https://aarongiles.com/dreamm/docs/v21/#install-portable), hence `config.json` is being created during `pre_install` section to enable it, together with 4 [documented](https://aarongiles.com/dreamm/docs/v21/#install-data) directories for holding generated files being added to persisted files & directories.

Closes #1036

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
