### PR TITLE
Update hash for OpenSpeedy version 1.7.6

### DIFF
--- a/bucket/openspeedy.json
+++ b/bucket/openspeedy.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/game1024/OpenSpeedy",
     "license": "GPL-3.0 license",
     "url": "https://github.com/game1024/OpenSpeedy/releases/download/v1.7.6/OpenSpeedy-v1.7.6.zip",
-    "hash": "9d9f8dfdec4e49b8ab8b0443db91cf54d55ba1335cff5a863b6bfb686bf5b1b4",
+    "hash": "ac069cad89ebfcdff8fa7bb99aa2790ba64f0ccee38a276563000b28a083acab",
     "pre_install": "if (!(Test-Path \"$persist_dir\\config.ini\")) { New-Item \"$dir\\config.ini\" | Out-Null }",
     "shortcuts": [
         [


### PR DESCRIPTION
The original hash value belongs to OpenSpeedy-v1.7.6-signed.zip and should be updated to the hash value of the target OpenSpeedy-v1.7.6.zip. The release page is located at https://github.com/game1024/OpenSpeedy/releases/tag/v1.7.6

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
