### PR TITLE
scummvm: rename if there's version in file name

### DIFF
--- a/bucket/scummvm.json
+++ b/bucket/scummvm.json
@@ -19,7 +19,9 @@
         }
     },
     "pre_install": [
-        "Rename-Item -Path \"$dir\\scummvm-$version.exe\" -NewName \"scummvm.exe\"",
+        "if (Test-Path \"$dir\\scummvm-$version.exe\") {",
+        "   Rename-Item -Path \"$dir\\scummvm-$version.exe\" -NewName \"scummvm.exe\"",
+        "}",
         "if (!(Test-Path \"$persist_dir\\scummvm.ini\")) {",
         "   New-Item -Path \"$dir\" -Name \"scummvm.ini\" -ItemType \"File\" | Out-Null",
         "}"


### PR DESCRIPTION
In new ScummVM release executable doesn't include version like that was it previous release, i.e. `scummvm.exe` instead of `scummvm-2.9.0.exe`. Because of this renaming added in #1124 results in error during installation (it still ends up successful). I think it's probably better to wrap rename command with condition in case user wants to install older version.

Here's installation log without change:
```
Updating one outdated app:
Updating 'scummvm' (2.8.1 -> 2.9.0)
Downloading new version
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: ff6093|OK  |   5.5MiB/s|C:/Users/User/scoop/cache/scummvm#2.9.0#83bb47a.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of scummvm-2.9.0-win32-x86_64.zip ... ok.
Uninstalling 'scummvm' (2.8.1)
Unlinking ~\scoop\apps\scummvm\current
Installing 'scummvm' (2.9.0) [64bit] from 'games' bucket
Loading scummvm-2.9.0-win32-x86_64.zip from cache.
Extracting scummvm-2.9.0-win32-x86_64.zip ... done.
Running pre_install script...Rename-Item: Cannot find path 'C:\Users\User\scoop\apps\scummvm\2.9.0\scummvm-2.9.0.exe' because it does not exist.
done.
Linking ~\scoop\apps\scummvm\current => ~\scoop\apps\scummvm\2.9.0
Creating shortcut for ScummVM (scummvm.exe)
Persisting scummvm.ini
Persisting saves
Persisting themes
Persisting extras
'scummvm' (2.9.0) was installed successfully!
```


- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
