### PR TITLE
plain-craft-launcher: Add version 2.7.1

### DIFF
--- a/bucket/plain-craft-launcher.json
+++ b/bucket/plain-craft-launcher.json
@@ -1,0 +1,34 @@
+{
+    "version": "2.7.1",
+    "description": "新一代 Minecraft / 我的世界 启动器",
+    "homepage": "https://github.com/Hex-Dragon/PCL2",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://shimo.im/docs/rGrd8pY8xWkt6ryW/read"
+    },
+    "url": "https://github.com/Hex-Dragon/PCL2/raw/main/%E6%9C%80%E6%96%B0%E6%AD%A3%E5%BC%8F%E7%89%88.zip",
+    "hash": "163454d7a51a14b291ea67b342ba9feb3058dca99f9e097d2c955cfba5d40039",
+    "pre_install": [
+        "ensure \"$persist_dir\\PCL\" | Out-Null",
+        "ensure \"$persist_dir\\.minecraft\" | Out-Null",
+        "$conf = \"$persist_dir\\PCL\\Setup.ini\"",
+        "if (!(Test-Path \"$conf\")) {",
+        "    $content = \"LaunchFolderSelect:$persist_dir\\.minecraft\\\"",
+        "    Add-Content \"$conf\" \"$content\"",
+        "}"
+    ],
+    "persist": [
+        "PCL",
+        ".minecraft"
+    ],
+    "shortcuts": [
+        [
+            "Plain Craft Launcher 2.exe",
+            "Plain Craft Launcher"
+        ]
+    ],
+    "autoupdate": {
+        "url": "https://github.com/Hex-Dragon/PCL2/raw/main/%E6%9C%80%E6%96%B0%E6%AD%A3%E5%BC%8F%E7%89%88.zip"
+    },
+    "checkver": "github"
+}


### PR DESCRIPTION
Plain craft launcher is a popular Minecraft launcher.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
