### PR TITLE
ryubing-ryujinx: init at 1.2.86

### DIFF
--- a/bucket/ryujinx-canary.json
+++ b/bucket/ryujinx-canary.json
@@ -36,7 +36,7 @@
     ],
     "persist": "portable",
     "checkver": {
-        "url": "https://git.ryujinx.app/api/v4/projects/ryubing%2Fryujinx/repository/tags?search=^Canary-",
+        "url": "https://git.ryujinx.app/api/v4/projects/ryubing%2Fryujinx/repository/tags?search=%5ECanary-",
         "jsonpath": "$[0].name",
         "regex": "Canary-([\\d.]+)"
     },

--- a/bucket/ryujinx-canary.json
+++ b/bucket/ryujinx-canary.json
@@ -1,0 +1,50 @@
+{
+    "version": "1.3.29",
+    "description": "A simple, experimental Nintendo Switch emulator",
+    "homepage": "https://ryujinx.app/",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://git.ryujinx.app/ryubing/ryujinx/-/blob/master/LICENSE.txt"
+    },
+    "notes": [
+        "ATTENTION: Ryujinx requires Nintendo Switch firmware and a prod.keys file to function.",
+        "Learn more at https://git.ryujinx.app/ryubing/ryujinx/-/wikis/FAQ-&-Troubleshooting"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Ryubing/Canary-Releases/releases/download/1.3.29/ryujinx-canary-1.3.29-win_x64.zip",
+            "hash": "3c9d73eace01480adbf63a9911440d416abb77e47a567cab5787068553bab19e"
+        }
+    },
+    "extract_dir": "publish",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\")) {",
+        "   New-item \"$persist_dir\\portable\" -ItemType Directory | Out-Null",
+        "   if (Test-Path \"$env:APPDATA\\Ryujinx\") {",
+        "       Write-host \"Migrating AppData...\" -ForegroundColor yellow",
+        "       Copy-Item -Path \"$env:APPDATA\\Ryujinx\\*\" -Destination \"$persist_dir\\portable\" -Recurse",
+        "       Remove-Item -Path \"$env:APPDATA\\Ryujinx\" -Recurse",
+        "   }",
+        "}"
+    ],
+    "bin": "Ryujinx.exe",
+    "shortcuts": [
+        [
+            "Ryujinx.exe",
+            "Ryujinx"
+        ]
+    ],
+    "persist": "portable",
+    "checkver": {
+        "url": "https://git.ryujinx.app/api/v4/projects/ryubing%2Fryujinx/repository/tags?search=^Canary-",
+        "jsonpath": "$[0].name",
+        "regex": "Canary-([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Ryubing/Canary-Releases/releases/download/$version/ryujinx-canary-$version-win_x64.zip"
+            }
+        }
+    }
+}

--- a/bucket/ryujinx.json
+++ b/bucket/ryujinx.json
@@ -1,18 +1,18 @@
 {
     "version": "1.2.86",
     "description": "A simple, experimental Nintendo Switch emulator",
-    "homepage": "https://github.com/GreemDev/Ryujinx",
+    "homepage": "https://ryujinx.app/",
     "license": {
         "identifier": "MIT",
-        "url": "https://github.com/GreemDev/Ryujinx/blob/master/LICENSE.txt"
+        "url": "https://git.ryujinx.app/ryubing/ryujinx/-/blob/master/LICENSE.txt"
     },
     "notes": [
         "ATTENTION: Ryujinx requires Nintendo Switch firmware and a prod.keys file to function.",
-        "Learn more at https://github.com/GreemDev/Ryujinx/wiki/FAQ-and-Troubleshooting"
+        "Learn more at https://git.ryujinx.app/ryubing/ryujinx/-/wikis/FAQ-&-Troubleshooting"
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/GreemDev/Ryujinx/releases/download/1.2.86/ryujinx-1.2.86-win_x64.zip",
+            "url": "https://github.com/Ryubing/Stable-Releases/releases/download/1.2.86/ryujinx-1.2.86-win_x64.zip",
             "hash": "e06183dbcf4c24a83960fa2277a83a1ff9401d08a5f1e75911e5a954d1f27f9d"
         }
     },
@@ -36,12 +36,13 @@
     ],
     "persist": "portable",
     "checkver": {
-        "github": "https://github.com/GreemDev/Ryujinx"
+        "url": "https://git.ryujinx.app/api/v4/projects/ryubing%2Fryujinx/releases",
+        "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/GreemDev/Ryujinx/releases/download/$version/ryujinx-$version-win_x64.zip"
+                "url": "https://github.com/Ryubing/Stable-Releases/releases/download/$version/ryujinx-$version-win_x64.zip"
             }
         }
     }


### PR DESCRIPTION
Ryujinx project have moved to their own GitLab platform for development.

The current Ryujinx package links to incorrect packages, so updates do not work.

There are already PRs to fix the issue, linked below.

My version is differs in checkver, it uses GitLab instance API to get the latest version. And I also add Canary release package.

Closes [#1337](https://github.com/Calinou/scoop-games/issues/1337)
Relates to [#1346](https://github.com/Calinou/scoop-games/pull/1346) [#1339](https://github.com/Calinou/scoop-games/pull/1339)

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
