### PR TITLE
enigma@1.30: Remove hash extraction

### DIFF
--- a/bucket/enigma.json
+++ b/bucket/enigma.json
@@ -18,10 +18,6 @@
     },
     "autoupdate": {
         "url": "https://github.com/Enigma-Game/Enigma/releases/download/$version/Enigma-$version-windows10.zip",
-        "hash": {
-            "url": "https://www.nongnu.org/enigma/download.html",
-            "regex": "(?sm)<b>Windows</b>.+?\\.zip file.+?<li>sha256 - $sha256</li>"
-        },
         "extract_dir": "Enigma-$version"
     }
 }


### PR DESCRIPTION
This PR makes the following changes:
- `enigma@1.30`: Remove hash extraction. Since it may get an incorrect hash value...

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).