### PR TITLE
Add PATH support for Stonecutter.

### DIFF
--- a/bucket/stonecutter.json
+++ b/bucket/stonecutter.json
@@ -9,6 +9,7 @@
             "hash": "bb81b18d5f81d000bc34178ef8db58c368ddad2d89df62ce1b89e4dfa166def1"
         }
     },
+    "bin": "Stonecutter.exe",
     "shortcuts": [
         [
             "Stonecutter.exe",


### PR DESCRIPTION

Minor update to the manifest that allows `Stonecutter.exe` to be invoked via the PATH.

[v1.8.5](https://github.com/Aetopia/Stonecutter/releases/tag/v1.8.5) allows the executable to accept the Minecraft URI protocol via the command line.

Relates to #1199

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
