### PR TITLE
melonds: fix incorrect persistence logic

### DIFF
--- a/bucket/melonds.json
+++ b/bucket/melonds.json
@@ -10,9 +10,14 @@
     "hash": "eda68ed9295bfce4504d9356d3614fbd77648dc3ab1e4ad415f78778f745b33e",
     "installer": {
         "script": [
-            "$FILE = 'melonDS.ini'",
-            "if (!(Test-Path \"$persist_dir\\$FILE\")) {",
-            "    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
+            "if (Test-Path \"$persist_dir\\melonDS.toml\" -PathType Container) {",
+            "    Remove-Item \"$persist_dir\\melonDS.toml\" -Recurse -Force",
+            "}",
+            "$FILES = @('melonDS.ini', 'melonDS.toml')",
+            "foreach ($FILE in $FILES) {",
+            "    if (!(Test-Path \"$persist_dir\\$FILE\")) {",
+            "        New-Item \"$dir\\$FILE\" -Type File | Out-Null",
+            "    }",
             "}"
         ]
     },


### PR DESCRIPTION
@Calinou sorry, #1431 has a [mistake](https://github.com/Calinou/scoop-games/issues/1430#issuecomment-2937159498)

Since `melonds.toml` doesn't exist initially, it's created by scoop as a folder, including when you `scoop update --force melonds` with the file _already existing_, apparently. Looks like `melonds.ini` already had special handling for not existing during install.

I modified the manifest locally this time and did `scoop update --force melonds` again. It correctly deleted the invalid _folder_ symlink created by running #1431, and set up the toml file correctly. Melonds functioned normally on its first run after this upgrade, including storing changed settings in the toml file.

![image](https://github.com/user-attachments/assets/cdea4d3f-5766-4866-b570-c36eeefd7884)

One thing I'm not sure how to test correctly now is the case of someone with a <1.0 version with content in the .ini file upgrading to 1.0 and this updated manifest preemptively creating the toml file. If melonds' logic to trigger its ini content migration is the absence of the toml file, creating the toml file ahead of time breaks this migration. We could test this and check melonds' code, but it feels wrong to entangle the manifest so hard with remote implementation details.

I would suggest we merge this for now anyway because #1431 left alone is positively breaking.

People who've run #1431 in the past few hours will need to `--force` run this change (or wait for a melonds update), or manually delete the folder symlink. Maybe you know a way to further enhance this but I feel we'd be working a problem that hasn't actually occurred in the wild yet.

Sorry for the mess, I've never worked on scoop packages before.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
