### PR TITLE
fix: shadps4 checkver

### DIFF
--- a/bucket/shadps4.json
+++ b/bucket/shadps4.json
@@ -19,7 +19,9 @@
         "user"
     ],
     "checkver": {
-        "github": "https://github.com/shadps4-emu/shadPS4/"
+        "url": "https://api.github.com/repos/shadps4-emu/shadPS4/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "v\\.([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://github.com/shadps4-emu/shadPS4/releases/download/v.$version/shadps4-win64-qt-$version.zip"

--- a/bucket/shadps4.json
+++ b/bucket/shadps4.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.4.0",
+    "version": "0.6.0",
     "description": "PlayStation 4 emulator for Windows, Linux and macOS",
     "homepage": "https://shadps4.net/",
     "license": {
         "identifier": "GPL-2.0-only",
         "url": "https://github.com/shadps4-emu/shadPS4/blob/main/LICENSE"
     },
-    "url": "https://github.com/shadps4-emu/shadPS4/releases/download/v.0.4.0/shadps4-win64-qt-0.4.0.zip",
-    "hash": "877e5c238673c3f5a2f6111caeb63a33ef4ff251fe878ea376b81294e1753666",
+    "url": "https://github.com/shadps4-emu/shadPS4/releases/download/v.0.6.0/shadps4-win64-qt-0.6.0.zip",
+    "hash": "cb057e133e729c1deb9bed1b4687ac89c0416254b8f6c460afaf485239f5afcb",
     "bin": "shadPS4.exe",
     "shortcuts": [
         [
@@ -15,9 +15,7 @@
             "shadPS4"
         ]
     ],
-    "persist": [
-        "user"
-    ],
+    "persist": "user",
     "checkver": {
         "url": "https://api.github.com/repos/shadps4-emu/shadPS4/releases/latest",
         "jsonpath": "$.tag_name",


### PR DESCRIPTION
shadps4 releases are tagged with an additional dot, which is included in
the extracted version when using the github checkver.

Using the url checkver with a small regex cleanup we can extract the
correct version that actually fits nicely into the autoupdate url.<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #1290 #1291 

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).