### PR TITLE
fix: rename dl_with_cache to Invoke-CachedDownload

### DIFF
--- a/bucket/blade-of-agony.json
+++ b/bucket/blade-of-agony.json
@@ -19,7 +19,7 @@
             "   \"https://www.moddb.com$fileUrl\"",
             ")",
             "$archiveUrls | ForEach-Object {",
-            "   dl_with_cache $app $version \"$_\" \"$dir\\$dlFile\"",
+            "   Invoke-CachedDownload $app $version \"$_\" \"$dir\\$dlFile\"",
             "   Expand-7zipArchive \"$dir\\$dlFile\" \"$dir\" -Removal",
             "}",
             "Remove-Item -Force \"$dir\\dl.html\""

--- a/bucket/freedoom.json
+++ b/bucket/freedoom.json
@@ -25,7 +25,7 @@
             "   \"https://github.com/freedoom/freedoom/releases/download/v$version/freedm-$version.zip\"",
             ")",
             "$archiveUrls | ForEach-Object {",
-            "   dl_with_cache $app $version \"$_\" \"$dir\\$dlFile\"",
+            "   Invoke-CachedDownload $app $version \"$_\" \"$dir\\$dlFile\"",
             "   Expand-7zipArchive \"$dir\\$dlFile\" \"$dir\" -Removal",
             "}"
         ]

--- a/bucket/speed-dreams.json
+++ b/bucket/speed-dreams.json
@@ -16,7 +16,7 @@
             "   \"https://sourceforge.net/projects/speed-dreams/files/$head/speed-dreams-wip-cars-and-tracks-$version-win32-setup.exe\"",
             ")",
             "$archiveUrls | ForEach-Object {",
-            "   dl_with_cache $app $version \"$_\" \"$dir\\$dlFile\"",
+            "   Invoke-CachedDownload $app $version \"$_\" \"$dir\\$dlFile\"",
             "   Expand-7zipArchive \"$dir\\$dlFile\" \"$dir\" -Removal",
             "}"
         ]


### PR DESCRIPTION
`dl_with_cache` was renamed to `Invoke-CachedDownload` in [#5173](https://github.com/ScoopInstaller/Scoop/pull/5143), this was causing decompression error during installation of the next apps: `blade-of-agony`, `freedoom` and `speed-dreams`.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #876
Closes #1004


- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
