### PR TITLE
duckstation-preview: fix shortcut issue, update bios link

### DIFF
--- a/bucket/duckstation-preview.json
+++ b/bucket/duckstation-preview.json
@@ -24,17 +24,17 @@
     "uninstaller": {
         "script": "Copy-Item \"$dir\\settings.ini\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
     },
-	"post_install": [
+    "post_install": [
         "echo \"update bin/shortcuts\"",
         "$shell = New-Object -COM WScript.Shell",
         "$shortcut = $shell.CreateShortCut(\"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation (preview).lnk\")",
         "$shortcut.TargetPath = \"$original_dir\\duckstation-qt-x64-ReleaseLTCG.exe\"",
         "$shortcut.Save()"
-	],
-	"post_uninstall": [
+    ],
+    "post_uninstall": [
         "echo \"update bin/shortcuts\"",
-		"Remove-Item \"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation (preview).lnk\""
-	],
+        "Remove-Item \"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation (preview).lnk\""
+    ],
     "persist": [
         "bios",
         "cache",

--- a/bucket/duckstation-preview.json
+++ b/bucket/duckstation-preview.json
@@ -9,7 +9,7 @@
     "notes": [
         "ATTENTION: Duckstation requires a PSX BIOS to function.",
         "Place the BIOS file in $persist_dir\\bios",
-        "Learn more at: https://www.duckstation.org/wiki/BIOS"
+        "Learn more at: https://web.archive.org/web/20210620033009/https://www.duckstation.org/wiki/BIOS"
     ],
     "url": "https://github.com/stenzek/duckstation/releases/download/preview/duckstation-windows-x64-release.zip",
     "hash": "f646b1bfc63e0832558bc19242c7fc1cc4c04ed4c252104c04b2f4f5e7e7918a",
@@ -24,12 +24,17 @@
     "uninstaller": {
         "script": "Copy-Item \"$dir\\settings.ini\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
     },
-    "shortcuts": [
-        [
-            "duckstation-qt-x64-ReleaseLTCG.exe",
-            "DuckStation (preview)"
-        ]
-    ],
+	"post_install": [
+        "echo \"update bin/shortcuts\"",
+        "$shell = New-Object -COM WScript.Shell",
+        "$shortcut = $shell.CreateShortCut(\"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation (preview).lnk\")",
+        "$shortcut.TargetPath = \"$original_dir\\duckstation-qt-x64-ReleaseLTCG.exe\"",
+        "$shortcut.Save()"
+	],
+	"post_uninstall": [
+        "echo \"update bin/shortcuts\"",
+		"Remove-Item \"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation (preview).lnk\""
+	],
     "persist": [
         "bios",
         "cache",

--- a/bucket/duckstation.json
+++ b/bucket/duckstation.json
@@ -21,20 +21,20 @@
             "}"
         ]
     },
-	"post_install": [
+    "uninstaller": {
+        "script": "Copy-Item \"$dir\\settings.ini\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
+    },
+    "post_install": [
         "echo \"update bin/shortcuts\"",
         "$shell = New-Object -COM WScript.Shell",
         "$shortcut = $shell.CreateShortCut(\"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation.lnk\")",
         "$shortcut.TargetPath = \"$original_dir\\duckstation-qt-x64-ReleaseLTCG.exe\"",
         "$shortcut.Save()"
-	],
-	"post_uninstall": [
+    ],
+    "post_uninstall": [
         "echo \"update bin/shortcuts\"",
-		"Remove-Item \"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation.lnk\""
-	],
-    "uninstaller": {
-        "script": "Copy-Item \"$dir\\settings.ini\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
-    },
+        "Remove-Item \"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation.lnk\""
+    ],
     "persist": [
         "bios",
         "cache",

--- a/bucket/duckstation.json
+++ b/bucket/duckstation.json
@@ -9,7 +9,7 @@
     "notes": [
         "ATTENTION: Duckstation requires a PSX BIOS to function.",
         "Place the BIOS file in $persist_dir\\bios",
-        "Learn more at: https://www.duckstation.org/wiki/BIOS"
+        "Learn more at: https://web.archive.org/web/20210620033009/https://www.duckstation.org/wiki/BIOS"
     ],
     "url": "https://github.com/stenzek/duckstation/releases/download/latest/duckstation-windows-x64-release.zip",
     "hash": "570516689115e77c8898bf85cc0b24a1055fd21f56a4fe70954b08e47b00277c",
@@ -21,15 +21,20 @@
             "}"
         ]
     },
+	"post_install": [
+        "echo \"update bin/shortcuts\"",
+        "$shell = New-Object -COM WScript.Shell",
+        "$shortcut = $shell.CreateShortCut(\"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation.lnk\")",
+        "$shortcut.TargetPath = \"$original_dir\\duckstation-qt-x64-ReleaseLTCG.exe\"",
+        "$shortcut.Save()"
+	],
+	"post_uninstall": [
+        "echo \"update bin/shortcuts\"",
+		"Remove-Item \"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\DuckStation.lnk\""
+	],
     "uninstaller": {
         "script": "Copy-Item \"$dir\\settings.ini\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
     },
-    "shortcuts": [
-        [
-            "duckstation-qt-x64-ReleaseLTCG.exe",
-            "Duckstation"
-        ]
-    ],
     "persist": [
         "bios",
         "cache",


### PR DESCRIPTION
Closes #1251 and #1268. 

Duckstation doesn't want to open in a junction folder, so I made its shortcut point to the original folder.

I also used the archive.org link for the BIOS wiki page. I would have used a different wiki or comparable link, but could not find anything with a quick search.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
