### PR TITLE
ppsspp-dev: Add ARM64, fix checkver, autoupdate, remove extract_dir

### DIFF
--- a/bucket/ppsspp-dev.json
+++ b/bucket/ppsspp-dev.json
@@ -59,7 +59,7 @@
             "32bit": {
                 "url": "https://builds.ppsspp.org/builds/v$matchVersion-$matchBuild-g$matchCommit/ppsspp_win.zip"
             },
-			"arm64": {
+            "arm64": {
                 "url": "https://builds.ppsspp.org/builds/v$matchVersion-$matchBuild-g$matchCommit/PPSSPPWindowsARM64.zip"
             }
         }

--- a/bucket/ppsspp-dev.json
+++ b/bucket/ppsspp-dev.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.17.1-35-g0159102a1",
+    "version": "1.17.1-747-g27815c7b5",
     "description": "Sony PlayStation Portable (PSP) emulator. Development build",
     "homepage": "https://www.ppsspp.org",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.17.1-35-g0159102a1&platform=windows-amd64#/dl.zip",
-            "hash": "b4f6313527316ed7041c09a5d68869e57f71a78b6ba8b4df8504d419f44c1dd9",
+            "url": "https://builds.ppsspp.org/builds/v1.17.1-747-g27815c7b5/ppsspp_win.zip",
+            "hash": "5C46B1688812EEFC78BB60BCC5E94769E91E5E762584215FD0CADAF59E72FE33",
             "shortcuts": [
                 [
                     "PPSSPPWindows64.exe",
@@ -15,17 +15,26 @@
             ]
         },
         "32bit": {
-            "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v1.17.1-35-g0159102a1&platform=windows-x86#/dl.zip",
-            "hash": "f5aef5c81e930200d62e3ac7b8fe8653577a91c9fe1a6ad66ee1b1fb114b0a35",
+            "url": "https://builds.ppsspp.org/builds/v1.17.1-747-g27815c7b5/ppsspp_win.zip",
+            "hash": "5C46B1688812EEFC78BB60BCC5E94769E91E5E762584215FD0CADAF59E72FE33",
             "shortcuts": [
                 [
                     "PPSSPPWindows.exe",
                     "PPSSPP (Development)"
                 ]
             ]
+        },
+        "arm64": {
+            "url": "https://builds.ppsspp.org/builds/v1.17.1-747-g27815c7b5/PPSSPPWindowsARM64.zip",
+            "hash": "47E5EFD702263D7AB2B7B07A5DF162BC2403187C6A40AB9D6D7EC9D25A0C9EA6",
+            "shortcuts": [
+                [
+                    "PPSSPPWindowsARM64.exe",
+                    "PPSSPP (Development)"
+                ]
+            ]
         }
     },
-    "extract_dir": "ppsspp",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-item \"$persist_dir\" -ItemType Directory | Out-Null",
@@ -38,17 +47,20 @@
         "demos"
     ],
     "checkver": {
-        "url": "https://buildbot.orphis.net/ppsspp/index.php",
-        "regex": "rev=v(?<version>[\\d.]+)-(?<build>[\\d]+)-g(?<commit>[\\da-fA-F]+)&(?:amp;)platform=windows-amd64",
+        "url": "https://builds.ppsspp.org/meta/history.json",
+        "regex": "v(?<version>[\\d.]+)-(?<build>[\\d]+)-g(?<commit>[\\da-fA-F]+)",
         "replace": "${version}-${build}-g${commit}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v$matchVersion-$matchBuild-g$matchCommit&platform=windows-amd64#/dl.zip"
+                "url": "https://builds.ppsspp.org/builds/v$matchVersion-$matchBuild-g$matchCommit/ppsspp_win.zip"
             },
             "32bit": {
-                "url": "https://buildbot.orphis.net/ppsspp/index.php?m=dl&rev=v$matchVersion-$matchBuild-g$matchCommit&platform=windows-x86#/dl.zip"
+                "url": "https://builds.ppsspp.org/builds/v$matchVersion-$matchBuild-g$matchCommit/ppsspp_win.zip"
+            },
+			"arm64": {
+                "url": "https://builds.ppsspp.org/builds/v$matchVersion-$matchBuild-g$matchCommit/PPSSPPWindowsARM64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Changed the builds server to the one currently used, removed extract_dir and added ARM64 builds.

Closes https://github.com/Calinou/scoop-games/issues/1145, https://github.com/Calinou/scoop-games/issues/794 (794 was already closed but the issue appears to still be a thing on ppsspp-dev)

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
