### PR TITLE
cataclysm-dda-tiles(-experimental): Update version, fix urls

### DIFF
--- a/bucket/cataclysm-dda-tiles-experimental.json
+++ b/bucket/cataclysm-dda-tiles-experimental.json
@@ -1,12 +1,12 @@
 {
-    "version": "2024-11-15-0247",
+    "version": "2025-05-28-0547",
     "description": "Roguelike in a post-apocalyptic world (with sprite-based graphics, experimental build)",
     "homepage": "https://cataclysmdda.org",
     "license": "CC-BY-SA-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-experimental-2024-11-15-0247/cdda-windows-tiles-x64-2024-11-15-0247.zip",
-            "hash": "61c5ed7b34d4e98bffea622bddb715cdabe010c9418a8ad5802def2643711b08"
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-experimental-2025-05-28-0547/cdda-windows-with-graphics-and-sounds-x64-2025-05-28-0547.zip",
+            "hash": "c80e45d6a2c5f4fbb0c96507e0c9e2d801361ac4987ed7473e77995d2c3cdf56"
         }
     },
     "shortcuts": [
@@ -22,13 +22,13 @@
         "templates"
     ],
     "checkver": {
-        "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/",
-        "re": "Cataclysm-DDA experimental build ([\\d.-]+)"
+        "url": "https://api.github.com/repos/CleverRaven/Cataclysm-DDA/releases",
+        "regex": "cdda-experimental-(?<version>\\d{4}-\\d{2}-\\d{2}-\\d{4})/cdda-windows-with-graphics-and-sounds-x64-\\k<version>\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-experimental-$version/cdda-windows-tiles-x64-$version.zip"
+                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/cdda-experimental-$version/cdda-windows-with-graphics-and-sounds-x64-$version.zip"
             }
         }
     }

--- a/bucket/cataclysm-dda-tiles.json
+++ b/bucket/cataclysm-dda-tiles.json
@@ -1,19 +1,15 @@
 {
     "homepage": "https://cataclysmdda.org",
     "description": "Roguelike in a post-apocalyptic world (with sprite-based graphics)",
-    "version": "0.G",
+    "version": "0.H-RELEASE",
     "license": {
         "identifier": "CC-BY-SA-3.0,GPL-2.0+,OFL-1.0,BSL-1.0,Zlib,MIT,BSD(libbacktrace)",
         "url": "https://github.com/CleverRaven/Cataclysm-DDA/blob/master/LICENSE.txt"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.G/cdda-windows-tiles-x64-2023-03-01-0054.zip",
-            "hash": "d55283e881d9d70af4823b2486d776e4bf30f2a4e53e0ebb25f8fd53f4b0d363"
-        },
-        "32bit": {
-            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.G/cdda-windows-tiles-x32-2023-03-01-0054.zip",
-            "hash": "e7ca644fbf65463694e7869a01a6b3888bff74579322adb37755a0aaec0fec74"
+            "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/0.H-RELEASE/cdda-windows-with-graphics-and-sounds-x64-2024-11-23-1857.zip",
+            "hash": "856b4e27f570b0ffb791e4572dab5691b79918c15b41d36e49ab689419231540"
         }
     },
     "shortcuts": [
@@ -29,16 +25,13 @@
         "templates"
     ],
     "checkver": {
-        "url": "https://cataclysmdda.org/releases/",
-        "regex": "The most recent stable release is ([\\d\\-.A-Z]+)?( )"
+        "url": "https://api.github.com/repos/CleverRaven/Cataclysm-DDA/releases/latest",
+        "regex": "releases/download/(?<version>[\\w\\.-]+)/cdda-windows-with-graphics-and-sounds-x64-(?<date>[\\d-]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/$version/cdda-windows-tiles-x64-2023-03-01-0054.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/$version/cdda-windows-tiles-x32-2023-03-01-0054.zip"
+                "url": "https://github.com/CleverRaven/Cataclysm-DDA/releases/download/$version/cdda-windows-with-graphics-and-sounds-x64-$matchDate.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `cataclysm-dda-tiles`: Update to version 0.H-RELEASE, remove 32bit arch, fix checkver, fix autoupdate.
- `cataclysm-dda-tiles-experimental`: Update to version 2025-05-28-0547, fix checkver, fix autoupdate.

Relates to #1406

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).