### PR TITLE
ryujinx: Update to new release repo

### DIFF
--- a/bucket/ryujinx.json
+++ b/bucket/ryujinx.json
@@ -1,18 +1,18 @@
 {
     "version": "1.2.86",
     "description": "A simple, experimental Nintendo Switch emulator",
-    "homepage": "https://github.com/GreemDev/Ryujinx",
+    "homepage": "https://ryujinx.app/",
     "license": {
         "identifier": "MIT",
-        "url": "https://github.com/GreemDev/Ryujinx/blob/master/LICENSE.txt"
+        "url": "https://git.ryujinx.app/ryubing/ryujinx/-/blob/master/LICENSE.txt"
     },
     "notes": [
         "ATTENTION: Ryujinx requires Nintendo Switch firmware and a prod.keys file to function.",
-        "Learn more at https://github.com/GreemDev/Ryujinx/wiki/FAQ-and-Troubleshooting"
+        "Learn more at https://git.ryujinx.app/ryubing/ryujinx/-/wikis/FAQ-&-Troubleshooting"
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/GreemDev/Ryujinx/releases/download/1.2.86/ryujinx-1.2.86-win_x64.zip",
+            "url": "https://github.com/Ryubing/Stable-Releases/releases/download/1.2.86/ryujinx-1.2.86-win_x64.zip",
             "hash": "e06183dbcf4c24a83960fa2277a83a1ff9401d08a5f1e75911e5a954d1f27f9d"
         }
     },
@@ -36,12 +36,12 @@
     ],
     "persist": "portable",
     "checkver": {
-        "github": "https://github.com/GreemDev/Ryujinx"
+        "github": "https://github.com/Ryubing/Stable-Releases"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/GreemDev/Ryujinx/releases/download/$version/ryujinx-$version-win_x64.zip"
+                "url": "https://github.com/Ryubing/Stable-Releases/releases/download/$version/ryujinx-$version-win_x64.zip"
             }
         }
     }


### PR DESCRIPTION
Update to Ryujinx [new release repo](https://github.com/Ryubing/Stable-Releases) since it migrated to [gitlab](https://git.ryujinx.app/ryubing/ryujinx).

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).

*Maintainer edit: This closes [#1337](https://github.com/Calinou/scoop-games/issues/1337).*