### PR TITLE
Dolphin: update new dolphin release url and checkver

### DIFF
--- a/bucket/dolphin.json
+++ b/bucket/dolphin.json
@@ -1,6 +1,6 @@
 {
     "version": "2407",
-    "description": "A Nintendo GameCube and Wii emulator, with enhancements and Netplay.",
+    "description": "Nintendo GameCube and Wii emulator, with enhancements and Netplay",
     "homepage": "https://dolphin-emu.org/",
     "license": {
         "identifier": "GPL-2.0-or-later",


### PR DESCRIPTION
The Dolphin emulator had finally a new stable (non-dev, non-beta) release after 8 years.

[As it was announced here](https://dolphin-emu.org/blog/2024/07/02/dolphin-releases-announcement/), they have changed the versioning scheme, and [as it can be seen here](https://dolphin-emu.org/download/) the download url has changed too.

This PR fixes the autoupdate, checkver, and download url in the manifest to match the new pattern.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).