### PR TITLE
evemaptool@1.41: Update repack url

### DIFF
--- a/bucket/evemaptool.json
+++ b/bucket/evemaptool.json
@@ -3,8 +3,8 @@
     "homepage": "https://github.com/Slazanger/SMT",
     "license": "MIT",
     "description": "Slazanger's Eve Map Tool",
-    "url": "https://github.com/Slazanger/SMT/releases/download/SMT_141/SMT_1.41.zip",
-    "hash": "7b469d985773326f9164134e11c434b68be89c939fe7bf857b322b4edbe425cf",
+    "url": "https://github.com/Slazanger/SMT/releases/download/SMT_141/SMT_1.41a.zip",
+    "hash": "f4f1d6ebc5dbb6d468c937573d89d429d327b07707836c1d08f80095d142784f",
     "bin": "SMT.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
This PR makes the following changes:
- `evemaptool@1.41`: Update repack url. 

Closes #1489

The CI may fail because the autoupdate URL is unreachable. But I still recommend keeping the original `autoupdate`, since this is a temporary change.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).