### PR TITLE
megamek(-dev), megameklab(-dev), megahq(-dev): Update to version 0.50.06, fix checkver, fix autoupdate, add hash, add extract_dir

### DIFF
--- a/bucket/megamek-dev.json
+++ b/bucket/megamek-dev.json
@@ -3,7 +3,9 @@
     "description": "Free turn-based strategy game based on the classic BattleTech/MechWarrior universe (development version)",
     "homepage": "https://megamek.org",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/MegaMek/megamek/releases/download/v0.50.06/megamek-windows-0.50.06.zip",
+    "url": "https://github.com/MegaMek/megamek/releases/download/v0.50.06/megamek-0.50.06.tar.gz",
+    "hash": "c38af9cb2ff0298905169e63b3c3923ceaf3f7a53702c24f6dd05e1810112219",
+    "extract_dir": "MegaMek-0.50.06",
     "shortcuts": [
         [
             "MegaMek.exe",
@@ -11,9 +13,11 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/MegaMek/megamek"
+        "url": "https://megamek.org/downloads.html",
+        "re": "MegaMek[\\s\\S]+?Milestone:[\\s]+(?<version>[\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/MegaMek/megamek/releases/download/v$version/megamek-windows-$version.zip"
+        "url": "https://github.com/MegaMek/megamek/releases/download/v$version/megamek-$version.tar.gz",
+        "extract_dir": "MegaMek-$version"
     }
 }

