### PR TITLE
Update Steam Art Manager to version 3.10.5

### DIFF
--- a/bucket/steam-art-manager.json
+++ b/bucket/steam-art-manager.json
@@ -1,13 +1,13 @@
 {
-    "version": "2.4.0",
+    "version": "3.10.5",
     "description": "Tool for setting the artwork of your Steam library",
     "homepage": "https://github.com/Tormak9970/Steam-Art-Manager",
     "license": {
         "identifier": "GPL-3.0-only",
         "url": "https://github.com/Tormak9970/Steam-Art-Manager/blob/main/LICENSE"
     },
-    "url": "https://github.com/Tormak9970/Steam-Art-Manager/releases/download/v2.4.0/Steam.Art.Manager_2.4.0_x64_en-US.msi.zip",
-    "hash": "88fe6ef51c7376696b9e58f3a961dfab79aad446d050eaebd54bd7856856095d",
+    "url": "https://github.com/Tormak9970/Steam-Art-Manager/releases/download/v3.10.5/steam-art-manager_3.10.5.msi.zip",
+    "hash": "3c08d11bfd0f9ee7b960695644fceb8580d6786d01425788973d0dfdac25b408",
     "pre_install": [
         "Get-ChildItem \"$dir\\Steam Art Manager_*.msi\" | Select-Object -First 1 | ForEach-Object { Rename-Item $_ \"dl.msi\" }",
         "Expand-MsiArchive \"$dir\\dl.msi\" \"$dir\" -ExtractDir \"PFiles\\Steam Art Manager\" -Removal | Out-Null"
@@ -29,6 +29,6 @@
         "github": "https://github.com/Tormak9970/Steam-Art-Manager"
     },
     "autoupdate": {
-        "url": "https://github.com/Tormak9970/Steam-Art-Manager/releases/download/v$version/Steam.Art.Manager_$version_x64_en-US.msi.zip"
+        "url": "https://github.com/Tormak9970/Steam-Art-Manager/releases/download/v3.10.5/steam-art-manager_$version.msi.zip"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
## Updated steam-art-manager.json
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Manifest now uses the updated naming scheme, version updated to 3.10.5. Autoupdates should work from here on.
Closes #1248 

- [✅] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
