### PR TITLE
katrain: Update to version 1.16, fix autoupdate

### DIFF
--- a/bucket/katrain.json
+++ b/bucket/katrain.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.10.1",
+    "version": "1.16",
     "description": "A tool for analyzing and playing go with AI feedback from KataGo",
     "homepage": "https://github.com/sanderland/katrain",
     "license": "MIT",
@@ -7,8 +7,8 @@
         "KaTrain config is stored in C:\\Users\\[USERNAME]\\.katrain",
         "Kivy config is stored C:\\Users\\[USERNAME]\\.kivy"
     ],
-    "url": "https://github.com/sanderland/katrain/releases/download/1.10.1/KaTrain.zip",
-    "hash": "70e878d87f28b8149506311570788bdc2456d5cc1865a263940388510f6cd129",
+    "url": "https://github.com/sanderland/katrain/releases/download/v1.16/KaTrain.zip",
+    "hash": "3624d9890f800898326cddf0e87f930ceb59dcaf89e1143ecdaf73fccdef6328",
     "extract_dir": "KaTrain",
     "shortcuts": [
         [
@@ -19,6 +19,6 @@
     "persist": "sgfout",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/sanderland/katrain/releases/download/$version/KaTrain.zip"
+        "url": "https://github.com/sanderland/katrain/releases/download/v$version/KaTrain.zip"
     }
 }


### PR DESCRIPTION
This PR makes the following changes:
- `katrain`: Update to version 1.16, fix autoupdate.

Relates to #1406

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).