### PR TITLE
pcsx2-dev.json: Add inputprofiles to persist list

### DIFF
--- a/bucket/pcsx2-dev.json
+++ b/bucket/pcsx2-dev.json
@@ -54,6 +54,7 @@
         "covers",
         "gamesettings",
         "inis",
+        "inputprofiles",
         "logs",
         "memcards",
         "snaps",


### PR DESCRIPTION
This directory contains controller mapping profiles.

Closes #1233

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
