### PR TITLE
Create pathofbuilding-poe2-community.json

### DIFF
--- a/bucket/pathofbuilding-poe2-community.json
+++ b/bucket/pathofbuilding-poe2-community.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.1.0",
+    "description": "Offline Build Planner for Path of Exile2, Community Fork",
+    "homepage": "https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2",
+    "license": "MIT",
+    "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/releases/download/v0.1.0/PathOfBuildingCommunity-PoE2-Portable.zip",
+    "hash": "dd9054f5df0ad81888ded379b4e36823dbabc7bee3cc66de4ce34bda58c56518",
+    "pre_install": [
+        "if(!(Test-Path \"$dir\\Settings.xml\")) {",
+        "    Set-Content \"$dir\\Settings.xml\" -Value '<?xml version=\"1.0\" encoding=\"UTF-8\"?><PathOfBuilding></PathOfBuilding>' -Encoding ascii",
+        "}"
+    ],
+    "bin": [
+        [
+            "Path of Building-PoE2.exe",
+            "pathofbuilding-poe2-community"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "Path of Building-PoE2.exe",
+            "Path of Building PoE2 Community"
+        ]
+    ],
+    "persist": [
+        "Builds",
+        "Settings.xml"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/releases/download/v$version/PathOfBuildingCommunity-PoE2-Portable.zip"
+    }
+}


### PR DESCRIPTION
Adds path of building for poe 2 to the bucket.

Made by cloning \scoop\buckets\games\bucket\pathofbuilding-community.json and adapting related fields with data from https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/releases/


Tested to be working locally, but please review. Feel free to change or delete anything/the whole thing.

BTW, thanks for the great work on the bucket and everything scoop related.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1310


- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
