### PR TITLE
rgbds: Update to version 0.9.3, fix autoupdate

### DIFF
--- a/bucket/rgbds.json
+++ b/bucket/rgbds.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.9.2",
+    "version": "0.9.3",
     "description": "A free assembler/linker package for the Game Boy and Game Boy Color",
     "homepage": "https://rednex.github.io/rgbds/",
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/rednex/rgbds/releases/download/v0.9.2/rgbds-0.9.2-win32.zip",
-            "hash": "2e2428ab42a3644dba73dd9c5147a45fb7bc529f220dfccf217faf47f8aebbdc"
+            "url": "https://github.com/rednex/rgbds/releases/download/v0.9.3/rgbds-win32.zip",
+            "hash": "507547d872baf978a244a87314a16ce8484f9d2ce68276590faf164c13a571f1"
         },
         "64bit": {
-            "url": "https://github.com/rednex/rgbds/releases/download/v0.9.2/rgbds-0.9.2-win64.zip",
-            "hash": "c889204feebd1d53eed1d90467619c4d5284d478d070d94f1ba91c72227cc7b3"
+            "url": "https://github.com/rednex/rgbds/releases/download/v0.9.3/rgbds-win64.zip",
+            "hash": "a35c18c671a28e959603966b24eff96cae94bff8ccfb8a111b1c748dbd4cce3d"
         }
     },
     "bin": [
@@ -25,10 +25,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/rednex/rgbds/releases/download/v$version/rgbds-$version-win32.zip"
+                "url": "https://github.com/rednex/rgbds/releases/download/v$version/rgbds-win32.zip"
             },
             "64bit": {
-                "url": "https://github.com/rednex/rgbds/releases/download/v$version/rgbds-$version-win64.zip"
+                "url": "https://github.com/rednex/rgbds/releases/download/v$version/rgbds-win64.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `rgbds`: Update to version 0.9.3, fix autoupdate.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).