### PR TITLE
lime3ds: fix bin and shortcuts

### DIFF
--- a/bucket/lime3ds.json
+++ b/bucket/lime3ds.json
@@ -20,12 +20,11 @@
         "}"
     ],
     "bin": [
-        "lime3ds-cli.exe",
-        "lime3ds-gui.exe"
+        "lime3ds.exe"
     ],
     "shortcuts": [
         [
-            "lime3ds-gui.exe",
+            "lime3ds.exe",
             "Lime3DS"
         ]
     ],


### PR DESCRIPTION
Fixes issue caused by renamed/removed binaries

https://github.com/Lime3DS/Lime3DS/releases/tag/2118

```
Linking ~\scoop\apps\lime3ds\current => ~\scoop\apps\lime3ds\2118
Creating shim for 'lime3ds-cli'.
Get-Command: ~\scoop\apps\scoop\current\lib\install.ps1:757
Line |
 757 |              $bin = (Get-Command $target).Source
     |                      ~~~~~~~~~~~~~~~~~~~
     | The term 'lime3ds-cli.exe' is not recognized as a name of a cmdlet, function, script file, or executable
     | program. Check the spelling of the name, or if a path was included, verify that the path is correct and try
     | again.
Can't shim 'lime3ds-cli.exe': File doesn't exist.
```

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
