### PR TITLE
assetstudio: Redirect to successor fork

### DIFF
--- a/bucket/assetstudio.json
+++ b/bucket/assetstudio.json
@@ -1,9 +1,9 @@
 {
-    "version":  "0.16.53",
+    "version": "0.16.53",
     "description": "Tool for exploring, extracting and exporting Unity assets and assetbundles.",
     "homepage": "https://github.com/zhangjiequan/AssetStudio",
     "license": "MIT",
-    "url":  "https://github.com/zhangjiequan/AssetStudio/releases/download/v0.16.53/AssetStudio.net6.0-windows_v0.16.53.zip",
+    "url": "https://github.com/zhangjiequan/AssetStudio/releases/download/v0.16.53/AssetStudio.net6.0-windows_v0.16.53.zip",
     "hash": "0922b22b62853cd77e7b796124d52373fc1e1257179a1e3f3d7258137723616b",
     "bin": "AssetStudioGUI.exe",
     "shortcuts": [

--- a/bucket/assetstudio.json
+++ b/bucket/assetstudio.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.16.47",
+    "version":  "0.16.53",
     "description": "Tool for exploring, extracting and exporting Unity assets and assetbundles.",
-    "homepage": "https://github.com/Perfare/AssetStudio",
+    "homepage": "https://github.com/zhangjiequan/AssetStudio",
     "license": "MIT",
-    "url": "https://github.com/Perfare/AssetStudio/releases/download/v0.16.47/AssetStudio.net6.v0.16.47.zip",
-    "hash": "af600c5c0b48648b878ba5eb43dcaf74dcf021fa31de8718fdcd90adb960d7dd",
+    "url":  "https://github.com/zhangjiequan/AssetStudio/releases/download/v0.16.53/AssetStudio.net6.0-windows_v0.16.53.zip",
+    "hash": "0922b22b62853cd77e7b796124d52373fc1e1257179a1e3f3d7258137723616b",
     "bin": "AssetStudioGUI.exe",
     "shortcuts": [
         [
@@ -13,9 +13,9 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/Perfare/AssetStudio"
+        "github": "https://github.com/zhangjiequan/AssetStudio"
     },
     "autoupdate": {
-        "url": "https://github.com/Perfare/AssetStudio/releases/download/v$version/AssetStudio.net6.v$version.zip"
+        "url": "https://github.com/zhangjiequan/AssetStudio/releases/download/v$version/AssetStudio.net6.0-windows_v$version.zip"
     }
 }


### PR DESCRIPTION
[Upstream repository](https://github.com/Perfare/AssetStudio) has been archived since 2023 Jan 21 and is no longer compatible with asset bundles generated by recent versions of Unity. zhangjiequan's fork seems the most active successor.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
