### PR TITLE
xemu: Fix post_install script overwriting config file even when not empty

### DIFF
--- a/bucket/xemu.json
+++ b/bucket/xemu.json
@@ -41,7 +41,7 @@
         "if (Test-Path \"$persist_dir\\eeprom.bin\") {",
         "   Move-Item -Path \"$persist_dir\\eeprom.bin\" -Destination \"$persist_dir\\eeprom\\eeprom.bin\"",
         "   (Get-Content -Path \"$persist_dir\\xemu.toml\").Replace(\"eeprom_path = '$env:APPDATA\\xemu\\xemu\\eeprom.bin'\", \"eeprom_path = '$dir\\eeprom\\eeprom.bin'\") | Set-Content -Path \"$persist_dir\\xemu.toml\"",
-        "} else {",
+        "} elseif (!(Get-Content \"$persist_dir\\xemu.toml\")) {",
         "    '[sys.files]', \"eeprom_path = '$dir\\eeprom\\eeprom.bin'\" | Set-Content \"$persist_dir\\xemu.toml\"",
         "}"
     ],


### PR DESCRIPTION
The post_install script currently overwrites the entirety of `xemu.toml` regardless of whether or not it contains any existing data. This PR modifies the script so that it checks to see if the file is empty or not (and only writes to it if it is).

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
