### PR TITLE
sudachi(fix): pre_install script missing closing '}'

### DIFF
--- a/bucket/sudachi.json
+++ b/bucket/sudachi.json
@@ -17,7 +17,8 @@
         "       Write-host \"Migrating AppData...\" -ForegroundColor yellow",
         "       Copy-Item -Path \"$env:APPDATA\\sudachi\\*\" -Destination \"$persist_dir\\user\" -Recurse",
         "       Remove-Item -Path \"$env:APPDATA\\sudachi\" -Recurse",
-        "   }"
+        "   }",
+        "}"
     ],
     "bin": [
         "sudachi.exe",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
