### PR TITLE
Update settings.json: add pre/post_uninstall fields to sortJSON lists

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,7 +70,9 @@
         "bin",
         "shortcuts",
         "persist",
+        "pre_uninstall",
         "uninstaller",
+        "post_uninstall",
         "checkver",
         "autoupdate"
     ],
@@ -101,7 +103,9 @@
         "bin",
         "shortcuts",
         "persist",
+        "pre_uninstall",
         "uninstaller",
+        "post_uninstall",
         "checkver",
         "autoupdate"
     ],

--- a/bucket/zandronum.json
+++ b/bucket/zandronum.json
@@ -1,7 +1,7 @@
 {
     "version": "3.1",
-    "homepage": "https://zandronum.com/",
     "description": "Modern multiplayer-oriented source port for Doom",
+    "homepage": "https://zandronum.com/",
     "license": "BSD-3-Clause|Sleepycat",
     "notes": [
         "Place WAD files (game data) in:",
@@ -24,6 +24,7 @@
         "$value | New-Item -ItemType File -Path \"$dir/zandronum_portable.ini\" -ErrorAction Ignore | Out-Null",
         "Copy-Item \"$persist_dir\\zandronum-$($env:USERNAME).ini\" \"$dir\\zandronum-$($env:USERNAME).ini\" -ErrorAction 'SilentlyContinue'"
     ],
+    "post_install": "New-Item -Path $dir\\zandronum-$($env:USERNAME).ini -Value $persist_dir\\zandronum_portable.ini -ItemType SymbolicLink -ErrorAction Ignore | Out-Null",
     "env_set": {
         "DOOMWADDIR": "$persist_dir\\..\\_doom"
     },
@@ -34,7 +35,6 @@
             "Zandronum"
         ]
     ],
-    "post_install": "New-Item -Path $dir\\zandronum-$($env:USERNAME).ini -Value $persist_dir\\zandronum_portable.ini -ItemType SymbolicLink -ErrorAction Ignore | Out-Null",
     "persist": [
         "addons",
         "announcer",


### PR DESCRIPTION
Add missing `pre_uninstall` and `post_uninstall` entries to sortJSON field list in settings.json.

Closes #1183

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
