### PR TITLE
sm64coopdx: Add version 1.3.2

### DIFF
--- a/bucket/sm64coopdx.json
+++ b/bucket/sm64coopdx.json
@@ -20,7 +20,6 @@
             "SM64 Coop Deluxe"
         ]
     ],
-    "url": "https://github.com/coop-deluxe/sm64coopdx/releases/latest",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/sm64coopdx.json
+++ b/bucket/sm64coopdx.json
@@ -1,6 +1,6 @@
 {
     "version": "1.3.2",
-    "description": "SM64 PC port that supports online multiplayer.",
+    "description": "SM64 PC port that supports online multiplayer",
     "homepage": "https://github.com/coop-deluxe/sm64coopdx",
     "license": "Unknown",
     "notes": [

--- a/bucket/sm64coopdx.json
+++ b/bucket/sm64coopdx.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.3.2",
+    "description": "SM64 PC port that supports online multiplayer.",
+    "homepage": "https://github.com/coop-deluxe/sm64coopdx",
+    "license": "Unknown",
+    "notes": [
+        "Follow the instructions on the screen to install the game contents.",
+        "The contents will be stored in %appdata%\\sm64coopdx"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/coop-deluxe/sm64coopdx/releases/download/v1.3.2/sm64coopdx_Windows_OpenGL.zip",
+            "hash": "b54055585d2adf40c9009390795014560c248a07a6be5b7fe325dcc61d99319d"
+        }
+    },
+    "bin": "sm64coopdx.exe",
+    "shortcuts": [
+        [
+            "sm64coopdx.exe",
+            "SM64 Coop Deluxe"
+        ]
+    ],
+    "url": "https://github.com/coop-deluxe/sm64coopdx/releases/latest",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/coop-deluxe/sm64coopdx/releases/download/v$version/sm64coopdx_Windows_OpenGL.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Adds manifest for sm64coopdx, a PC port of SM64 with multiplayer support

https://github.com/coop-deluxe/sm64coopdx

Repute: 684 stars on github

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
