### PR TITLE
Fix broken autoupdate url for Raze

### DIFF
--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -28,7 +28,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/coelckers/Raze/releases/download/$version/raze_$version.zip"
+                "url": "https://github.com/coelckers/Raze/releases/download/$version/raze-$version-windows.zip"
             }
         }
     }

--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.9.1",
+    "version": "1.10.2",
     "description": "Modern source port for Duke Nukem 3D, Blood, Redneck Rampage, Shadow Warrior and Exhumed/Powerslave",
     "homepage": "https://github.com/coelckers/Raze",
     "license": "Custom",
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/coelckers/Raze/releases/download/1.9.1/raze_1.9.1.zip",
-            "hash": "f4caea7fed7e9122011c9f53757205dd73f54fb9f2006a9acf777ef12ca68e41"
+            "url": "https://github.com/coelckers/Raze/releases/download/1.10.2/raze-1.10.2-windows.zip",
+            "hash": "966e40c38bb79bc71cc137b662d0598eaad39f1413b506b803a40fab49828b52"
         }
     },
     "bin": "raze.exe",

--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -1,7 +1,7 @@
 {
     "version": "1.10.2",
     "description": "Modern source port for Duke Nukem 3D, Blood, Redneck Rampage, Shadow Warrior and Exhumed/Powerslave",
-    "homepage": "https://github.com/coelckers/Raze",
+    "homepage": "https://raze.zdoom.org/about",
     "license": "Custom",
     "notes": [
         "Place GRP and RTS files (game data) in:",
@@ -10,7 +10,7 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/coelckers/Raze/releases/download/1.10.2/raze-1.10.2-windows.zip",
+            "url": "https://github.com/ZDoom/Raze/releases/download/1.10.2/raze-1.10.2-windows.zip",
             "hash": "966e40c38bb79bc71cc137b662d0598eaad39f1413b506b803a40fab49828b52"
         }
     },
@@ -28,7 +28,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/coelckers/Raze/releases/download/$version/raze-$version-windows.zip"
+                "url": "https://github.com/ZDoom/Raze/releases/download/$version/raze-$version-windows.zip"
             }
         }
     }


### PR DESCRIPTION
Raze was stuck on 1.9.1 because the name format changed.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
