### PR TITLE
project64-dev: Fix installation failure

### DIFF
--- a/bucket/project64-dev.json
+++ b/bucket/project64-dev.json
@@ -6,7 +6,7 @@
         "identifier": "GPL-2.0",
         "url": "https://github.com/project64/project64/blob/develop/license.md"
     },
-    "url": "https://www.pj64-emu.com/file/setup-project64-Dev-4-0-0-6566-fbbf7c7/",
+    "url": "https://www.pj64-emu.com/file/setup-project64-Dev-4-0-0-6566-fbbf7c7/#/setup-project64-Dev-4-0-0-6566-fbbf7c7.exe",
     "hash": "2e8bc0012b59d83d8efd5c4f1c3fcd291f888b0bd75baebc8eac832d3129dcc7",
     "bin": [
         [
@@ -34,7 +34,7 @@
         "regex": "((?<major>[\\d]+)\\.(?<minor>[\\d]+)\\.(?<patch>[\\d]+)-(?<build>[\\d]+)-(?<commit>[\\da-f]+))"
     },
     "autoupdate": {
-        "url": "https://www.pj64-emu.com/file/setup-project64-Dev-$dashVersion/"
+        "url": "https://www.pj64-emu.com/file/setup-project64-Dev-$dashVersion/#/setup-project64-Dev-$dashVersion.exe"
     },
     "innosetup": true
 }


### PR DESCRIPTION
The `Expand-InnoArchive` function is not triggered for non-`.exe` files, despite the `innosetup` parameter being enabled.

This PR makes the following changes to `project64-dev`:
- Update `download url` & `autoupdate url` to fix installation failure.

Closes #1394