### PR TITLE
warzone2100: Update to version 4.6.0, fix autoupdate

### DIFF
--- a/bucket/warzone2100.json
+++ b/bucket/warzone2100.json
@@ -1,20 +1,20 @@
 {
-    "version": "4.5.5",
+    "version": "4.6.0",
     "description": "Real-time strategy game set in a futuristic universe",
     "homepage": "https://wz2100.net/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Warzone2100/warzone2100/releases/download/4.5.5/warzone2100_win_x64_portable.exe#/dl.7z",
-            "hash": "c300bd7481d5d0d36532f9270b14599e20a09eaeda454832f479e01c9200e464"
+            "url": "https://github.com/Warzone2100/warzone2100/releases/download/4.6.0/warzone2100_win_x64_archive.zip",
+            "hash": "be3f19a3c11e9be6d564dc4a19c2e94247e62a0eaf7d04941728cf51cb1773db"
         },
         "32bit": {
-            "url": "https://github.com/Warzone2100/warzone2100/releases/download/4.5.5/warzone2100_win_x86_portable.exe#/dl.7z",
-            "hash": "2c4cb8a532f2a173b8f48f10ae76d886f12ca0ccfdbe1ba0aebd5e1bc857202d"
+            "url": "https://github.com/Warzone2100/warzone2100/releases/download/4.6.0/warzone2100_win_x86_archive.zip",
+            "hash": "5afdd6cfadfd04ed11bd360b4ba7cebaa52b362cfa53ed34679b787b31eb5d6f"
         },
         "arm64": {
-            "url": "https://github.com/Warzone2100/warzone2100/releases/download/4.5.5/warzone2100_win_arm64_portable.exe#/dl.7z",
-            "hash": "212868d8d6f00df1c1c33fd6479a6920825946deaadb9d46ead2f7ae0f355ec0"
+            "url": "https://github.com/Warzone2100/warzone2100/releases/download/4.6.0/warzone2100_win_arm64_archive.zip",
+            "hash": "6994b8f7fe21bf546a89eeeab6a36e1b4bbcee4ad18d6665461efcd2540541bf"
         }
     },
     "bin": "bin\\warzone2100.exe",
@@ -30,13 +30,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Warzone2100/warzone2100/releases/download/$version/warzone2100_win_x64_portable.exe#/dl.7z"
+                "url": "https://github.com/Warzone2100/warzone2100/releases/download/$version/warzone2100_win_x64_archive.zip"
             },
             "32bit": {
-                "url": "https://github.com/Warzone2100/warzone2100/releases/download/$version/warzone2100_win_x86_portable.exe#/dl.7z"
+                "url": "https://github.com/Warzone2100/warzone2100/releases/download/$version/warzone2100_win_x86_archive.zip"
             },
             "arm64": {
-                "url": "https://github.com/Warzone2100/warzone2100/releases/download/$version/warzone2100_win_arm64_portable.exe#/dl.7z"
+                "url": "https://github.com/Warzone2100/warzone2100/releases/download/$version/warzone2100_win_arm64_archive.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `warzone2100`: Update to version [4.6.0](https://github.com/Warzone2100/warzone2100/releases/tag/4.6.0), fix autoupdate.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).