--- a/bucket/megamek.json
+++ b/bucket/megamek.json
@@ -1,9 +1,11 @@
 {
-    "version": "0.48.0",
+    "version": "0.50.06",
     "description": "Free turn-based strategy game based on the classic BattleTech/MechWarrior universe",
     "homepage": "https://megamek.org",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/MegaMek/megamek/releases/download/v0.48.0/megamek-windows-0.48.0.zip",
+    "url": "https://github.com/MegaMek/megamek/releases/download/v0.50.06/megamek-0.50.06.tar.gz",
+    "hash": "c38af9cb2ff0298905169e63b3c3923ceaf3f7a53702c24f6dd05e1810112219",
+    "extract_dir": "MegaMek-0.50.06",
     "shortcuts": [
         [
             "MegaMek.exe",
@@ -12,9 +14,10 @@
     ],
     "checkver": {
         "url": "https://megamek.org/downloads.html",
-        "re": "Stable: ([\\d.]+)"
+        "re": "MegaMek[\\s\\S]+?Milestone:[\\s]+(?<version>[\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/MegaMek/megamek/releases/download/v$version/megamek-windows-$version.zip"
+        "url": "https://github.com/MegaMek/megamek/releases/download/v$version/megamek-$version.tar.gz",
+        "extract_dir": "MegaMek-$version"
     }
 }

--- a/bucket/megameklab-dev.json
+++ b/bucket/megameklab-dev.json
@@ -3,7 +3,9 @@
     "description": "BattleTech unit modification program for MegaMek (development version)",
     "homepage": "https://megamek.org",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/MegaMek/megameklab/releases/download/v0.50.06/megameklab-windows-0.50.06.zip",
+    "url": "https://github.com/MegaMek/megameklab/releases/download/v0.50.06/megameklab-0.50.06.tar.gz",
+    "hash": "48baf8914ac041149565ff5d9cceed4a6cba55785eaa79c69e29a7109cf1859f",
+    "extract_dir": "MegaMekLab-0.50.06",
     "shortcuts": [
         [
             "MegaMekLab.exe",
@@ -11,9 +13,11 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/MegaMek/megameklab"
+        "url": "https://megamek.org/downloads.html",
+        "re": "MegaMekLab[\\s\\S]+?Development:[\\s]+(?<version>[\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/MegaMek/megameklab/releases/download/v$version/megameklab-windows-$version.zip"
+        "url": "https://github.com/MegaMek/megameklab/releases/download/v$version/megameklab-$version.tar.gz",
+        "extract_dir": "MegaMekLab-$version"
     }
 }

--- a/bucket/megameklab.json
+++ b/bucket/megameklab.json
@@ -1,9 +1,11 @@
 {
-    "version": "0.48.0",
+    "version": "0.50.06",
     "description": "BattleTech unit modification program for MegaMek",
     "homepage": "https://megamek.org",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/MegaMek/megameklab/releases/download/v0.48.0/megameklab-windows-0.48.0.zip",
+    "url": "https://github.com/MegaMek/megameklab/releases/download/v0.50.06/megameklab-0.50.06.tar.gz",
+    "hash": "48baf8914ac041149565ff5d9cceed4a6cba55785eaa79c69e29a7109cf1859f",
+    "extract_dir": "MegaMekLab-0.50.06",
     "shortcuts": [
         [
             "MegaMekLab.exe",
@@ -12,9 +14,10 @@
     ],
     "checkver": {
         "url": "https://megamek.org/downloads.html",
-        "re": "Stable: ([\\d.]+)"
+        "re": "MegaMekLab[\\s\\S]+?Milestone:[\\s]+(?<version>[\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/MegaMek/megameklab/releases/download/v$version/megameklab-windows-$version.zip"
+        "url": "https://github.com/MegaMek/megameklab/releases/download/v$version/megameklab-$version.tar.gz",
+        "extract_dir": "MegaMekLab-$version"
     }
 }

--- a/bucket/mekhq-dev.json
+++ b/bucket/mekhq-dev.json
@@ -3,7 +3,9 @@
     "description": "Helper program for MegaMek - includes MegaMek and MegaMekLab (development version)",
     "homepage": "https://megamek.org",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/MegaMek/mekhq/releases/download/v0.50.06/mekhq-windows-0.50.06.zip",
+    "url": "https://github.com/MegaMek/mekhq/releases/download/v0.50.06/mekhq-0.50.06.tar.gz",
+    "hash": "673cfab23ef67be7d379b8f050b9d8a05fe613b3a6299dad916fa33b1c6fb639",
+    "extract_dir": "MekHQ-0.50.06",
     "shortcuts": [
         [
             "MekHQ.exe",
@@ -19,9 +21,11 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/MegaMek/mekhq"
+        "url": "https://megamek.org/downloads.html",
+        "re": "MekHQ[\\s\\S]+?Development:[\\s]+(?<version>[\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/MegaMek/mekhq/releases/download/v$version/mekhq-windows-$version.zip"
+        "url": "https://github.com/MegaMek/mekhq/releases/download/v$version/mekhq-$version.tar.gz",
+        "extract_dir": "MekHQ-$version"
     }
 }

--- a/bucket/mekhq.json
+++ b/bucket/mekhq.json
@@ -1,9 +1,11 @@
 {
-    "version": "0.48.0",
+    "version": "0.50.06",
     "description": "Helper program for MegaMek - includes MegaMek and MegaMekLab",
     "homepage": "https://megamek.org",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/MegaMek/mekhq/releases/download/v0.48.0/mekhq-windows-0.48.0.zip",
+    "url": "https://github.com/MegaMek/mekhq/releases/download/v0.50.06/mekhq-0.50.06.tar.gz",
+    "hash": "673cfab23ef67be7d379b8f050b9d8a05fe613b3a6299dad916fa33b1c6fb639",
+    "extract_dir": "MekHQ-0.50.06",
     "shortcuts": [
         [
             "MekHQ.exe",
@@ -20,9 +22,10 @@
     ],
     "checkver": {
         "url": "https://megamek.org/downloads.html",
-        "re": "Stable: ([\\d.]+)"
+        "re": "MekHQ[\\s\\S]+?Milestone:[\\s]+(?<version>[\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/MegaMek/mekhq/releases/download/v$version/mekhq-windows-$version.zip"
+        "url": "https://github.com/MegaMek/mekhq/releases/download/v$version/mekhq-$version.tar.gz",
+        "extract_dir": "MekHQ-$version"
     }
 }


### PR DESCRIPTION
This PR makes the following changes:
- `megamek(-dev), megameklab(-dev), megahq(-dev)`: Update to version 0.50.06, fix checkver, fix autoupdate, add hash, add extract_dir.

Relates to #1406

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).