### PR TITLE
duckstation-preview: Fix URL case for hash extraction

### DIFF
--- a/bucket/duckstation-preview.json
+++ b/bucket/duckstation-preview.json
@@ -34,7 +34,7 @@
             ]
         },
         "arm64": {
-            "url": "https://github.com/stenzek/duckstation/releases/download/preview/duckstation-windows-ARM64-release.zip",
+            "url": "https://github.com/stenzek/duckstation/releases/download/preview/duckstation-windows-arm64-release.zip",
             "hash": "b124303e7fb67e7e1de7d89a7cd3562f909e14dbb41b8a1125a7dc47faacf3ee",
             "post_install": [
                 "New-item \"$dir\\portable.txt\" -ItemType File | Out-Null",
@@ -95,7 +95,7 @@
                 "url": "https://github.com/stenzek/duckstation/releases/download/preview/duckstation-windows-x64-release.zip"
             },
             "arm64": {
-                "url": "https://github.com/stenzek/duckstation/releases/download/preview/duckstation-windows-ARM64-release.zip"
+                "url": "https://github.com/stenzek/duckstation/releases/download/preview/duckstation-windows-arm64-release.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `duckstation-preview`: _Fix URL case for hash extraction._
The [predefined hash extraction for Github](https://github.com/ScoopInstaller/Scoop/releases/tag/v0.5.3) does not work due to case issues in URL.
See also: https://github.com/Calinou/scoop-games/actions/runs/17177660079/job/48735786811
  >...
Could not find hash in https://api.github.com/repos/stenzek/duckstation/releases
Downloading duckstation-windows-ARM64-release.zip to compute hashes!
...

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).