### PR TITLE
gzdoom: Update to version 4.12.2 and fix URL

### DIFF
--- a/bucket/gzdoom.json
+++ b/bucket/gzdoom.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.11.3",
+    "version": "4.12.2",
     "description": "Modern source port for Doom, Heretic, Hexen and more",
     "homepage": "https://zdoom.org/",
     "license": "GPL-3.0-or-later",
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ZDoom/gzdoom/releases/download/g4.11.3/gzdoom-4-11-3.a.-Windows-64bit.zip",
-            "hash": "9ba87f54b7da13d65ef295404480441f727479b44efb65a51dae54691e2786b7"
+            "url": "https://github.com/ZDoom/gzdoom/releases/download/g4.12.2/gzdoom-4-12-2-windows.zip",
+            "hash": "9548f7bb7d62b13f914e6be653570ac0c4e8b95e11105f00c62362a5bdf5a6fc"
         }
     },
     "pre_install": [
@@ -40,7 +40,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ZDoom/gzdoom/releases/download/g$version/gzdoom-$dashVersion-Windows-64bit.zip"
+                "url": "https://github.com/ZDoom/gzdoom/releases/download/g$version/gzdoom-$dashVersion-Windows.zip"
             }
         }
     }


### PR DESCRIPTION
- Updates to version 4.12.2
- Omits the "-64bit" part of the URL, since the latest versions only support 64 bit and therefore don't type it out in the filename.

(The last part should be the reason the manifest wasn't updating properly.)

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
