### PR TITLE
hedge-mod-manager: Add version 7.12-9

### DIFF
--- a/bucket/hedge-mod-manager.json
+++ b/bucket/hedge-mod-manager.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/thesupersonic16/HedgeModManager/releases/latest",
-		"jsonpath": "$.tag_name"
+        "jsonpath": "$.tag_name"
     },
     "autoupdate": {
         "url": "https://github.com/thesupersonic16/HedgeModManager/releases/download/$version/HedgeModManager.exe"

--- a/bucket/hedge-mod-manager.json
+++ b/bucket/hedge-mod-manager.json
@@ -1,0 +1,26 @@
+{
+    "version": "7.12-9",
+    "description": "A mod manager for all PC Hedgehog Engine Sonic games (+Puyo Puyo Tetris 2)",
+    "homepage": "https://github.com/thesupersonic16/HedgeModManager/",
+    "license": "MIT",
+    "url": "https://github.com/thesupersonic16/HedgeModManager/releases/download/7.12-9/HedgeModManager.exe",
+    "hash": "565901F1CED9D4893EF1D988AF55F16A9B0FBCD1A860D4B631D5B7381CA924C7",
+    "bin": [
+        [
+            "HedgeModManager.exe"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "HedgeModManager.exe",
+            "Hedge Mod Manager"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/thesupersonic16/HedgeModManager/releases/latest",
+		"jsonpath": "$.tag_name"
+    },
+    "autoupdate": {
+        "url": "https://github.com/thesupersonic16/HedgeModManager/releases/download/$version/HedgeModManager.exe"
+    }
+}

--- a/bucket/hedge-mod-manager.json
+++ b/bucket/hedge-mod-manager.json
@@ -1,6 +1,6 @@
 {
     "version": "7.12-9",
-    "description": "Mod manager for all PC Hedgehog Engine Sonic games (+Puyo Puyo Tetris 2)",
+    "description": "Mod manager for all PC Hedgehog Engine Sonic games (and Puyo Puyo Tetris 2)",
     "homepage": "https://github.com/thesupersonic16/HedgeModManager/",
     "license": "MIT",
     "url": "https://github.com/thesupersonic16/HedgeModManager/releases/download/7.12-9/HedgeModManager.exe",

--- a/bucket/hedge-mod-manager.json
+++ b/bucket/hedge-mod-manager.json
@@ -1,6 +1,6 @@
 {
     "version": "7.12-9",
-    "description": "A mod manager for all PC Hedgehog Engine Sonic games (+Puyo Puyo Tetris 2)",
+    "description": "Mod manager for all PC Hedgehog Engine Sonic games (+Puyo Puyo Tetris 2)",
     "homepage": "https://github.com/thesupersonic16/HedgeModManager/",
     "license": "MIT",
     "url": "https://github.com/thesupersonic16/HedgeModManager/releases/download/7.12-9/HedgeModManager.exe",


### PR DESCRIPTION
A simple mod manager for Sonic games

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
