### PR TITLE
Dolphin: fix bin and shortcut to executable due to change in the archive structure

### DIFF
--- a/bucket/dolphin.json
+++ b/bucket/dolphin.json
@@ -23,10 +23,10 @@
         "}"
     ],
     "post_install": "Set-Content -Value $null -Path \"$dir\\portable.txt\"",
-    "bin": "Dolphin.exe",
+    "bin": "Dolphin-x64\\Dolphin.exe",
     "shortcuts": [
         [
-            "Dolphin.exe",
+            "Dolphin-x64\\Dolphin.exe",
             "Dolphin"
         ]
     ],


### PR DESCRIPTION
On top of changing the version number schema and the URL pattern to the downloads, the Dolphin emulator team also changed the structure of the archive, so the installation was failing because now everything, including the main executable, is inside a folder named `Dolphin-x64\`. This PR fixes that.

Relates to #1176

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
