### PR TITLE
cambridge@0.3.4: Fix urls, fix hash

### DIFF
--- a/bucket/cambridge.json
+++ b/bucket/cambridge.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/MillaBasset/cambridge/releases/download/v0.3.4/cambridge-win32.zip",
-            "hash": "69eade4d797d5a643b309377406b3e7f6f611f5b27e7b215dd9fb10564f0af6d"
+            "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v0.3.4/cambridge-win32.zip",
+            "hash": "af00abda285d26108d9f40c6800bcfb9c6de1b9801eb4389fe871a141438c17b"
         },
         "64bit": {
-            "url": "https://github.com/MillaBasset/cambridge/releases/download/v0.3.4/cambridge-windows.zip",
-            "hash": "64bbf1e22eb5495fc6668cd401201cd666bf149ef931f1ddd93faa17e85e46e9"
+            "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v0.3.4/cambridge-windows.zip",
+            "hash": "9dfb127950a811c26555974686547e218c0c44469596127e1052a13127b17ac5"
         }
     },
     "shortcuts": [
@@ -20,15 +20,15 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/MillaBasset/cambridge"
+        "github": "https://github.com/cambridge-stacker/cambridge"
     },
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/MillaBasset/cambridge/releases/download/v$version/cambridge-win32.zip"
+                "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v$version/cambridge-win32.zip"
             },
             "64bit": {
-                "url": "https://github.com/MillaBasset/cambridge/releases/download/v$version/cambridge-windows.zip"
+                "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v$version/cambridge-windows.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `cambridge@0.3.4`: Fix urls, fix hash.

Relates to #1406

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).