### PR TITLE
undertale-mod-tool: Fix installation

### DIFF
--- a/bucket/undertale-mod-tool.json
+++ b/bucket/undertale-mod-tool.json
@@ -17,6 +17,6 @@
         "regex": "tags/([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/UnderminersTeam/UndertaleModTool/releases/download/$version/UndertaleModTool_v$version-Windows.zip",
+        "url": "https://github.com/UnderminersTeam/UndertaleModTool/releases/download/$version/UndertaleModTool_v$version-Windows.zip"
     }
 }


### PR DESCRIPTION
This PR makes the following changes:
- Reomve extra comma in `undertale-mod-tool.json` to fix installation.

Relates to #1383