### PR TITLE
Remove PATH support for Stonecutter.

### DIFF
--- a/bucket/stonecutter.json
+++ b/bucket/stonecutter.json
@@ -9,7 +9,6 @@
             "hash": "350ea8cf5bfc548376da3c396e3fa5af348c86db1d30770c4e45a90070d59187"
         }
     },
-    "bin": "Stonecutter.exe",
     "shortcuts": [
         [
             "Stonecutter.exe",


### PR DESCRIPTION
Decided to remove URI protocol support from Stonecutter, a last minute change hence no longer requiring `PATH` support.

The original intentional was to provide users with granular control over how MCBE launched via Stonecutter's executable alongside the fixes it provided.

After careful consideration, I thought it would be best to modularize the project itself providing more control to users & that modularization be its own repository hence the rollback. 

Relates to #1335

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
