### PR TITLE
Change Prismlauncher persist files to symlink

### DIFF
--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -34,8 +34,9 @@
         "",
         "'accounts.json', 'metacache', 'prismlauncher.cfg' | ForEach-Object {",
         "    if (!(Test-Path -Path $persist_dir\\$_)) {",
-        "        New-Item -Type File $dir/$_ | Out-Null",
+        "        New-Item -Type File $persist_dir/$_ | Out-Null",
         "    }",
+        "    New-Item -Type SymbolicLink -Value $persist_dir/$_ -Path $dir/$_ | Out-Null",
         "}",
         "Add-Content $dir/metacache '{}'",
         "Remove-Item $original_dir/prismlauncher_updater.exe"
@@ -70,9 +71,6 @@
         "mods",
         "themes",
         "translations",
-        "accounts.json",
-        "metacache",
-        "prismlauncher.cfg"
     ],
     "checkver": {
         "github": "https://github.com/PrismLauncher/PrismLauncher"

--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -36,9 +36,11 @@
         "    if (!(Test-Path -Path $persist_dir\\$_)) {",
         "        New-Item -Type File $persist_dir/$_ | Out-Null",
         "    }",
+        "    if (!(Get-Content $persist_dir/metacache)) {",
+        "        Add-Content $persist_dir/metacache '{}'",
+        "    }",
         "    New-Item -Type SymbolicLink -Value $persist_dir/$_ -Path $dir/$_ | Out-Null",
         "}",
-        "Add-Content $dir/metacache '{}'",
         "Remove-Item $original_dir/prismlauncher_updater.exe"
     ],
     "post_install": [
@@ -70,7 +72,7 @@
         "meta",
         "mods",
         "themes",
-        "translations",
+        "translations"
     ],
     "checkver": {
         "github": "https://github.com/PrismLauncher/PrismLauncher"

--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -36,10 +36,10 @@
         "    if (!(Test-Path -Path $persist_dir\\$_)) {",
         "        New-Item -Type File $persist_dir/$_ | Out-Null",
         "    }",
-        "    if (!(Get-Content $persist_dir/metacache)) {",
-        "        Add-Content $persist_dir/metacache '{}'",
-        "    }",
         "    New-Item -Type SymbolicLink -Value $persist_dir/$_ -Path $dir/$_ | Out-Null",
+        "}",
+        "if (!(Get-Content $persist_dir/metacache)) {",
+        "    Add-Content $persist_dir/metacache '{}'",
         "}",
         "Remove-Item $original_dir/prismlauncher_updater.exe"
     ],


### PR DESCRIPTION
The files accounts.json, prismlauncher.cfg, and metacache weren't properly persisted.

Added SymbolicLink line to the pre_install script part, removed the files from the inbuilt persist list.

Relates to #1065

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
