### PR TITLE
0ad: Update to version 0.0.27

### DIFF
--- a/bucket/0ad.json
+++ b/bucket/0ad.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.0.26",
+    "version": "0.27.0",
     "description": "Free and open source strategy game of ancient warfare",
     "homepage": "https://play0ad.com/",
     "license": {
         "identifier": "Freeware",
         "url": "https://github.com/0ad/0ad/blob/master/LICENSE.txt"
     },
-    "url": "https://releases.wildfiregames.com/0ad-0.0.26-alpha-win32.exe#/setup.exe",
-    "hash": "sha1:7f036bb5afb84c5a2168d1689c7f8fdca960fb61",
+    "url": "https://releases.wildfiregames.com/0ad-0.27.0-win32.exe#/setup.exe",
+    "hash": "sha1:f886b5cc76a11163f19628be4619a1facd771c94",
     "installer": {
         "script": "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList \"/S\", \"/D=$dir\" -Wait"
     },
@@ -17,10 +17,10 @@
     },
     "checkver": {
         "url": "https://play0ad.com/download/win/",
-        "regex": "0ad-([\\w.]+)-alpha-win32.exe"
+        "regex": "0ad-([\\w.]+)-win32.exe"
     },
     "autoupdate": {
-        "url": "https://releases.wildfiregames.com/0ad-$version-alpha-win32.exe#/setup.exe",
+        "url": "https://releases.wildfiregames.com/0ad-$version-win32.exe#/setup.exe",
         "hash": {
             "url": "$url.sha1sum"
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
New 0ad release: https://play0ad.com/new-release-0-a-d-alpha-27-agni/.

A new naming scheme requires minor changes to the spec. This is likely to change again when 0ad reaches v28.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
