### PR TITLE
endless-sky@0.10.12: Fix shortcuts, remove bin

### DIFF
--- a/bucket/endless-sky.json
+++ b/bucket/endless-sky.json
@@ -9,10 +9,9 @@
             "hash": "de70d21050615685f715e1ccf7832098e1da1594ffd73634165444b0ce2929f3"
         }
     },
-    "bin": "EndlessSky.exe",
     "shortcuts": [
         [
-            "EndlessSky.exe",
+            "Endless Sky.exe",
             "Endless Sky"
         ]
     ],


### PR DESCRIPTION
This PR makes the following changes:
- `endless-sky@0.10.12`: Fix shortcuts, remove bin.

Relates to #1413

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).