### PR TITLE
rpcs3@0.0.37-18025: Update url, fix checkver, fix autoupdate

### DIFF
--- a/bucket/rpcs3.json
+++ b/bucket/rpcs3.json
@@ -15,7 +15,7 @@
     "suggest": {
         "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
     },
-    "url": "https://github.com/rpcs3/rpcs3-binaries-win/releases/download/build-329655a1bff2460bdd388397184a1bcb18373d76/rpcs3-v0.0.37-18025-329655a1_win64.7z",
+    "url": "https://github.com/RPCS3/rpcs3-binaries-win/releases/download/build-329655a1bff2460bdd388397184a1bcb18373d76/rpcs3-v0.0.37-18025-329655a1_win64_msvc.7z",
     "hash": "237637871565723b345ef709ee23b11e44c35effa53f39c02344746811c8f05d",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\")) {",
@@ -50,15 +50,14 @@
         "patches"
     ],
     "checkver": {
-        "url": "https://rpcs3.net/compatibility?b",
-        "regex": "/rpcs3-binaries-win/releases/download/build-(?<fullhash>[0-9a-f]+)/rpcs3-v(?<build>[0-9]+\\.[0-9]+\\.[0-9]+\\-[0-9]+)-(?<shorthash>[0-9a-f]{8})",
-        "replace": "${build}"
+        "url": "https://api.github.com/repos/RPCS3/rpcs3-binaries-win/releases/latest",
+        "jsonpath": "$.assets[?(@.name =~ /rpcs3-v[a-f\\d.-]+_win64_msvc\\.7z/)].browser_download_url",
+        "regex": "releases/download/(?<build>build-[a-f\\d]+)/rpcs3-v(?<version>[\\d.-]+)-(?<commit>[a-f\\d]+)_win64_msvc\\.7z"
     },
     "autoupdate": {
-        "url": "https://github.com/rpcs3/rpcs3-binaries-win/releases/download/build-$matchFullhash/rpcs3-v$matchBuild-$matchShorthash_win64.7z",
+        "url": "https://github.com/RPCS3/rpcs3-binaries-win/releases/download/$matchBuild/rpcs3-v$version-$matchCommit_win64_msvc.7z",
         "hash": {
-            "url": "https://rpcs3.net/compatibility?b",
-            "regex": "Windows x64 SHA-256: ($sha256)"
+            "url": "https://github.com/RPCS3/rpcs3-binaries-win/releases/download/$matchBuild/rpcs3-v$version-$matchCommit_win64_msvc.7z.sha256"
         }
     }
 }


### PR DESCRIPTION
https://github.com/Calinou/scoop-games/actions/runs/15623733818/job/44013968223

> rpcs3: The remote server returned an error: (403) Forbidden.
> URL https://rpcs3.net/compatibility?b is not valid

This PR makes the following changes:
- `rpcs3@0.0.37-18025`: Update url, fix checkver, fix autoupdate.

Closes #1454
Closes #1455
Closes #1461

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
