### PR TITLE
naev: Fix shortcut issue

### DIFF
--- a/bucket/naev.json
+++ b/bucket/naev.json
@@ -12,7 +12,7 @@
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse",
     "shortcuts": [
         [
-            "naev-0.10.5-win64.exe",
+            "naev.exe",
             "Naev"
         ]
     ],


### PR DESCRIPTION
This PR makes the following changes:
- `naev`: Fix shortcut.

![image](https://github.com/user-attachments/assets/ed0bcd71-acc7-4dfc-bf03-8d5a997e2933)

Closes #1472

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).