### PR TITLE
Fix BZFlag 2.4.28 hash and switch the vcredist

### DIFF
--- a/bucket/bzflag.json
+++ b/bucket/bzflag.json
@@ -3,9 +3,9 @@
     "description": "3D multiplayer tank battle game",
     "homepage": "https://www.bzflag.org/",
     "license": "MPL-2.0",
-    "depends": "extras/vcredist2017",
+    "depends": "extras/vcredist2022",
     "url": "https://download.bzflag.org/bzflag/windows/2.4.28/bzflag-2.4.28.exe#/dl.7z",
-    "hash": "689f625ca50d8782ba09ebf2f88a005d2feeb70e3699b1b0f95649f41b5946eb",
+    "hash": "6ad8956bb02f319a31b27f7a1c65753a42da8ebb42a2c5b853df4784efc9b5bb",
     "bin": "bzflag.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
The original BZFlag 2.4.28 installer that I uploaded was corrupted, so the hash that was pulled into scoop-games was incorrect.  I uploaded a corrected installer file and I corrected the hash. The manifest also referenced extra/vsredist2017, which doesn't exist anymore, so I replaced that with extra/vcredist2022.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
