### PR TITLE
xenia-canary: Fix persists

### DIFF
--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "20250406155356-0771938",
+    "version": "20250420211300-179591c",
     "description": "Xbox 360 Emulator Research Project (development version)",
     "homepage": "https://github.com/xenia-canary/xenia-canary",
     "license": {
@@ -11,8 +11,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/0771938/xenia_canary_windows.zip",
-            "hash": "aaf0a88f4c0dd5d5283b7a79c9e2d247edde2a03f2e17ae836971f9fb8627e14"
+            "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/179591c/xenia_canary_windows.zip",
+            "hash": "705a84bc9911dd8af5994af3ce708846c17e6a48f381ddfac7d8cf7286159ac6"
         }
     },
     "pre_install": [
@@ -46,14 +46,14 @@
     ],
     "checkver": {
         "url": "https://github.com/xenia-canary/xenia-canary-releases/releases.atom",
+        "regex": "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})T(?<hour>\\d{2}):(?<minute>\\d{2}):(?<second>\\d{2})Z (?<commit>[a-f0-9]+)_canary_experimental",
+        "replace": "${year}${month}${day}${hour}${minute}${second}-${commit}",
         "script": [
             "$xml = [xml]$page",
             "$updated = ($xml.feed.entry | Where-Object {$_.title -ne 'canary_experimental'} | Sort-Object -Descending { $_.updated })[0].updated",
             "$title = ($xml.feed.entry | Where-Object {$_.title -ne 'canary_experimental'} | Sort-Object -Descending { $_.updated })[0].title",
             "Write-Output \"$updated $title\""
-        ],
-        "regex": "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})T(?<hour>\\d{2}):(?<minute>\\d{2}):(?<second>\\d{2})Z (?<commit>[a-f0-9]+)_canary_experimental",
-        "replace": "${year}${month}${day}${hour}${minute}${second}-${commit}"
+        ]
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -38,6 +38,7 @@
     ],
     "persist": [
         "cache",
+        "cache_host",
         "cache0",
         "cache1",
         "content",

--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -46,14 +46,14 @@
     ],
     "checkver": {
         "url": "https://github.com/xenia-canary/xenia-canary-releases/releases.atom",
-        "regex": "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})T(?<hour>\\d{2}):(?<minute>\\d{2}):(?<second>\\d{2})Z (?<commit>[a-f0-9]+)_canary_experimental",
-        "replace": "${year}${month}${day}${hour}${minute}${second}-${commit}",
         "script": [
             "$xml = [xml]$page",
             "$updated = ($xml.feed.entry | Where-Object {$_.title -ne 'canary_experimental'} | Sort-Object -Descending { $_.updated })[0].updated",
             "$title = ($xml.feed.entry | Where-Object {$_.title -ne 'canary_experimental'} | Sort-Object -Descending { $_.updated })[0].title",
             "Write-Output \"$updated $title\""
-        ]
+        ],
+        "regex": "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})T(?<hour>\\d{2}):(?<minute>\\d{2}):(?<second>\\d{2})Z (?<commit>[a-f0-9]+)_canary_experimental",
+        "replace": "${year}${month}${day}${hour}${minute}${second}-${commit}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -24,6 +24,7 @@
         "       Rename-Item \"$persist_dir\\xenia.config.toml\" -NewName \"xenia-canary.config.toml\"",
         "       Remove-Item -Path \"$env:USERPROFILE\\Documents\\Xenia\" -Recurse",
         "   } else {",
+        "       New-item \"$dir\\recent.toml\" -ItemType File | Out-Null",
         "       New-item \"$dir\\xenia-canary.config.toml\" -ItemType File | Out-Null",
         "   }",
         "}"
@@ -41,6 +42,7 @@
         "cache1",
         "content",
         "patches",
+        "recent.toml",
         "xenia-canary.config.toml"
     ],
     "checkver": {

--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -39,8 +39,6 @@
     "persist": [
         "cache",
         "cache_host",
-        "cache0",
-        "cache1",
         "content",
         "patches",
         "recent.toml",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Changes made in this PR:
- Added persist for cache_host folder
- Added persist for recent.toml file
- Removed persist for cache0 folder
- Removed persist for cache1 folder

The cache0 & 1 folders do not require persistence as they do not contain any data that would aide running (or even re-running) games on xenia-canary. 

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
