### PR TITLE
Add Bedrock Updater.

### DIFF
--- a/bucket/bedrockupdater.json
+++ b/bucket/bedrockupdater.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0",
-    "description": "Download, update & install Minecraft: Bedrock Edition without the Microsoft Store.",
+    "description": "Download, update & install Minecraft: Bedrock Edition without the Microsoft Store",
     "homepage": "https://github.com/Aetopia/BedrockUpdater",
     "license": "GPL-3.0-only",
     "architecture": {

--- a/bucket/bedrockupdater.json
+++ b/bucket/bedrockupdater.json
@@ -1,0 +1,49 @@
+{
+    "version": "1.0.0",
+    "description": "Download, update & install Minecraft: Bedrock Edition without the Microsoft Store.",
+    "homepage": "https://github.com/Aetopia/BedrockUpdater",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Aetopia/BedrockUpdater/releases/download/v1.0.0/BedrockUpdater.exe",
+            "hash": "00702f2ddb6eac4a275eae42e5e023e881baf0c4a6ed6bfd2d4ecd94ca9455f7"
+        },
+        "32bit": {
+            "url": "https://github.com/Aetopia/BedrockUpdater/releases/download/v1.0.0/BedrockUpdater.exe",
+            "hash": "00702f2ddb6eac4a275eae42e5e023e881baf0c4a6ed6bfd2d4ecd94ca9455f7"
+        }
+    },
+    "shortcuts": [
+        [
+            "BedrockUpdater.exe",
+            "Bedrock Updater"
+        ],
+        [
+            "BedrockUpdater.exe",
+            "Bedrock Updater Preview",
+            "/Preview"
+        ]
+    ],
+    "notes": [
+        "To uninstall the following:",
+        "\t - Minecraft: Bedrock Edition",
+        "\t - Xbox Identity Provider",
+        "\nRun the following command in PowerShell:",
+        "Get-AppxPackage | ForEach-Object { if ($_.Name -in @(\"Microsoft.MinecraftUWP\", \"Microsoft.MinecraftWindowsBeta\", \"Microsoft.XboxIdentityProvider\")) { Remove-AppxPackage $_ } }"
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/Aetopia/BedrockUpdater/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Aetopia/BedrockUpdater/releases/download/v$version/BedrockUpdater.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/Aetopia/BedrockUpdater/releases/download/v$version/BedrockUpdater.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This program/project/application allows one to download, install and update Minecraft: Bedrock Edition (Release & Preview) without the Microsoft Store.

> [!CAUTION]
> This project doesn't allow you to pirate Minecraft: Bedrock Edition, you must own it.
> DRM exists at the game level, if a Microsoft Account that owns the game doesn't exist, the game refuses to start.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
