### PR TITLE
battlenet: Fix pre_install

### DIFF
--- a/bucket/battlenet.json
+++ b/bucket/battlenet.json
@@ -17,7 +17,8 @@
         "if ($null -ne $SetupProcess) { Wait-Process $SetupProcess.Id }",
         "$BattlenetProcess = Get-Process Battle.net -ErrorAction Ignore",
         "if ($null -ne $BattlenetProcess) { Stop-Process $BattlenetProcess -Force -ErrorAction Ignore } else { error \"Unable to $cmd $app\" successfully; break }",
-        "Remove-Item $setup, \"$dir/.battlenet\" -Recurse"
+        "Remove-Item $setup",
+        "Remove-Item \"$dir/.battlenet\" -Recurse -ErrorAction SilentlyContinue"
     ],
     "pre_uninstall": [
         "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",


### PR DESCRIPTION
Sometimes the $dir/.battlenet dir exists,
and sometimes it doesn't, Idk why,
but it's accounted for now.

```pwsh
Remove-Item:
Line |
   9 |  Remove-Item $setup, "$dir/.battlenet" -Recurse
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find path '~\scoop\apps\battlenet\1.18.10.3141\.battlenet' because it does not exist.
```

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).