### PR TITLE
Update trenchbroom.json vcredist2015 dependency

### DIFF
--- a/bucket/trenchbroom.json
+++ b/bucket/trenchbroom.json
@@ -3,7 +3,7 @@
     "description": "Level editor for Quake-based games",
     "homepage": "https://kristianduske.com/trenchbroom/",
     "license": "GPL-3.0-or-later",
-    "depends": "extras/vcredist2015",
+    "depends": "extras/vcredist2022",
     "url": "https://github.com/kduske/TrenchBroom/releases/download/v2024.1/TrenchBroom-Win32-v2024.1-Release.7z",
     "hash": "5336ee07cf3d82cfa113f37ee41bcdae79e517391161431fe36c27774017d387",
     "bin": "TrenchBroom.exe",


### PR DESCRIPTION
changed dependency to "extras/vcredist2022" since "extras/vcredist2015" does not seem to exist anymore

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1066

- [ x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
