### PR TITLE
chiaki-ng: Add arm64 build, switch x64 to MSYS2 build

### DIFF
--- a/bucket/chiaki-ng.json
+++ b/bucket/chiaki-ng.json
@@ -3,7 +3,7 @@
     "description": "Next-Generation of Chiaki (the open-source remote play client for PlayStation)",
     "homepage": "https://streetpea.github.io/chiaki-ng/",
     "license": {
-        "identifier": "AGPL-3.0-only",
+        "identifier": "AGPL-3.0-or-later",
         "url": "https://github.com/streetpea/chiaki-ng/blob/main/COPYING"
     },
     "suggest": {
@@ -11,8 +11,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/streetpea/chiaki-ng/releases/download/v1.9.7/chiaki-ng-win_x64-VC-portable-1.9.7.zip",
-            "hash": "dc70ab2d7bf81014a07496936347b346cc7ce6798f69f42b3d50007c0b391590"
+            "url": "https://github.com/streetpea/chiaki-ng/releases/download/v1.9.7/chiaki-ng-win_x64-MSYS2-portable-1.9.7.zip",
+            "hash": "35e35a2b8c1041d344afe5e3ccfff0efc5549d060fb57b0ab4b5dfc8d9716e4a"
+        },
+        "arm64": {
+            "url": "https://github.com/streetpea/chiaki-ng/releases/download/v1.9.7/chiaki-ng-win_arm64-MSYS2-portable-1.9.7.zip",
+            "hash": "652417dc8116e08522e0b7958ae8e757fed97d1652912051ab90938e7505971b"
         }
     },
     "extract_dir": "chiaki-ng-Win",
@@ -38,7 +42,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/streetpea/chiaki-ng/releases/download/v$version/chiaki-ng-win_x64-VC-portable-$version.zip"
+                "url": "https://github.com/streetpea/chiaki-ng/releases/download/v$version/chiaki-ng-win_x64-MSYS2-portable-$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/streetpea/chiaki-ng/releases/download/v$version/chiaki-ng-win_arm64-MSYS2-portable-$version.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR does the following:
- Adds an arm64 build
- Switches the x64 build to the MSYS2 version (as VC version no longer exists)
- Fixes licence

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
