### PR TITLE
shadps4-dev: fix autoupdate url

### DIFF
--- a/bucket/shadps4-dev.json
+++ b/bucket/shadps4-dev.json
@@ -6,8 +6,8 @@
         "identifier": "GPL-2.0-only",
         "url": "https://github.com/shadps4-emu/shadPS4/blob/main/LICENSE"
     },
-    "url": "https://github.com/shadps4-emu/shadPS4/releases/download/Pre-release-shadPS4-2024-12-12-5be807f/shadps4-win64-qt-2024-12-12-5be807f.zip",
-    "hash": "",
+    "url": "https://github.com/shadps4-emu/shadPS4/releases/download/Pre-release-shadPS4-2024-12-13-715ac8a/shadps4-win64-qt-2024-12-13-715ac8a.zip",
+    "hash": "f62e1ce2c1031eec777f2c36ee974a284c755bf63542222dd7b90fb417f5aed0",
     "bin": "shadPS4.exe",
     "shortcuts": [
         [
@@ -22,10 +22,6 @@
         "regex": "((\\d+-){3}[a-f0-9]{7})"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/shadps4-emu/shadPS4/releases/download/Pre-release-shadPS4-$version/shadps4-win64-qt-$version.zip"
-            }
-        }
+        "url": "https://github.com/shadps4-emu/shadPS4/releases/download/Pre-release-shadPS4-$version/shadps4-win64-qt-$version.zip"
     }
 }


### PR DESCRIPTION
Closes #1290.

It seems that the url setting for the autoupdate rule was wrong, the architecture property was used incorrectly. I tested this change and it seems to fix the issue.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
