### PR TITLE
Add Dungeons Updater.

### DIFF
--- a/bucket/dungeonsupdater.json
+++ b/bucket/dungeonsupdater.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0",
-    "description": "Download, install & update Minecraft Dungeons. ",
+    "description": "Download, install & update Minecraft Dungeons.",
     "homepage": "https://github.com/Aetopia/DungeonsUpdater",
     "license": "GPL-3.0-only",
     "architecture": {

--- a/bucket/dungeonsupdater.json
+++ b/bucket/dungeonsupdater.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.0.0",
+    "description": "Download, install & update Minecraft Dungeons. ",
+    "homepage": "https://github.com/Aetopia/DungeonsUpdater",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Aetopia/DungeonsUpdater/releases/download/v1.0.0/DungeonsUpdater.exe",
+            "hash": "8c035cffd4482c0537100ef3672181401057b4ac76332beeee0be5ad9c4efc46"
+        }
+    },
+    "shortcuts": [
+        [
+            "DungeonsUpdater.exe",
+            "Dungeons Updater"
+        ]
+    ],
+    "persist": "Content",
+    "checkver": {
+        "url": "https://api.github.com/repos/Aetopia/DungeonsUpdater/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Aetopia/DungeonsUpdater/releases/download/v$version/DungeonsUpdater.exe"
+            }
+        }
+    }
+}

--- a/bucket/dungeonsupdater.json
+++ b/bucket/dungeonsupdater.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0",
-    "description": "Download, install & update Minecraft Dungeons.",
+    "description": "Download, install and update Minecraft Dungeons",
     "homepage": "https://github.com/Aetopia/DungeonsUpdater",
     "license": "GPL-3.0-only",
     "architecture": {


### PR DESCRIPTION
Dungeons Update provides an alternative way to download Minecraft Dungeons by allowing one to download game files without the need of the Minecraft Launcher or Xbox App.

> [!NOTE]
> - DRM is performed at application level.
> - The project doesn't allow for piracy in anyway.
> - The project fetches the Launcher version of Minecraft Dungeons.
> - The Launcher/Microsoft Store versions of Minecraft Dungeons seem to have been merged under the name of [Minecraft Dungeons for Windows](https://www.xbox.com/games/store/minecraft-dungeons-for-windows/9P8MK4NC0LJB).
> - If a Microsoft account owns Minecraft Dungeons for Windows then the account has effective access to both the Microsoft Store/PC Game Pass + Launcher versions of the game.



<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
