### PR TITLE
mcreator@2025.1: Add manifest for MCreator app

### DIFF
--- a/mcreator.json
+++ b/mcreator.json
@@ -1,0 +1,9 @@
+{
+  "version": "2025.1",
+  "description": "MCreator - Minecraft mod maker",
+  "homepage": "https://mcreator.net/",
+  "license": "GPL-3.0-or-later",
+  "url": "https://github.com/MCreator/MCreator/releases/download/2025.1.13416/MCreator.2025.1.Windows.64bit.zip",
+  "hash": "sha256:71924E1A76019266A1A7D1C6CA33AC38BE4EC3533F2A925ACE22154A545FC522",
+  "bin": "MCreator20251\\mcreator.exe"
+}


### PR DESCRIPTION
This pull request adds a Scoop manifest for MCreator version 2025.1.

- Downloads official release zip from GitHub
- Includes SHA256 hash for verification
- Adds the main executable for easy access

Tested locally, installs and runs fine.

- [x] Use conventional PR title: mcreator@2025.1: Add manifest for MCreator app
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)