### PR TITLE
steam-achievement-manager-syntaxtm: autoupdate fix for 0.6.0, name change

### DIFF
--- a/bucket/steam-achievement-manager-syntaxtm.json
+++ b/bucket/steam-achievement-manager-syntaxtm.json
@@ -1,18 +1,18 @@
 {
-    "version": "0.5.0",
+    "version": "0.6.0",
     "homepage": "https://github.com/syntax-tm/SteamAchievementManager",
     "description": "Fork of Steam Achievement Manager with the goal of updating to .NET Core, WPF and modernizing the app",
     "license": "Zlib",
-    "url": "https://github.com/syntax-tm/SteamAchievementManager/releases/download/v0.5.0/SAM.zip",
-    "hash": "7f52c38c911914ed92269a5429a10d0b02a9d44f4e68e2b4e3037a59d1f32983",
+    "url": "https://github.com/syntax-tm/SteamAchievementManager/releases/download/v0.6.0/SAM_0.6.0.zip",
+    "hash": "7776156D146DC9DB54EFAA3503240EB8743D1356C0D269C2BBF0603D77BBF3F3",
     "shortcuts": [
         [
             "SAM.exe",
-            "syntax-tm's Steam Achievement Manager"
+            "Steam Achievement Manager (syntax-tm)"
         ]
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/syntax-tm/SteamAchievementManager/releases/download/v$version/SAM.zip"
+        "url": "https://github.com/syntax-tm/SteamAchievementManager/releases/download/v$version/SAM_$version.zip"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
The zip filename changed, so the automatic updater didn't update. Also changed how it shows up on the start menu
- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
