### PR TITLE
(chore): Replace vcredist2015-2019 with vcredist2022

### DIFF
--- a/bucket/dolphin.json
+++ b/bucket/dolphin.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/dolphin-emu/dolphin/blob/master/COPYING"
     },
     "suggest": {
-        "Microsoft Visual C++ Runtime 2019": "extras/vcredist2019"
+        "vcredist": "extras/vcredist2022"
     },
     "architecture": {
         "64bit": {

--- a/bucket/extremetuxracer.json
+++ b/bucket/extremetuxracer.json
@@ -3,6 +3,9 @@
     "description": "High-speed arctic racing game based on Tux Racer",
     "homepage": "https://sourceforge.net/projects/extremetuxracer/",
     "license": "GPL-2.0-or-later",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://sourceforge.net/projects/extremetuxracer/files/releases/0.8.4/ExtremeTuxRacer.msi",

--- a/bucket/vkquake.json
+++ b/bucket/vkquake.json
@@ -24,7 +24,7 @@
         ""
     ],
     "suggest": {
-        "vcredist": "extras/vcredist2019"
+        "vcredist": "extras/vcredist2022"
     },
     "architecture": {
         "32bit": {

--- a/bucket/vkquake2.json
+++ b/bucket/vkquake2.json
@@ -38,7 +38,7 @@
         ""
     ],
     "suggest": {
-        "vcredist": "extras/vcredist2019"
+        "vcredist": "extras/vcredist2022"
     },
     "architecture": {
         "32bit": {


### PR DESCRIPTION
This PR makes the following changes:
- chore: Replace vcredist2015-2019 with 2022, since vcredist2015-2019 has been deprecated in extra bucket. https://github.com/ScoopInstaller/Extras/commit/6dd50d15488d67ba96c1b7af012ea5b9401ab590
- `extremetuxracer@0.8.4`: Restore the suggestion mistakenly deleted in #1427.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).