### PR TITLE
cambridge: Update to version 0.4.4.1, fix autoupdate

### DIFF
--- a/bucket/cambridge.json
+++ b/bucket/cambridge.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.3.4",
+    "version": "0.4.4.1",
     "homepage": "https://t-sp.in/cambridge",
     "description": "Open source arcade stacker",
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v0.3.4/cambridge-win32.zip",
-            "hash": "af00abda285d26108d9f40c6800bcfb9c6de1b9801eb4389fe871a141438c17b"
+            "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v0.4.4.1/cambridge_windows_x86.zip",
+            "hash": "abfe40c9e3bcacb5d2be1b94f1569c74c58a56cbcd0b8b7dabbb2d6682b0f5ae"
         },
         "64bit": {
-            "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v0.3.4/cambridge-windows.zip",
-            "hash": "9dfb127950a811c26555974686547e218c0c44469596127e1052a13127b17ac5"
+            "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v0.4.4.1/cambridge_windows_x64.zip",
+            "hash": "3aa627165c349ab77d9b44edf859126b5ecb7cb92c97b0a08d96f8caaa21107c"
         }
     },
     "shortcuts": [
@@ -25,10 +25,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v$version/cambridge-win32.zip"
+                "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v$version/cambridge_windows_x86.zip"
             },
             "64bit": {
-                "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v$version/cambridge-windows.zip"
+                "url": "https://github.com/cambridge-stacker/cambridge/releases/download/v$version/cambridge_windows_x64.zip"
             }
         }
     }


### PR DESCRIPTION
https://github.com/Calinou/scoop-games/actions/runs/15886482087/job/44799602039

> cambridge: 0.4.4.1 (scoop version is 0.3.4) autoupdate available
> Autoupdating cambridge
> Downloading cambridge-win32.zip to compute hashes!
> The remote server returned an error: (404) Not Found.
> URL https://github.com/cambridge-stacker/cambridge/releases/download/v0.4.4.1/cambridge-win32.zip is not valid
> ERROR Could not update cambridge, hash for cambridge-win32.zip failed!

This PR makes the following changes:
- `cambridge`: Update to version 0.4.4.1, fix autoupdate.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).