### PR TITLE
zelda64recomp: Add version 1.2.0

### DIFF
--- a/bucket/zelda64recomp.json
+++ b/bucket/zelda64recomp.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.2.0",
+    "description": "Majora's Mask PC port with mod support.",
+    "homepage": "https://github.com/Zelda64Recomp/Zelda64Recomp",
+    "license": "GPL-3.0-only",
+    "notes": [
+        "Follow the instructions on the screen to install the game contents.",
+        "Game contents, mods and configs are stored in %localappdata%\\Zelda64Recompiled"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Zelda64Recomp/Zelda64Recomp/releases/download/v1.2.0/Zelda64Recompiled-v1.2.0-Windows.zip",
+            "hash": "e481c7ca8ff6dec332b3c23b09bebb7d404525c8ce64930a2673a36440b2f695"
+        }
+    },
+    "bin": "Zelda64Recompiled.exe",
+    "shortcuts": [
+        [
+            "Zelda64Recompiled.exe",
+            "Zelda 64 Recompiled"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Zelda64Recomp/Zelda64Recomp/releases/download/v$version/Zelda64Recompiled-v$version-Windows.zip"
+            }
+        }
+    }
+}

--- a/bucket/zelda64recomp.json
+++ b/bucket/zelda64recomp.json
@@ -1,6 +1,6 @@
 {
     "version": "1.2.0",
-    "description": "Majora's Mask PC port with mod support.",
+    "description": "Majora's Mask PC port with mod support",
     "homepage": "https://github.com/Zelda64Recomp/Zelda64Recomp",
     "license": "GPL-3.0-only",
     "notes": [


### PR DESCRIPTION
Majora's Mask port

https://github.com/Zelda64Recomp/Zelda64Recomp

Repute: 6.3k stars on github

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
