### PR TITLE
Ryujinx@1.2.76: fix version string in autoupdate url and update

### DIFF
--- a/bucket/ryujinx.json
+++ b/bucket/ryujinx.json
@@ -41,7 +41,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/GreemDev/Ryujinx/releases/download/$version/ryujinx-1.2.76-win_x64.zip"
+                "url": "https://github.com/GreemDev/Ryujinx/releases/download/$version/ryujinx-$version-win_x64.zip"
             }
         }
     }

--- a/bucket/ryujinx.json
+++ b/bucket/ryujinx.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.76",
+    "version": "1.2.78",
     "description": "A simple, experimental Nintendo Switch emulator",
     "homepage": "https://github.com/GreemDev/Ryujinx",
     "license": {
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/GreemDev/Ryujinx/releases/download/1.2.76/ryujinx-1.2.76-win_x64.zip",
-            "hash": "d94be8369f739252f33e4271cd9af05c7a59d52de5d8f407d066bbef8780f8b0"
+            "url": "https://github.com/GreemDev/Ryujinx/releases/download/1.2.78/ryujinx-1.2.78-win_x64.zip",
+            "hash": "c479027e01bf3b0953a9bafd705e73ceb3fb7dbbc511e4fecce4555b74fa9202"
         }
     },
     "extract_dir": "publish",


### PR DESCRIPTION
The autoupdate url used a fixed version in the name of the artefact which made it useless and broken. Using `$version` now. 
And update to `1.2.78` cuz otherwise it doesn't pass the checks. 

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
