### PR TITLE
mesa3d & mesa3d-mingw: Add version 24.3.3

### DIFF
--- a/bucket/mesa3d-mingw.json
+++ b/bucket/mesa3d-mingw.json
@@ -7,6 +7,7 @@
         "url": "https://docs.mesa3d.org/license.html"
     },
     "url": "https://github.com/pal1000/mesa-dist-win/releases/download/24.3.3/mesa3d-24.3.3-release-mingw.7z",
+    "hash": "f7f434f5c70632d844864f52ce9848a3c8c8772388575180a0a8c33d9c39b721",
     "notes": [
         "",
         "This project provides multiple drivers and deployment options:",

--- a/bucket/mesa3d-mingw.json
+++ b/bucket/mesa3d-mingw.json
@@ -1,0 +1,25 @@
+{
+    "version": "24.3.3",
+    "description": "Windows builds of Mesa3D, an open source implementation of OpenGL, OpenGL ES, Vulkan and other specifications",
+    "homepage": "https://github.com/pal1000/mesa-dist-win",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://docs.mesa3d.org/license.html"
+    },
+    "url": "https://github.com/pal1000/mesa-dist-win/releases/download/24.3.3/mesa3d-24.3.3-release-mingw.7z",
+    "notes": [
+        "",
+        "This project provides multiple drivers and deployment options:",
+        "",
+        "1. System-wide deployment tool - For systems lacking hardware accelerated OpenGL",
+        "",
+        "2. Per-application deployment tool - Deploy Mesa for specific programs",
+        "",
+        "Run the deployment tools from the Mesa installation directory to configure",
+        ""
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/pal1000/mesa-dist-win/releases/download/$version/mesa3d-$version-release-mingw.7z"
+    }
+}

--- a/bucket/mesa3d-mingw.json
+++ b/bucket/mesa3d-mingw.json
@@ -1,6 +1,6 @@
 {
     "version": "24.3.3",
-    "description": "Windows builds of Mesa3D, an open source implementation of OpenGL, OpenGL ES, Vulkan and other specifications",
+    "description": "Windows builds of Mesa3D, an open source implementation of OpenGL, OpenGL ES, Vulkan and other specifications (MinGW build)",
     "homepage": "https://github.com/pal1000/mesa-dist-win",
     "license": {
         "identifier": "MIT",

--- a/bucket/mesa3d.json
+++ b/bucket/mesa3d.json
@@ -1,0 +1,25 @@
+{
+    "version": "24.3.3",
+    "description": "Windows builds of Mesa3D, an open source implementation of OpenGL, OpenGL ES, Vulkan and other specifications",
+    "homepage": "https://github.com/pal1000/mesa-dist-win",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://docs.mesa3d.org/license.html"
+    },
+    "url": "https://github.com/pal1000/mesa-dist-win/releases/download/24.3.3/mesa3d-24.3.3-release-msvc.7z",
+    "notes": [
+        "",
+        "This project provides multiple drivers and deployment options:",
+        "",
+        "1. System-wide deployment tool - For systems lacking hardware accelerated OpenGL",
+        "",
+        "2. Per-application deployment tool - Deploy Mesa for specific programs",
+        "",
+        "Run the deployment tools from the Mesa installation directory to configure",
+        ""
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/pal1000/mesa-dist-win/releases/download/$version/mesa3d-$version-release-msvc.7z"
+    }
+}

--- a/bucket/mesa3d.json
+++ b/bucket/mesa3d.json
@@ -7,6 +7,7 @@
         "url": "https://docs.mesa3d.org/license.html"
     },
     "url": "https://github.com/pal1000/mesa-dist-win/releases/download/24.3.3/mesa3d-24.3.3-release-msvc.7z",
+    "hash": "a4372a320e3875a7ddf8c07de8dcb135bd3dc32bf55b1807d98d42527555e08f",
     "notes": [
         "",
         "This project provides multiple drivers and deployment options:",

--- a/bucket/mesa3d.json
+++ b/bucket/mesa3d.json
@@ -1,6 +1,6 @@
 {
     "version": "24.3.3",
-    "description": "Windows builds of Mesa3D, an open source implementation of OpenGL, OpenGL ES, Vulkan and other specifications",
+    "description": "Windows builds of Mesa3D, an open source implementation of OpenGL, OpenGL ES, Vulkan and other specifications (MSVC build)",
     "homepage": "https://github.com/pal1000/mesa-dist-win",
     "license": {
         "identifier": "MIT",


### PR DESCRIPTION
Closes #1262

Since `systemwidedeploy.cmd` and `perappdeploy.cmd` might break the system, no `post_install`, a note is displayed instead.

I'm unsure if the naming is proper since this is not an official Mesa project.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
