### PR TITLE
Patch raze to use hotfix zip.

### DIFF
--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -24,7 +24,7 @@
     "persist": "data",
     "checkver": {
         "url": "https://api.github.com/repos/ZDoom/Raze/releases/latest",
-        "regex": "releases/download/([\\d.]+)/Raze-([\\d.]+[a-z]?)-windows\\.zip",
+        "regex": "releases/download/([\\d.]+)/Raze-(\\1[a-z]?)-windows\\.zip",
         "replace": "$2"
     },
     "autoupdate": {

--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.11.0",
+    "version": "1.11.0b",
     "description": "Modern source port for Duke Nukem 3D, Blood, Redneck Rampage, Shadow Warrior and Exhumed/Powerslave",
     "homepage": "https://raze.zdoom.org/about",
     "license": "Custom",
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ZDoom/Raze/releases/download/1.11.0/raze-1.11.0a-windows.zip",
-            "hash": "5ac388e86cc9f635d2b20654bc44790adc47c193111ab082fcf1593dcab33858"
+            "url": "https://github.com/ZDoom/Raze/releases/download/1.11.0/Raze-1.11.0b-windows.zip",
+            "hash": "16718c28d8d6853b418d467af0354b8c2a21f6c1bebb1686ef2da9896caac2e5"
         }
     },
     "bin": "raze.exe",
@@ -23,12 +23,14 @@
     ],
     "persist": "data",
     "checkver": {
-        "github": "https://github.com/coelckers/raze"
+        "url": "https://api.github.com/repos/ZDoom/Raze/releases/latest",
+        "regex": "releases/download/([\\d.]+)/Raze-([\\d.]+[a-z]?)-windows\\.zip",
+        "replace": "$2"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ZDoom/Raze/releases/download/$version/raze-$version-windows.zip"
+                "url": "https://github.com/ZDoom/Raze/releases/download/$match1/Raze-$match2-windows.zip"
             }
         }
     }

--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -11,7 +11,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/ZDoom/Raze/releases/download/1.11.0/raze-1.11.0a-windows.zip",
-            "hash": "91414f368ad20e7b36726bae8319de2d9c8b582770216209945db5a162eea066"
+            "hash": "5ac388e86cc9f635d2b20654bc44790adc47c193111ab082fcf1593dcab33858"
         }
     },
     "bin": "raze.exe",

--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -24,7 +24,7 @@
     "persist": "data",
     "checkver": {
         "url": "https://api.github.com/repos/ZDoom/Raze/releases/latest",
-        "regex": "releases/download/([^/]+)/Raze-(\\1[a-z]?)-windows\\.zip",
+        "regex": "releases/download/([\\d.]+?)/Raze-(\\1[a-z]?)-windows\\.zip",
         "replace": "$2"
     },
     "autoupdate": {

--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -24,7 +24,7 @@
     "persist": "data",
     "checkver": {
         "url": "https://api.github.com/repos/ZDoom/Raze/releases/latest",
-        "regex": "releases/download/([\\d.]+?)/Raze-(\\1[a-z]?)-windows\\.zip",
+        "regex": "releases/download/([\\d.]+)/Raze-([\\d.]+[a-z]?)-windows\\.zip",
         "replace": "$2"
     },
     "autoupdate": {

--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -24,7 +24,7 @@
     "persist": "data",
     "checkver": {
         "url": "https://api.github.com/repos/ZDoom/Raze/releases/latest",
-        "regex": "releases/download/([\\d.]+)/Raze-([\\d.]+[a-z]?)-windows\\.zip",
+        "regex": "releases/download/([\\d.]+?)/Raze-(\\1[a-z]?)-windows\\.zip",
         "replace": "$2"
     },
     "autoupdate": {

--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -10,7 +10,7 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ZDoom/Raze/releases/download/1.11.0/raze-1.11.0-windows.zip",
+            "url": "https://github.com/ZDoom/Raze/releases/download/1.11.0/raze-1.11.0a-windows.zip",
             "hash": "91414f368ad20e7b36726bae8319de2d9c8b582770216209945db5a162eea066"
         }
     },

--- a/bucket/raze.json
+++ b/bucket/raze.json
@@ -24,7 +24,7 @@
     "persist": "data",
     "checkver": {
         "url": "https://api.github.com/repos/ZDoom/Raze/releases/latest",
-        "regex": "releases/download/([\\d.]+?)/Raze-(\\1[a-z]?)-windows\\.zip",
+        "regex": "releases/download/([^/]+)/Raze-(\\1[a-z]?)-windows\\.zip",
         "replace": "$2"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The Raze zip changed names (1.11.0 to 1.11.0a) but the version in the url path was unchanged (still 1.11.0), so now the link and the autoupdate pattern are broken.  ~I think the new name is not proper, so it's better to make a one time patch instead of changing the pattern, and have autoupdate take care of the next one~ Updated with a better solution that handles this weird url

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
