### PR TITLE
ryujinx: Add arm64 arch & suggest

### DIFF
--- a/bucket/ryujinx-canary.json
+++ b/bucket/ryujinx-canary.json
@@ -10,10 +10,17 @@
         "ATTENTION: Ryujinx requires Nintendo Switch firmware and a prod.keys file to function.",
         "Learn more at https://git.ryujinx.app/ryubing/ryujinx/-/wikis/FAQ-&-Troubleshooting"
     ],
+    "suggest": {
+        "Switch Army Knife (SAK)": "games/sak"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/Ryubing/Canary-Releases/releases/download/1.3.40/ryujinx-canary-1.3.40-win_x64.zip",
             "hash": "2899bf342378110c667bb9b3d0788fcde78d07d01b88172f63e98e885e2f174c"
+        },
+        "arm64": {
+            "url": "https://github.com/Ryubing/Canary-Releases/releases/download/1.3.40/ryujinx-canary-1.3.40-win_arm64.zip",
+            "hash": "401cf61091f4da29c0e1f2b31212599e6ad03b880635a2bc402dd6a5e1e9f0db"
         }
     },
     "extract_dir": "publish",
@@ -42,6 +49,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/Ryubing/Canary-Releases/releases/download/$version/ryujinx-canary-$version-win_x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Ryubing/Canary-Releases/releases/download/$version/ryujinx-canary-$version-win_arm64.zip"
             }
         }
     }

--- a/bucket/ryujinx.json
+++ b/bucket/ryujinx.json
@@ -10,10 +10,17 @@
         "ATTENTION: Ryujinx requires Nintendo Switch firmware and a prod.keys file to function.",
         "Learn more at https://git.ryujinx.app/ryubing/ryujinx/-/wikis/FAQ-&-Troubleshooting"
     ],
+    "suggest": {
+        "Switch Army Knife (SAK)": "games/sak"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/Ryubing/Stable-Releases/releases/download/1.3.1/ryujinx-1.3.1-win_x64.zip",
             "hash": "438e643d5e8a8ccde9eca9e6a3432b59578e01fe9f5e1fbd3e27cee4e476ecf5"
+        },
+        "arm64": {
+            "url": "https://github.com/Ryubing/Stable-Releases/releases/download/1.3.1/ryujinx-1.3.1-win_arm64.zip",
+            "hash": "32dd21271e20ac9ef34a51a5e07ebcea30f7bec8b33cfe70b6e6779ed26076d6"
         }
     },
     "extract_dir": "publish",
@@ -42,6 +49,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/Ryubing/Stable-Releases/releases/download/$version/ryujinx-$version-win_x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Ryubing/Stable-Releases/releases/download/$version/ryujinx-$version-win_arm64.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- Add `arm64 arch` & `suggest` for `ryujinx` and `ryujinx-canary`.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
