### PR TITLE
cxbx-reloaded: Update to version a659fca, fix autoupdate

### DIFF
--- a/bucket/cxbx-reloaded.json
+++ b/bucket/cxbx-reloaded.json
@@ -1,13 +1,13 @@
 {
-    "version": "ec9934a",
+    "version": "a659fca",
     "description": "Microsoft Xbox emulator",
     "homepage": "https://cxbx-reloaded.co.uk/",
     "license": {
         "identifier": "GPL-2.0",
         "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/blob/master/COPYING"
     },
-    "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-ec9934a/CxbxReloaded-Release-VS2019.zip",
-    "hash": "9916b5c6e6e381705ac00ab8360937ee5a8b80e4f8d5faf3bab5294335afb137",
+    "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-a659fca/CxbxReloaded-Release.zip",
+    "hash": "f04023a2e31a5e2e0cba279068a4a1ad1212b0acbc2050eeac7b8943c3e0e168",
     "pre_install": "if (!(Test-Path \"$persist_dir\\settings.ini\")) { $null = New-Item \"$dir\\settings.ini\" }",
     "bin": "cxbx.exe",
     "shortcuts": [
@@ -25,6 +25,6 @@
         "regex": "CI-([a-f\\d]+)."
     },
     "autoupdate": {
-        "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-$version/CxbxReloaded-Release-VS2019.zip"
+        "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-$version/CxbxReloaded-Release.zip"
     }
 }


### PR DESCRIPTION
This PR makes the following changes:
- `cxbx-reloaded`: Update to version a659fca, [fix autoupdate](https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/blob/a659fcae89965f6ee3e3a80509b2ad1865e35673/.github/workflows/CI.yml#L47).

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).