### PR TITLE
gzdoom@4.14.0: Fixed gzdoom download url and hash

### DIFF
--- a/bucket/gzdoom.json
+++ b/bucket/gzdoom.json
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ZDoom/gzdoom/releases/download/g4.14.0/gzdoom-4-14-0-Windows.zip",
-            "hash": "47f18688da9e2dcf12705013a46d0d176c4303ec55e6e60c3f31016037ebf27f"
+            "url": "https://github.com/ZDoom/gzdoom/releases/download/g4.14.0/gzdoom-4-14-0a-windows.zip",
+            "hash": "BD846558FE9FBDF3063D93C522935FB0F263568F73A374537EF732066A5E5CC5"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Fixed the gzdoom download url and the associated file hash.
Current url: https://github.com/ZDoom/gzdoom/releases/download/g4.14.0/gzdoom-4-14-0-Windows.zip
Correct url: [https://github.com/ZDoom/gzdoom/releases/download/g4.14.0/gzdoom-4-14-0a-windows.zip](https://github.com/ZDoom/gzdoom/releases/tag/g4.14.0)

Closes [#1299](https://github.com/Calinou/scoop-games/issues/1299)

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
