### PR TITLE
lim3ds@2115: Fix extract_dir and add it to autoupdate

### DIFF
--- a/bucket/lime3ds.json
+++ b/bucket/lime3ds.json
@@ -8,7 +8,7 @@
     },
     "url": "https://github.com/Lime3DS/Lime3DS/releases/download/2115/lime3ds-2115-windows-msvc.zip",
     "hash": "c6c6784724b69245e3890ba0aa618deeeeabee5f70515a45ab4183da1ffcf3e4",
-    "extract_dir": "lime3ds-2114.1-windows-msvc",
+    "extract_dir": "lime3ds-2115-windows-msvc",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\user\")) {",
         "   New-Item -Path \"$persist_dir\" -Name \"user\" -ItemType \"directory\" | Out-Null",
@@ -34,6 +34,7 @@
         "github": "https://github.com/Lime3DS/Lime3DS"
     },
     "autoupdate": {
-        "url": "https://github.com/Lime3DS/Lime3DS/releases/download/$version/lime3ds-$version-windows-msvc.zip"
+        "url": "https://github.com/Lime3DS/Lime3DS/releases/download/$version/lime3ds-$version-windows-msvc.zip",
+        "extract_dir": "lime3ds-$version-windows-msvc"
     }
 }


### PR DESCRIPTION
![image](https://github.com/Calinou/scoop-games/assets/67732686/254979e8-5694-4fed-bb16-5ec2c550dd7d)


This should fix the exception. I also checked that the app still uses this naming scheme in the latest version.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
