### PR TITLE
vkquake: Update to version 1.32.3.1, fix autoupdate

### DIFF
--- a/bucket/vkquake.json
+++ b/bucket/vkquake.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.32.3",
+    "version": "1.32.3.1",
     "description": "Quake 1 port using Vulkan instead of OpenGL for rendering, based on QuakeSpasm",
     "homepage": "https://github.com/Novum/vkQuake",
     "license": "GPL-2.0-or-later",
@@ -28,12 +28,12 @@
     },
     "architecture": {
         "32bit": {
-            "url": "https://github.com/Novum/vkQuake/releases/download/1.32.3/vkquake-1.32.3_win32.zip",
-            "hash": "ae5a95e966aef7b941f4d4d6d624e4ba06f659fc27c185f543f9f64592009012"
+            "url": "https://github.com/Novum/vkQuake/releases/download/1.32.3.1/vkquake-1.32.3_win32.zip",
+            "hash": "3f3bbd33b67dd438db2651b3b8003ec072218b3ddd434ccb8b4736ab04a3b424"
         },
         "64bit": {
-            "url": "https://github.com/Novum/vkQuake/releases/download/1.32.3/vkquake-1.32.3_win64.zip",
-            "hash": "15ff1fca3a576b0808c1e73dde995a97ccb0051f88fc41db1b0bb07754296448"
+            "url": "https://github.com/Novum/vkQuake/releases/download/1.32.3.1/vkquake-1.32.3_win64.zip",
+            "hash": "cbdca7bb429d8078a801f0cc038085a887d3079b279afcbd92ff9d0792b0b057"
         }
     },
     "bin": [
@@ -80,10 +80,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/Novum/vkQuake/releases/download/$version/vkquake-$version_win32.zip"
+                "url": "https://github.com/Novum/vkQuake/releases/download/$version/vkquake-$matchHead_win32.zip"
             },
             "64bit": {
-                "url": "https://github.com/Novum/vkQuake/releases/download/$version/vkquake-$version_win64.zip"
+                "url": "https://github.com/Novum/vkQuake/releases/download/$version/vkquake-$matchHead_win64.zip"
             }
         }
     }


### PR DESCRIPTION
https://github.com/Calinou/scoop-games/actions/runs/15838300168/job/44646253645
> vkquake: 1.32.3.1 (scoop version is 1.32.3) autoupdate available
> Autoupdating vkquake
> Downloading vkquake-1.32.3.1_win32.zip to compute hashes!
> The remote server returned an error: (404) Not Found.
> URL https://github.com/Novum/vkQuake/releases/download/1.32.3.1/vkquake-1.32.3.1_win32.zip is not valid
> ERROR Could not update vkquake, hash for vkquake-1.32.3.1_win32.zip failed!

This PR makes the following changes:
- `vkquake`: Update to version 1.32.3.1, fix autoupdate.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).