### PR TITLE
prismlauncher: Persist skins folder

### DIFF
--- a/bucket/prismlauncher.json
+++ b/bucket/prismlauncher.json
@@ -76,6 +76,7 @@
         "logs",
         "meta",
         "mods",
+        "skins",
         "themes",
         "translations"
     ],


### PR DESCRIPTION
This PR adds `skins` to the list of persisted folders on the Prism Launcher manifest.

Closes #1342

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
