### PR TITLE
chiaki-ng: Update download & autoupdate url

### DIFF
--- a/bucket/chiaki-ng.json
+++ b/bucket/chiaki-ng.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.9.3",
+    "version": "1.9.5",
     "description": "Next-Generation of Chiaki (the open-source remote play client for PlayStation)",
     "homepage": "https://streetpea.github.io/chiaki-ng/",
     "license": {
@@ -11,11 +11,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/streetpea/chiaki-ng/releases/download/v1.9.3/chiaki-ng-windows-installer.exe",
-            "hash": "52aa644f80e4f16217c7b54793d266084074f6a172eafa42060e166a9a6fa467"
+            "url": "https://github.com/streetpea/chiaki-ng/releases/download/v1.9.5/chiaki-ng-win_x64-VC-portable-1.9.5.zip",
+            "hash": "8bc46c058494aeb8218612870e451b35535a7c01878ffc71eefcc68f81eff05b"
         }
     },
-    "innosetup": true,
+    "extract_dir": "chiaki-ng-Win",
     "bin": [
         [
             "chiaki.exe",
@@ -38,7 +38,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/streetpea/chiaki-ng/releases/download/v$version/chiaki-ng-windows-installer.exe"
+                "url": "https://github.com/streetpea/chiaki-ng/releases/download/v$version/chiaki-ng-win_x64-VC-portable-$version.zip"
             }
         }
     }


### PR DESCRIPTION
Closes #1314 

This PR modifies the download url to correctly pull the current portable release and changes the autoupdate url to do the same for updates.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
