### PR TITLE
azahar@2120.2: Licence fix & reloaded-ii@1.28.8: Licence fix

### DIFF
--- a/bucket/azahar.json
+++ b/bucket/azahar.json
@@ -3,7 +3,7 @@
     "description": "Open source 3DS emulator project based on Citra",
     "homepage": "https://azahar-emu.org/",
     "license": {
-        "identifier": "GPL-2.0-only",
+        "identifier": "GPL-2.0-or-later",
         "url": "https://github.com/azahar-emu/azahar/blob/master/license.txt"
     },
     "architecture": {

--- a/bucket/reloaded-ii.json
+++ b/bucket/reloaded-ii.json
@@ -3,7 +3,7 @@
     "description": "Universal .NET-powered modding framework for any native x86/x64 game",
     "homepage": "https://reloaded-project.github.io/Reloaded-II/",
     "license": {
-        "identifier": "GPL-3.0-only",
+        "identifier": "GPL-3.0-or-later",
         "url": "https://github.com/Reloaded-Project/Reloaded-II/blob/master/LICENSE.md"
     },
     "suggest": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

The current licence identifiers for `azahar` and `reloaded-ii` are incorrect, this PR remedies that.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #1360 & #1362 

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
