### PR TITLE
project64-dev: Fix checkver

### DIFF
--- a/bucket/project64-dev.json
+++ b/bucket/project64-dev.json
@@ -31,7 +31,8 @@
     ],
     "checkver": {
         "url": "https://www.pj64-emu.com/nightly-builds",
-        "regex": "((?<major>[\\d]+)\\.(?<minor>[\\d]+)\\.(?<patch>[\\d]+)-(?<build>[\\d]+)-(?<commit>[\\da-f]+))"
+        "regex": "href=\"/file/project64-win32-dev-(?<major>[\\d]+)-(?<minor>[\\d]+)-(?<patch>[\\d]+)-(?<build>[\\d]+)-(?<commit>[\\da-f]+).*btn zip",
+        "replace": "${major}.${minor}.${patch}-${build}-${commit}"
     },
     "autoupdate": {
         "url": "https://www.pj64-emu.com/file/setup-project64-Dev-$dashVersion/#/setup-project64-Dev-$dashVersion.exe"


### PR DESCRIPTION
https://github.com/Calinou/scoop-games/actions/runs/15838300168/job/44646253645

> project64-dev: 4.0.0-6585-825f786 (scoop version is 4.0.0-6583-d97c7cb) autoupdate available
> Autoupdating project64-dev
> Downloading setup-project64-Dev-4-0-0-6585-825f786.exe to compute hashes!
> The remote server returned an error: (404) NOT FOUND.
> URL https://www.pj64-emu.com/file/setup-project64-Dev-4-0-0-6585-825f786/#/setup-project64-Dev-4-0-0-6585-825f786.exe is not valid
> ERROR Could not update project64-dev, hash for setup-project64-Dev-4-0-0-6585-825f786.exe failed!

This PR makes the following changes:
- `project64-dev`: Fix checkver.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).