### PR TITLE
steam-art-manager: Fix autoupdate URL

### DIFF
--- a/bucket/steam-art-manager.json
+++ b/bucket/steam-art-manager.json
@@ -29,6 +29,6 @@
         "github": "https://github.com/Tormak9970/Steam-Art-Manager"
     },
     "autoupdate": {
-        "url": "https://github.com/Tormak9970/Steam-Art-Manager/releases/download/v3.10.5/steam-art-manager_$version.msi.zip"
+        "url": "https://github.com/Tormak9970/Steam-Art-Manager/releases/download/v$version/steam-art-manager_$version.msi.zip"
     }
 }

--- a/bucket/steam-art-manager.json
+++ b/bucket/steam-art-manager.json
@@ -29,6 +29,6 @@
         "github": "https://github.com/Tormak9970/Steam-Art-Manager"
     },
     "autoupdate": {
-        "url": "https://github.com/Tormak9970/Steam-Art-Manager/releases/download/v$version/steam-art-manager_$version.msi.zip"
+        "url": "https://github.com/Tormak9970/Steam-Art-Manager/releases/download/$version/steam-art-manager_$version.msi.zip"
     }
 }


### PR DESCRIPTION
Fixed autoupdate URL. HOPEFULLY my final pull request for this same issue, your patience has been appreciated!

Relates to #1272

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
