### PR TITLE
Fix OSU extract_dir

### DIFF
--- a/bucket/osulazer.json
+++ b/bucket/osulazer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "url": "https://github.com/ppy/osu/releases/download/2024.906.2/osulazer-2024.906.2-full.nupkg#/dl.7z",
     "hash": "aab55ec9514f1fd72307404c954ca2e05e748f2c047fc8807f5e96f33792cff4",
-    "extract_dir": "lib\\net45",
+    "extract_dir": "lib\\app",
     "pre_install": "Rename-Item -Path $dir/osu!.exe -NewName $dir/osulazer.exe",
     "bin": "osulazer.exe",
     "shortcuts": [


### PR DESCRIPTION
OSU migrated updater from Squirrel to Velopack since [2024.906.1](https://github.com/ppy/osu/releases/tag/2024.906.1)
This caused the file path changed from `/lib/net45` to `/lib/app`.
https://github.com/ppy/osu/issues/29783#issuecomment-2336649935

```bash
❯ scoop install osulazer
Installing 'osulazer' (2024.906.2) [64bit] from 'games' bucket
Loading osulazer-2024.906.2-full.nupkg from cache.
Checking hash of osulazer-2024.906.2-full.nupkg ... ok.
Extracting osulazer-2024.906.2-full.nupkg ... Could not find 'net45'! (error 16)
発生場所 C:\****\Scoop\apps\scoop\current\lib\core.ps1:889 文字:9
+         throw "Could not find '$(fname $from)'! (error $($proc.ExitCo ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Could not find 'net45'! (error 16):String) [], RuntimeException
    + FullyQualifiedErrorId : Could not find 'net45'! (error 16)
```

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
