### PR TITLE
Fix broken Marathon Shortcuts

### DIFF
--- a/bucket/alephone-marathon-trilogy.json
+++ b/bucket/alephone-marathon-trilogy.json
@@ -28,15 +28,15 @@
     ],
     "shortcuts": [
         [
-            "Marathon 1/Marathon.exe",
+            "Marathon 1/Classic Marathon.exe",
             "Aleph One (Marathon 1)"
         ],
         [
-            "Marathon 2/Marathon 2.exe",
+            "Marathon 2/Classic Marathon 2.exe",
             "Aleph One (Marathon 2)"
         ],
         [
-            "Marathon Infinity/Marathon Infinity.exe",
+            "Marathon Infinity/Classic Marathon Infinity.exe",
             "Aleph One (Marathon Infinity)"
         ]
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Marathon executables were renamed to "Classic Marathon", which broke the shortcuts.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
