### PR TITLE
taisei: Update to version 1.4.3, remove 32-bit arch, add hash extraction

### DIFF
--- a/bucket/taisei.json
+++ b/bucket/taisei.json
@@ -1,16 +1,12 @@
 {
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "Free and open source Touhou Project clone and fangame",
     "homepage": "https://github.com/taisei-project/taisei",
     "license": "MIT",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/taisei-project/taisei/releases/download/v1.4.2/Taisei-1.4.2-windows-x86.zip",
-            "hash": "898f8597f79cd3bb293a8d4e6a5af7c0e9fea1b47db84b6471204582214d45bc"
-        },
         "64bit": {
-            "url": "https://github.com/taisei-project/taisei/releases/download/v1.4.2/Taisei-1.4.2-windows-x86_64.zip",
-            "hash": "ce78461fc535095c4e3e0a9be89b659fe0bd18a28c6e023e3c0c63a65aea2586"
+            "url": "https://github.com/taisei-project/taisei/releases/download/v1.4.3/Taisei-1.4.3-windows-x86_64.zip",
+            "hash": "2942cacb3bf540947d444dbd466be78f43765a075f2620a2ce56464b7dfa68c2"
         }
     },
     "bin": "taisei.exe",
@@ -23,11 +19,11 @@
     "checkver": "github",
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/taisei-project/taisei/releases/download/v$version/Taisei-$version-windows-x86.zip"
-            },
             "64bit": {
-                "url": "https://github.com/taisei-project/taisei/releases/download/v$version/Taisei-$version-windows-x86_64.zip"
+                "url": "https://github.com/taisei-project/taisei/releases/download/v$version/Taisei-$version-windows-x86_64.zip",
+                "hash": {
+                    "url": "$url.sha256sum"
+                }
             }
         }
     }


### PR DESCRIPTION
#### Description
This PR makes the following changes:
- `taisei`: Update to version 1.4.3, remove 32-bit arch, add hash extraction.

#### Motivation and Context

> osulazer: 2025.710.0 (scoop version is 2025.607.0) autoupdate available
> Autoupdating osulazer
> The remote server returned an error: (404) Not Found.
> URL https://github.com/ppy/osu/releases/download/2025.710.0/osulazer-2025.710.0-full.nupkg#/dl.7z is not valid
> ERROR Could not update osulazer, hash for osulazer-2025.710.0-full.nupkg failed!

`taisei` 32-bit x86 builds are [no longer provided](https://github.com/taisei-project/taisei/releases/tag/v1.4.3) for Windows.

<img width="1267" height="721" alt="image" src="https://github.com/user-attachments/assets/fcdaaaed-6256-4c5d-bbba-8c9217f5d249" />

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).