### PR TITLE
xenia, xenia-canary: Improve pre/post install scripts

### DIFF
--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -6,6 +6,9 @@
         "identifier": "BSD-3-Clause",
         "url": "https://github.com/xenia-canary/xenia-canary/blob/canary_experimental/LICENSE"
     },
+    "suggest": {
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/0771938/xenia_canary_windows.zip",
@@ -14,13 +17,14 @@
     },
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
-        "   New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
-        "   New-item \"$persist_dir\\portable.txt\" -ItemType File | Out-Null",
-        "   New-item \"$persist_dir\\xenia-canary.config.toml\" -ItemType File | Out-Null",
+        "   New-item \"$persist_dir\" -ItemType Directory | Out-Null",
         "   if (Test-Path \"$env:USERPROFILE\\Documents\\Xenia\") {",
         "       Write-host \"Migrating AppData...\" -ForegroundColor yellow",
         "       Copy-Item -Path \"$env:USERPROFILE\\Documents\\Xenia\\*\" -Destination \"$persist_dir\" -Recurse",
+        "       Rename-Item \"$persist_dir\\xenia.config.toml\" -NewName \"xenia-canary.config.toml\"",
         "       Remove-Item -Path \"$env:USERPROFILE\\Documents\\Xenia\" -Recurse",
+        "   } else {",
+        "       New-item \"$dir\\xenia-canary.config.toml\" -ItemType File | Out-Null",
         "   }",
         "}"
     ],
@@ -32,13 +36,12 @@
         ]
     ],
     "persist": [
-        "portable.txt",
-        "xenia-canary.config.toml",
-        "content",
         "cache",
         "cache0",
         "cache1",
-        "patches"
+        "content",
+        "patches",
+        "xenia-canary.config.toml"
     ],
     "checkver": {
         "url": "https://github.com/xenia-canary/xenia-canary-releases/releases.atom",
@@ -52,6 +55,10 @@
         "replace": "${year}${month}${day}${hour}${minute}${second}-${commit}"
     },
     "autoupdate": {
-        "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/$matchCommit/xenia_canary_windows.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/$matchCommit/xenia_canary_windows.zip"
+            }
+        }
     }
 }

--- a/bucket/xenia.json
+++ b/bucket/xenia.json
@@ -6,6 +6,9 @@
         "identifier": "BSD-3-Clause",
         "url": "https://github.com/xenia-project/xenia/blob/master/LICENSE"
     },
+    "suggest": {
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/xenia-project/release-builds-windows/releases/download/v1.0.2817-master/xenia_master.zip",
@@ -15,15 +18,16 @@
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
         "   New-item \"$persist_dir\" -ItemType Directory | Out-Null",
-        "   New-item \"$persist_dir\\portable.txt\" -ItemType File | Out-Null",
-        "   New-item \"$persist_dir\\xenia.config.toml\" -ItemType File | Out-Null",
         "   if (Test-Path \"$env:USERPROFILE\\Documents\\Xenia\") {",
         "       Write-host \"Migrating AppData...\" -ForegroundColor yellow",
         "       Copy-Item -Path \"$env:USERPROFILE\\Documents\\Xenia\\*\" -Destination \"$persist_dir\" -Recurse",
         "       Remove-Item -Path \"$env:USERPROFILE\\Documents\\Xenia\" -Recurse",
+        "   } else {",
+        "       New-item \"$dir\\xenia.config.toml\" -ItemType File | Out-Null",
         "   }",
         "}"
     ],
+    "post_install": "New-item \"$dir\\portable.txt\" -ItemType File | Out-Null",
     "bin": "xenia.exe",
     "shortcuts": [
         [
@@ -32,10 +36,9 @@
         ]
     ],
     "persist": [
-        "portable.txt",
-        "xenia.config.toml",
+        "cache",
         "content",
-        "cache"
+        "xenia.config.toml"
     ],
     "checkver": {
         "github": "https://github.com/xenia-project/release-builds-windows",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR makes some improvements to install scripts and other miscellaneous bits.

xenia:
- Add vcredist dependency to suggest
- Remove creation of persistent portable.txt in pre_install script
- Changed how xenia.config.toml is generated (avoid redundancy if appdata migrated)
- Create portable.txt in $dir instead via post_install script

xenia-canary:
- Add vcredist dependency to suggest
- Remove creation of persistent portable.txt as app is inherently portable
- Renamed xenia.config.toml to xenia-canary.config.toml if appdata is migrated
- Changed how xenia-canary.config.toml is generated (avoid redundancy if appdata migrated)
- Removed persisting of now non-existent portable.txt
- Updated autoupdate to include architecture property
 
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
