### PR TITLE
freedoom: fix creating shortcut

### DIFF
--- a/bucket/freedoom.json
+++ b/bucket/freedoom.json
@@ -39,7 +39,7 @@
     ],
     "shortcuts": [
         [
-            "freedoom-manual.pdf",
+            "freedoom-manual-en.pdf",
             "Freedoom Manual"
         ]
     ],


### PR DESCRIPTION
freedoom-manual.pdf is now called freedoom-manual-en.pdf

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
