### PR TITLE
unciv: Fix checkver

### DIFF
--- a/bucket/unciv.json
+++ b/bucket/unciv.json
@@ -25,7 +25,8 @@
         "SaveFiles"
     ],
     "checkver": {
-        "github": "https://github.com/yairm210/UnCiv"
+        "url": "https://api.github.com/repos/yairm210/UnCiv/releases",
+        "jsonpath": "$[?(@.prerelease == false && @.assets[?(@.name == 'Unciv-Windows64.zip')])].tag_name"
     },
     "autoupdate": {
         "url": "https://github.com/yairm210/Unciv/releases/download/$version/Unciv-Windows64.zip"


### PR DESCRIPTION
> unciv: 4.16.14 (scoop version is 4.16.13) autoupdate available
> Autoupdating unciv
> The remote server returned an error: (404) Not Found.
> URL https://github.com/yairm210/Unciv/releases/download/4.16.14/Unciv-Windows64.zip is not valid
> ERROR Could not update unciv, hash for Unciv-Windows64.zip failed!

[unciv@4.16.13-patch1](https://github.com/yairm210/Unciv/releases/tag/4.16.13-patch1) and [unciv@4.16.14 (source-only)](https://github.com/yairm210/Unciv/releases/tag/4.16.14) is now available.

The current `checkver` will cause the automatic updater to fail to get the release version with `-patch` postfix or get the wrong release version with source code only.

This PR makes the following changes:
- `unciv`: Fix checkver.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).