### PR TITLE
chiaki-ng: Delete post_uninstall script, Revert licence fix

### DIFF
--- a/bucket/chiaki-ng.json
+++ b/bucket/chiaki-ng.json
@@ -3,7 +3,7 @@
     "description": "Next-Generation of Chiaki (the open-source remote play client for PlayStation)",
     "homepage": "https://streetpea.github.io/chiaki-ng/",
     "license": {
-        "identifier": "AGPL-3.0-or-later",
+        "identifier": "AGPL-3.0-only",
         "url": "https://github.com/streetpea/chiaki-ng/blob/main/COPYING"
     },
     "suggest": {
@@ -31,10 +31,6 @@
             "chiaki.exe",
             "chiaki-ng"
         ]
-    ],
-    "post_uninstall": [
-        "Remove-Item -Path \"$env:LocalAppData\\Chiaki\" -Recurse -Force -ErrorAction SilentlyContinue",
-        "Remove-Item -Path \"$env:AppData\\Chiaki\" -Recurse -Force -ErrorAction SilentlyContinue"
     ],
     "checkver": {
         "github": "https://github.com/streetpea/chiaki-ng/"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Changes made in this PR:
 - Removes the post_uninstall script from the manifest
 - Reverts the Licence from the change made in the prior PR (#1404)

The post_uninstall script is unnecessary and is slightly problematic as it forces recreation of the app's cache every time it's updated. Additionally, the licence has been reverted as it turns out the original one was correct, and the change was therefore unnecessary.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
