### PR TITLE
assetstudio: add suggest

### DIFF
--- a/bucket/assetstudio.json
+++ b/bucket/assetstudio.json
@@ -3,6 +3,9 @@
     "description": "Tool for exploring, extracting and exporting Unity assets and assetbundles.",
     "homepage": "https://github.com/zhangjiequan/AssetStudio",
     "license": "MIT",
+    "suggest": {
+        ".NET 6.0 Desktop Runtime": "versions/windowsdesktop-runtime-6.0"
+    },
     "url": "https://github.com/zhangjiequan/AssetStudio/releases/download/v0.16.53/AssetStudio.net6.0-windows_v0.16.53.zip",
     "hash": "0922b22b62853cd77e7b796124d52373fc1e1257179a1e3f3d7258137723616b",
     "bin": "AssetStudioGUI.exe",


### PR DESCRIPTION
> PS >> assetstudiogui.exe 
> You must install .NET to run this application.
> 
> App: D:\Scoop\apps\assetstudio\current\AssetStudioGUI.exe
> Architecture: x64
> App host version: 6.0.25
> .NET location: Not found

AssetStudio in games bucket is a `.NET 6.0` version.
> {
>     ......
>     "url": ".../download/v0.16.53/AssetStudio.net6.0-windows_v0.16.53.zip",
>     ......
> }

It requires `.NET 6.0` to work properly: https://github.com/zhangjiequan/AssetStudio?tab=readme-ov-file#requirements

This PS makes the following changes:
- Add `suggest` for `assetstudio`.



- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
