### PR TITLE
daggerfallunity: persist mods and gamefiles

### DIFF
--- a/bucket/daggerfallunity.json
+++ b/bucket/daggerfallunity.json
@@ -16,6 +16,15 @@
     "pre_install": [
         "New-Item -ItemType File \"$dir\\Portable.txt\" | Out-Null"
     ],
+    "post_install": [
+        "$Subdirs = @('Mods', 'GameFiles')",
+        "ForEach($DirName in $Subdirs) {",
+        "    if (Test-Path \"$dir\\DaggerfallUnity_Data\\StreamingAssets\\$DirName.original\") {",
+        "        Copy-Item \"$dir\\DaggerfallUnity_Data\\StreamingAssets\\$DirName.original\\*\" \"$persist_dir\\DaggerfallUnity_Data\\StreamingAssets\\$DirName\" -Force -Recurse",
+        "        Remove-Item \"$dir\\DaggerfallUnity_Data\\StreamingAssets\\$DirName.original\" -Force -Recurse | Out-Null",
+        "    }",
+        "}"
+    ],
     "shortcuts": [
         [
             "DaggerfallUnity.exe",
@@ -23,7 +32,9 @@
         ]
     ],
     "persist": [
-        "PortableAppdata"
+        "PortableAppdata",
+        "DaggerfallUnity_Data\\StreamingAssets\\GameFiles",
+        "DaggerfallUnity_Data\\StreamingAssets\\Mods"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
Daggerfall Unity expects `.dfmod` files to be stored within a subfolder of StreamingAssets. Failing to persist this folder means users will lose any installed mods any time the app updates.

Also persisting GameFiles in case users want to place Daggerfall's arena2 folder there and create a truly portable install.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
