### PR TITLE
ryujinx(-canary): Update URLs, drop arm64 support

### DIFF
--- a/bucket/ryujinx-canary.json
+++ b/bucket/ryujinx-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.3.62",
+    "version": "1.3.73",
     "description": "A simple, experimental Nintendo Switch emulator",
     "homepage": "https://ryujinx.app/",
     "license": {
@@ -15,12 +15,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/iurehg8uetgyh8ui5e/cr/releases/download/1.3.62/ryujinx-canary-1.3.62-win_x64.zip",
-            "hash": "c649c090eb840a8a346dc08f5916c44cef8c2c9dd502633de2f412c5957c1dc8"
-        },
-        "arm64": {
-            "url": "https://github.com/iurehg8uetgyh8ui5e/cr/releases/download/1.3.62/ryujinx-canary-1.3.62-win_arm64.zip",
-            "hash": "b9b8863f210d6f4c5234590befd008edf214392f9e6b95cf14309779d1d9cdef"
+            "url": "https://git.ryujinx.app/api/v4/projects/68/packages/generic/Ryubing-Canary/1.3.73/ryujinx-canary-1.3.73-win_x64.zip",
+            "hash": "4bfc17161eab6520033de94367eea86e553f3e417953d27c95c2969f1cc782d9"
         }
     },
     "extract_dir": "publish",
@@ -43,15 +39,13 @@
     ],
     "persist": "portable",
     "checkver": {
-        "github": "https://github.com/iurehg8uetgyh8ui5e/cr"
+        "url": "https://git.ryujinx.app/api/v4/projects/ryubing%2Fcanary/releases",
+        "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/iurehg8uetgyh8ui5e/cr/releases/download/$version/ryujinx-canary-$version-win_x64.zip"
-            },
-            "arm64": {
-                "url": "https://github.com/iurehg8uetgyh8ui5e/cr/releases/download/$version/ryujinx-canary-$version-win_arm64.zip"
+                "url": "https://git.ryujinx.app/api/v4/projects/68/packages/generic/Ryubing-Canary/$version/ryujinx-canary-$version-win_x64.zip"
             }
         }
     }

--- a/bucket/ryujinx.json
+++ b/bucket/ryujinx.json
@@ -15,12 +15,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Ryubing/Stable-Releases/releases/download/1.3.1/ryujinx-1.3.1-win_x64.zip",
+            "url": "https://git.ryujinx.app/api/v4/projects/1/packages/generic/Ryubing/1.3.1/ryujinx-1.3.1-win_x64.zip",
             "hash": "438e643d5e8a8ccde9eca9e6a3432b59578e01fe9f5e1fbd3e27cee4e476ecf5"
-        },
-        "arm64": {
-            "url": "https://github.com/Ryubing/Stable-Releases/releases/download/1.3.1/ryujinx-1.3.1-win_arm64.zip",
-            "hash": "32dd21271e20ac9ef34a51a5e07ebcea30f7bec8b33cfe70b6e6779ed26076d6"
         }
     },
     "extract_dir": "publish",
@@ -43,15 +39,13 @@
     ],
     "persist": "portable",
     "checkver": {
-        "github": "https://github.com/Ryubing/Stable-Releases"
+        "url": "https://git.ryujinx.app/api/v4/projects/ryubing%2Fryujinx/releases",
+        "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Ryubing/Stable-Releases/releases/download/$version/ryujinx-$version-win_x64.zip"
-            },
-            "arm64": {
-                "url": "https://github.com/Ryubing/Stable-Releases/releases/download/$version/ryujinx-$version-win_arm64.zip"
+                "url": "https://git.ryujinx.app/api/v4/projects/1/packages/generic/Ryubing/$version/ryujinx-$version-win_x64.zip"
             }
         }
     }


### PR DESCRIPTION
Ryujinx has recently [migrated](https://git.ryujinx.app/ryubing/ryujinx/-/commit/0652d7e7402b5d32ada8c276912f818ba7195364) their release repository to [gitlab](https://git.ryujinx.app/ryubing/ryujinx/-/releases) and has removed win-arm64 releases.

> ryujinx: The remote server returned an error: (404) Not Found.
> URL https://api.github.com/repos/Ryubing/Stable-Releases/releases/latest is not valid

> ryujinx-canary: 1.3.73 (scoop version is 1.3.62) autoupdate available
> Autoupdating ryujinx-canary
> ......
> URL https://github.com/iurehg8uetgyh8ui5e/cr/releases/download/1.3.73/ryujinx-canary-1.3.73-win_arm64.zip is not valid
> ERROR Could not update ryujinx-canary, hash for ryujinx-canary-1.3.73-win_arm64.zip failed!

This PR makes the following changes:
- `ryujinx@1.3.1`: Fix checkver, remove arm64 arch.
- `ryujinx-canary`: Update to version 1.3.73, fix checkver, remove arm64 arch.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).