### PR TITLE
supermodel: add version 0.3a-git-f9cb795

### DIFF
--- a/bucket/supermodel.json
+++ b/bucket/supermodel.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.3a-git-f9cb795",
+    "description": "Sega Model 3 Arcade Emulator",
+    "homepage": "https://supermodel3.com/index.html",
+    "license": "GPL-3.0-only",
+    "url": "https://supermodel3.com/Files/Git_Snapshots/Supermodel_0.3a-git-f9cb795_Win64.zip",
+    "hash": "0c41a4f1f20427149f66f85654e45ca92a744643588bcc819cd42cacbaaa8d58",
+    "bin": [
+        [
+            "Launch-Supermodel.ps1",
+            "supermodel"
+        ]
+    ],
+    "persist": [
+        "Assets",
+        "Config",
+        "NVRAM",
+        "ROMs",
+        "Saves"
+    ],
+    "pre_install": "\"Push-Location $dir; & ./Supermodel.exe `$args; Pop-Location \" | Out-File (Join-Path $dir 'Launch-Supermodel.ps1')",
+    "checkver": {
+        "url": "https://supermodel3.com/Download.html",
+        "regex": "Supermodel_([0-9a-zA-Z.-]+)_Win64.zip"
+    },
+    "autoupdate": {
+        "url": "https://supermodel3.com/Files/Git_Snapshots/Supermodel_$version_Win64.zip"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Added supermodel package version 0.3a-git-f9cb795.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The versioning string for the newest development versions of Supermodel is random, but the Supermodel download page sorts the builds in order of newest, so we only need to capture the first match to get the newest version. 

Supermodel in Scoop has to be run using a wrapper script that temporarily sets the working directory to the executable location, as Supermodel is hardcoded to load configuration files relative to the executable. As far as I could see, there are no Scoop options yet for being able to set the working directory of an entry in the bin field. 

Closes #681 

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
