### PR TITLE
playit: Update to version 0.16.2, simplify pre_install script, fix autoupdate

### DIFF
--- a/bucket/playit.json
+++ b/bucket/playit.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.15.26",
+    "version": "0.16.2",
     "description": "Playit.gg is a networking service that enables users to host game servers at home, making them accessible to players worldwide through its custom tunneling software and Anycast Network",
     "homepage": "https://playit.gg/",
     "license": {
@@ -8,16 +8,15 @@
     },
     "architecture": {
         "32bit": {
-            "url": "https://github.com/playit-cloud/playit-agent/releases/download/v0.15.26/playit-windows-x86-signed.exe",
-            "hash": "f7bcf4175af95221a6ec3039dd8157e0bb30f1df62f8707c075e1f549c7bc23b",
-            "pre_install": "Rename-Item -Path $dir/playit-windows-x86-signed.exe -NewName $dir/playit.exe"
+            "url": "https://github.com/playit-cloud/playit-agent/releases/download/v0.16.2/playit-windows-x86.exe",
+            "hash": "2a8f176161393f3dc9b3504a92d51f8f24cddab7879e71f638f842578be59597"
         },
         "64bit": {
-            "url": "https://github.com/playit-cloud/playit-agent/releases/download/v0.15.26/playit-windows-x86_64-signed.exe",
-            "hash": "dd1acb19e47bca4a935f2f72a68390bd2fc3a8ed608af7c9c247d3a69d7fba0a",
-            "pre_install": "Rename-Item -Path $dir/playit-windows-x86_64-signed.exe -NewName $dir/playit.exe"
+            "url": "https://github.com/playit-cloud/playit-agent/releases/download/v0.16.2/playit-windows-x86_64.exe",
+            "hash": "c4751fc59af4fd58f3f258bdcf540ab9ef1f23ee94dbd9882dc5e6faf34dff03"
         }
     },
+    "pre_install": "Rename-Item -Path $dir/$fname -NewName $dir/playit.exe",
     "bin": "playit.exe",
     "shortcuts": [
         [
@@ -31,10 +30,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/playit-cloud/playit-agent/releases/download/v$version/playit-windows-x86-signed.exe"
+                "url": "https://github.com/playit-cloud/playit-agent/releases/download/v$version/playit-windows-x86.exe"
             },
             "64bit": {
-                "url": "https://github.com/playit-cloud/playit-agent/releases/download/v$version/playit-windows-x86_64-signed.exe"
+                "url": "https://github.com/playit-cloud/playit-agent/releases/download/v$version/playit-windows-x86_64.exe"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `playit`:
  - Update to version 0.16.2.
  - Simplify the pre_install script.
  - Fix autoupdate. Update the executable filename.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).