### PR TITLE
Fishstrap: add version 2.9.1.2

### DIFF
--- a/bucket/fishstrap.json
+++ b/bucket/fishstrap.json
@@ -14,11 +14,12 @@
         }
     },
     "installer": {
-        "script": "if ($cmd -eq 'update') {Start-Process \"$dir\\$framescoop \" -Wait -Args @('-quiet', '-upgrade'); } else { Start-Process \"$dir\\$fname\" -Wait -Args @('-quiet'); }"
+        "script": "if ($cmd -eq 'update') {Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-quiet', '-upgrade'); } else { Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-quiet'); }"
     },
     "uninstaller": {
         "script": "Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-uninstall', '-quiet');  Remove-Item 'HKCU:\\SOFTWARE\\Classes\\roblox\\', 'HKCU:\\SOFTWARE\\Classes\\roblox-player\\' -Recurse -Force"
     },
+    "post_uninstall": ["Remove-Item \"$dir\\Fishstrap\\\" -Recurse -Force"],
     "checkver": {
         "github": "https://github.com/fishstrap/fishstrap"
     },

--- a/bucket/fishstrap.json
+++ b/bucket/fishstrap.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
     "version": "2.9.1.2",
-    "description": "Fishstrap is a Bloxstrap fork aiming to enhance some of the features.",
+    "description": "Bloxstrap fork aiming to enhance some features",
     "homepage": "https://www.fishstrap.app/",
     "license": "MIT",
     "architecture": {

--- a/bucket/fishstrap.json
+++ b/bucket/fishstrap.json
@@ -17,9 +17,8 @@
         "script": "if ($cmd -eq 'update') {Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-quiet', '-upgrade'); } else { Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-quiet'); }"
     },
     "uninstaller": {
-        "script": "Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-uninstall', '-quiet');  Remove-Item 'HKCU:\\SOFTWARE\\Classes\\roblox\\', 'HKCU:\\SOFTWARE\\Classes\\roblox-player\\' -Recurse -Force"
+        "script": "Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-uninstall', '-quiet');"
     },
-    "post_uninstall": ["Remove-Item \"$dir\\Fishstrap\\\" -Recurse -Force"],
     "checkver": {
         "github": "https://github.com/fishstrap/fishstrap"
     },

--- a/bucket/fishstrap.json
+++ b/bucket/fishstrap.json
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/fishstrap/fishstrap/releases/download/v$version/Fishstrap-$version.exe#/Fishstrap.exe"
+                "url": "https://github.com/fishstrap/fishstrap/releases/download/v$version/Fishstrap-v$version.exe#/Fishstrap.exe"
             }
         }
     }

--- a/bucket/fishstrap.json
+++ b/bucket/fishstrap.json
@@ -4,6 +4,7 @@
     "description": "Bloxstrap fork aiming to enhance some features",
     "homepage": "https://www.fishstrap.app/",
     "license": "MIT",
+    "depends": "versions/windowsdesktop-runtime-6.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/fishstrap/fishstrap/releases/download/v2.9.1.2/Fishstrap-v2.9.1.2.exe#/Fishstrap.exe",
@@ -15,6 +16,9 @@
     },
     "uninstaller": {
         "script": "Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-uninstall', '-quiet');  Remove-Item 'HKCU:\\SOFTWARE\\Classes\\roblox\\', 'HKCU:\\SOFTWARE\\Classes\\roblox-player\\' -Recurse -Force"
+    },
+    "checkver": {
+        "github": "https://github.com/fishstrap/fishstrap"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/fishstrap.json
+++ b/bucket/fishstrap.json
@@ -4,7 +4,9 @@
     "description": "Bloxstrap fork aiming to enhance some features",
     "homepage": "https://www.fishstrap.app/",
     "license": "MIT",
-    "depends": "versions/windowsdesktop-runtime-6.0",
+    "suggest": {
+        ".NET 6.0 Desktop Runtime": "versions/windowsdesktop-runtime-6.0"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/fishstrap/fishstrap/releases/download/v2.9.1.2/Fishstrap-v2.9.1.2.exe#/Fishstrap.exe",

--- a/bucket/fishstrap.json
+++ b/bucket/fishstrap.json
@@ -14,7 +14,7 @@
         }
     },
     "installer": {
-        "script": "if ($cmd -eq 'update') {Start-Process \"$dir\\$fnamescoop \" -Wait -Args @('-quiet', '-upgrade'); } else { Start-Process \"$dir\\$fname\" -Wait -Args @('-quiet'); }"
+        "script": "if ($cmd -eq 'update') {Start-Process \"$dir\\$framescoop \" -Wait -Args @('-quiet', '-upgrade'); } else { Start-Process \"$dir\\$fname\" -Wait -Args @('-quiet'); }"
     },
     "uninstaller": {
         "script": "Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-uninstall', '-quiet');  Remove-Item 'HKCU:\\SOFTWARE\\Classes\\roblox\\', 'HKCU:\\SOFTWARE\\Classes\\roblox-player\\' -Recurse -Force"

--- a/bucket/fishstrap.json
+++ b/bucket/fishstrap.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+    "version": "2.9.1.2",
+    "description": "Fishstrap is a Bloxstrap fork aiming to enhance some of the features.",
+    "homepage": "https://www.fishstrap.app/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fishstrap/fishstrap/releases/download/v2.9.1.2/Fishstrap-v2.9.1.2.exe#/Fishstrap.exe",
+            "hash": "sha256:49EAB3E743C5FFF94C41BCEDBDA02B00C42009A8A0F38281103D91ABFD418A62"
+        }
+    },
+    "installer": {
+        "script": "if ($cmd -eq 'update') {Start-Process \"$dir\\$fnamescoop \" -Wait -Args @('-quiet', '-upgrade'); } else { Start-Process \"$dir\\$fname\" -Wait -Args @('-quiet'); }"
+    },
+    "uninstaller": {
+        "script": "Start-Process \"$dir\\Fishstrap.exe\" -Wait -Args @('-uninstall', '-quiet');  Remove-Item 'HKCU:\\SOFTWARE\\Classes\\roblox\\', 'HKCU:\\SOFTWARE\\Classes\\roblox-player\\' -Recurse -Force"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fishstrap/fishstrap/releases/download/v$version/Fishstrap-$version.exe#/Fishstrap.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the addition of Fishstrap (a fork of Bloxstrap) to scoop. I have been requested a few times over on GitHub/ Discord, so I thought I would take up the issue as I wanted it on scoop myself.

closes #1324 

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
