### PR TITLE
xenia-canary: Modify persists

### DIFF
--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -41,6 +41,7 @@
         "cache_host",
         "content",
         "patches",
+        "screenshots",
         "recent.toml",
         "xenia-canary.config.toml"
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Changes made in this PR:

 - Added persist for 'screenshot' folder

The screenshot folder is auto-created by xenia-canary when hitting the screenshot hotkey in-app. Persist is needed so these screenshots aren't lost between updates.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
