### PR TITLE
asset-ripper@1.3.2: Remove post_uninstall script, add persist

### DIFF
--- a/bucket/asset-ripper.json
+++ b/bucket/asset-ripper.json
@@ -22,7 +22,13 @@
             "AssetRipper"
         ]
     ],
-    "post_uninstall": "Remove-Item \"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\AssetRipper.lnk\" -Force -ErrorAction SilentlyContinue",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\AssetRipper.Settings.json\")) {",
+        "    $config = @{'Import' = @{}; 'Processing' = @{}; 'Export' = @{}}",
+        "    $config | ConvertTo-Json | Set-Content \"$dir\\AssetRipper.Settings.json\" -ErrorAction SilentlyContinue",
+        "}"
+    ],
+    "persist": "AssetRipper.Settings.json",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This PR makes the following changes:
- `asset-ripper@1.3.2`:
    - `Remove post_uninstall script`: The post_uninstall script was used to clean up shortcuts generated by Asset Ripper, but this cleanup process is now unnecessary.
    - `Add persist`: Persist _AssetRipper.Settings.json_.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).