### PR TITLE
sokoban: update license to Apache-2.0

### DIFF
--- a/bucket/sokoban.json
+++ b/bucket/sokoban.json
@@ -3,7 +3,7 @@
     "description": "Sokoban with a solver",
     "homepage": "https://github.com/ShenMian/sokoban-rs",
     "checkver": "github",
-    "license": "MIT|Apache-2.0",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ShenMian/sokoban-rs/releases/download/v0.1.19/sokoban-windows.zip",


### PR DESCRIPTION
- Changed the license from "MIT|Apache-2.0" to "Apache-2.0" in the sokoban.json file

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
