### PR TITLE
Mcrcon: Repair manifest

### DIFF
--- a/bucket/mcrcon.json
+++ b/bucket/mcrcon.json
@@ -2,7 +2,6 @@
     "version": "0.7.2",
     "description": "Rcon client for Minecraft",
     "homepage": "https://github.com/Tiiffi/mcrcon",
-
     "license": "Zlib",
     "architecture": {
         "64bit": {

--- a/bucket/mcrcon.json
+++ b/bucket/mcrcon.json
@@ -2,7 +2,7 @@
     "version": "0.7.2",
     "description": "Rcon client for Minecraft",
     "homepage": "https://github.com/Tiiffi/mcrcon/",
-    "license": "Zlib license",
+    "license": "Zlib",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Tiiffi/mcrcon/releases/download/v0.7.2/mcrcon-0.7.2-windows-x86-64.zip",

--- a/bucket/mcrcon.json
+++ b/bucket/mcrcon.json
@@ -1,7 +1,8 @@
 {
     "version": "0.7.2",
     "description": "Rcon client for Minecraft",
-    "homepage": "https://github.com/Tiiffi/mcrcon/",
+    "homepage": "https://github.com/Tiiffi/mcrcon",
+
     "license": "Zlib",
     "architecture": {
         "64bit": {

--- a/bucket/mcrcon.json
+++ b/bucket/mcrcon.json
@@ -1,25 +1,28 @@
 {
     "version": "0.7.2",
-    "description": "RCON client for Minecraft",
-    "homepage": "https://github.com/Tiiffi/mcrcon",
-    "license": "Zlib",
-    "url": "https://github.com/Tiiffi/mcrcon/releases/download/v0.7.2/mcrcon-0.7.2-windows-x86-32.zip",
-    "hash": "9bc513cd039c4738764a6354df45e776ea4db58eafefaa19f92e845a9147f85e",
-    "extract_dir": "mcrcon-0.7.2-windows-x86-32",
+    "description": "Rcon client for Minecraft",
+    "homepage": "https://github.com/Tiiffi/mcrcon/",
+    "license": "Zlib license",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Tiiffi/mcrcon/releases/download/v0.7.2/mcrcon-0.7.2-windows-x86-64.zip",
+            "hash": "47ca5f9e29aac4113283c01a9aa1418ba011c0ba17b791a227c098509e0035a4"
+        },
+        "32bit": {
+            "url": "https://github.com/Tiiffi/mcrcon/releases/download/v0.7.2/mcrcon-0.7.2-windows-x86-32.zip",
+            "hash": "9bc513cd039c4738764a6354df45e776ea4db58eafefaa19f92e845a9147f85e"
+        }
+    },
     "bin": "mcrcon.exe",
-    "shortcuts": [
-        [
-            "mcrcon.exe",
-            "mcrcon"
-        ]
-    ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Tiiffi/mcrcon/releases/download/v$version/mcrcon-$version-windows-x86-32.zip",
-        "hash": {
-            "url": "https://github.com/Tiiffi/mcrcon/releases/tag/v$version",
-            "regex": "windows.*\\s<td>$sha256</td>"
-        },
-        "extract_dir": "mcrcon-$version-windows-x86-32"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Tiiffi/mcrcon/releases/download/v$version/mcrcon-$version-windows-x86-64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/Tiiffi/mcrcon/releases/download/v$version/mcrcon-$version-windows-x86-32.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Mcrcon manifest in this bucket is not working. I created manifest for it by myself some time ago for my personal Scoop bucket, and I believe it should replace this one.

Changes::
- fix that decompress error
- x64 and x86 support (instead of only x86)

Closes [#851](https://github.com/Calinou/scoop-games/issues/851)

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
