### PR TITLE
pychess: Update to version 1.0.6, fix autoupdate

### DIFF
--- a/bucket/pychess.json
+++ b/bucket/pychess.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "A chess client for Linux and Windows",
     "homepage": "https://pychess.github.io/",
     "license": "GPL-3.0",
@@ -8,8 +8,8 @@
         "Config is stored in C:\\Users\\[USERNAME]\\.config\\pychess",
         "Data is stored C:\\Users\\[USERNAME]\\.local\\share\\pychess"
     ],
-    "url": "https://github.com/pychess/pychess/releases/download/1.0.5/pychess-1.0.5-mingw_x86_64.msi",
-    "hash": "a2ed5a66874041b2504d00643d7cb050d60a155979bbb3e476675c88a61dc79c",
+    "url": "https://github.com/pychess/pychess/releases/download/1.0.6/pychess-1.0.6-mingw_x86_64_msvcrt_gnu.msi",
+    "hash": "db8962c6a879f66ae9aeafc8b6148962928fe08258e649632396d979afa52f2b",
     "bin": "pychess.exe",
     "shortcuts": [
         [
@@ -21,6 +21,6 @@
         "github": "https://github.com/pychess/pychess"
     },
     "autoupdate": {
-        "url": "https://github.com/pychess/pychess/releases/download/$version/pychess-$version-mingw_x86_64.msi"
+        "url": "https://github.com/pychess/pychess/releases/download/$version/pychess-$version-mingw_x86_64_msvcrt_gnu.msi"
     }
 }


### PR DESCRIPTION
> pychess: 1.0.6 (scoop version is 1.0.5) autoupdate available
Autoupdating pychess
Could not find hash in https://api.github.com/repos/pychess/pychess/releases
Downloading pychess-1.0.6-mingw_x86_64.msi to compute hashes!
The remote server returned an error: (404) Not Found.
URL https://github.com/pychess/pychess/releases/download/1.0.6/pychess-1.0.6-mingw_x86_64.msi is not valid
ERROR Could not update pychess, hash for pychess-1.0.6-mingw_x86_64.msi failed!


This PR makes the following changes:
- `pychess`: Update to version 1.0.6, fix autoupdate.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).