### PR TITLE
xenia-canary: Fix autoupdate & xenia: slight update to manifest description

### DIFF
--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -1,13 +1,13 @@
 {
-    "version": "20250126163205-a4412ad",
-    "description": "Xbox 360 Research Emulator (development version)",
-    "homepage": "https://xenia.jp",
+    "version": "20250408175152-47f327e",
+    "description": "Xbox 360 Emulator Research Project (development version)",
+    "homepage": "https://github.com/xenia-canary/xenia-canary",
     "license": {
         "identifier": "BSD-3-Clause",
-        "url": "https://github.com/xenia-canary/xenia-canary/blob/canary_pr/LICENSE"
+        "url": "https://github.com/xenia-canary/xenia-canary/blob/canary_experimental/LICENSE"
     },
-    "url": "https://github.com/xenia-canary/xenia-canary/releases/download/a4412ad/xenia_canary.zip",
-    "hash": "d78aaf63eb2dd3520b81e218b30d1653ddd43f53978aa01644905bec7977774d",
+    "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/47f327e/xenia_canary_windows.zip",
+    "hash": "06e744d2f5a460e25cf6547878a0317139b00642284560b9c6a6813a86bd99e3",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
@@ -32,10 +32,12 @@
         "xenia-canary.config.toml",
         "content",
         "cache",
+        "cache0",
+        "cache1",
         "patches"
     ],
     "checkver": {
-        "url": "https://github.com/xenia-canary/xenia-canary/releases.atom",
+        "url": "https://github.com/xenia-canary/xenia-canary-releases/releases.atom",
         "script": [
             "$xml = [xml]$page",
             "$updated = ($xml.feed.entry | Where-Object {$_.title -ne 'canary_experimental'} | Sort-Object -Descending { $_.updated })[0].updated",
@@ -46,6 +48,6 @@
         "replace": "${year}${month}${day}${hour}${minute}${second}-${commit}"
     },
     "autoupdate": {
-        "url": "https://github.com/xenia-canary/xenia-canary/releases/download/$matchCommit/xenia_canary.zip"
+        "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/$matchCommit/xenia_canary_windows.zip"
     }
 }

--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -1,13 +1,13 @@
 {
-    "version": "20250408175152-47f327e",
+    "version": "20250406154947-0771938",
     "description": "Xbox 360 Emulator Research Project (development version)",
     "homepage": "https://github.com/xenia-canary/xenia-canary",
     "license": {
         "identifier": "BSD-3-Clause",
         "url": "https://github.com/xenia-canary/xenia-canary/blob/canary_experimental/LICENSE"
     },
-    "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/47f327e/xenia_canary_windows.zip",
-    "hash": "06e744d2f5a460e25cf6547878a0317139b00642284560b9c6a6813a86bd99e3",
+    "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/0771938/xenia_canary_windows.zip",
+    "hash": "aaf0a88f4c0dd5d5283b7a79c9e2d247edde2a03f2e17ae836971f9fb8627e14",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-Item \"$persist_dir\" -ItemType Directory | Out-Null",

--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "20250406154947-0771938",
+    "version": "20250406155356-0771938",
     "description": "Xbox 360 Emulator Research Project (development version)",
     "homepage": "https://github.com/xenia-canary/xenia-canary",
     "license": {

--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -6,8 +6,12 @@
         "identifier": "BSD-3-Clause",
         "url": "https://github.com/xenia-canary/xenia-canary/blob/canary_experimental/LICENSE"
     },
-    "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/0771938/xenia_canary_windows.zip",
-    "hash": "aaf0a88f4c0dd5d5283b7a79c9e2d247edde2a03f2e17ae836971f9fb8627e14",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/0771938/xenia_canary_windows.zip",
+            "hash": "aaf0a88f4c0dd5d5283b7a79c9e2d247edde2a03f2e17ae836971f9fb8627e14"
+        }
+    },
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-Item \"$persist_dir\" -ItemType Directory | Out-Null",

--- a/bucket/xenia.json
+++ b/bucket/xenia.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.2817",
-    "description": "Xbox 360 Research Emulator",
+    "description": "Xbox 360 Emulator Research Project",
     "homepage": "https://xenia.jp",
     "license": {
         "identifier": "BSD-3-Clause",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Updates xenia-canary.json to:
- Slightly change description to match upstream
- Change homepage to GitHub repo (current one does not refer to canary version of xenia)
- Fixes licence url (change to main branch)
- Uses architecture property to meet scoop manifest guidelines
- Includes new cache folders in persist
- Fixes checkver and autoupdate urls (old location retired).

Updates xenia.json to slightly change description to match upstream.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1361

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
