### PR TITLE
(chore): Run formatjson.ps1 for all manifests

### DIFF
--- a/bucket/daggerfallunity.json
+++ b/bucket/daggerfallunity.json
@@ -13,9 +13,7 @@
             "hash": "a2584d57e7d9b0ba3cdde9b75b0db2a818b5327af657b2833c03759148fe557e"
         }
     },
-    "pre_install": [
-        "New-Item -ItemType File \"$dir\\Portable.txt\" | Out-Null"
-    ],
+    "pre_install": "New-Item -ItemType File \"$dir\\Portable.txt\" | Out-Null",
     "post_install": [
         "$Subdirs = @('Mods', 'GameFiles')",
         "ForEach($DirName in $Subdirs) {",

--- a/bucket/eve-iph.json
+++ b/bucket/eve-iph.json
@@ -20,9 +20,6 @@
         "regex": "Build ([0-9]+(.[0-9]+)+)"
     },
     "autoupdate": {
-        "url": "https://github.com/EVEIPH/LatestFiles/raw/master/EVEIPH%20Binaries.zip",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://github.com/EVEIPH/LatestFiles/raw/master/EVEIPH%20Binaries.zip"
     }
 }

--- a/bucket/evemaptool.json
+++ b/bucket/evemaptool.json
@@ -17,9 +17,6 @@
         "regex": "SMT ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Slazanger/SMT/releases/download/SMT_$cleanVersion/SMT_$version.zip",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://github.com/Slazanger/SMT/releases/download/SMT_$cleanVersion/SMT_$version.zip"
     }
 }

--- a/bucket/evemon.json
+++ b/bucket/evemon.json
@@ -7,15 +7,17 @@
     "hash": "35fe49eab245280dc86db64fa2f08d43e44988b948a611d6c87bd484ead321d1",
     "extract_dir": "EVEMon",
     "bin": "EVEMon.exe",
-    "shortcuts": [["EVEMon.exe", "EVEMon"]],
+    "shortcuts": [
+        [
+            "EVEMon.exe",
+            "EVEMon"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/mgoeppner/evemon",
         "regex": "tag/([\\w.-]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/mgoeppner/evemon/releases/download/$version/EVEMon-binaries-$version.zip",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://github.com/mgoeppner/evemon/releases/download/$version/EVEMon-binaries-$version.zip"
     }
 }

--- a/bucket/jeveassets.json
+++ b/bucket/jeveassets.json
@@ -22,9 +22,6 @@
         "regex": "tag/([\\w.-]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/GoldenGnu/jeveassets/releases/download/$version/$version.zip",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://github.com/GoldenGnu/jeveassets/releases/download/$version/$version.zip"
     }
 }

--- a/bucket/lime3ds.json
+++ b/bucket/lime3ds.json
@@ -9,9 +9,7 @@
     "suggest": {
         "Azahar": "games/azahar"
     },
-    "notes": [
-        "Lime3DS has been discontinued. Please use Azahar instead: https://github.com/azahar-emu/azahar"
-    ],
+    "notes": "Lime3DS has been discontinued. Please use Azahar instead: https://github.com/azahar-emu/azahar",
     "url": "https://archive.org/download/lime3ds-2119.1-linux-appimage.tar/lime3ds-2119.1-windows-msvc.zip",
     "hash": "e28cfc25082d5663ae4144e716c374b7e85e80983c9544e2ec4ecb753e8bc3b7",
     "extract_dir": "lime3ds-2119.1-windows-msvc",

--- a/bucket/mesen.json
+++ b/bucket/mesen.json
@@ -8,9 +8,7 @@
     },
     "url": "https://github.com/SourMesen/Mesen2/releases/download/2.1.1/Mesen_2.1.1_Windows.zip",
     "hash": "23ccc2bc060b663c68dad3a8c5d6da7d23a50f872d04f135bafa2b04ff7d5cbe",
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\settings.json\")) { New-Item -ItemType File \"$dir\\settings.json\" | Out-Null }"
-    ],
+    "pre_install": "if (!(Test-Path \"$persist_dir\\settings.json\")) { New-Item -ItemType File \"$dir\\settings.json\" | Out-Null }",
     "bin": "Mesen.exe",
     "shortcuts": [
         [

--- a/bucket/modboy.json
+++ b/bucket/modboy.json
@@ -35,7 +35,6 @@
         "hash": {
             "type": "md5",
             "url": "https://gamebanana.com/apiv11/Tool/6321/Updates",
-            "mode": "json",
             "jsonpath": "$._aRecords[0]._aFiles[0]._sMd5Checksum",
             "find": "$md5"
         }

--- a/bucket/pacmc.json
+++ b/bucket/pacmc.json
@@ -4,9 +4,7 @@
     "homepage": "https://github.com/jakobkmar/pacmc",
     "license": "AGPL-3.0-or-later",
     "suggest": {
-        "JDK": [
-            "java/openjdk"
-        ]
+        "JDK": "java/openjdk"
     },
     "url": "https://github.com/jakobkmar/pacmc/releases/download/0.5.2/pacmc-0.5.2.zip",
     "hash": "d071b0c5d22af66156e9440c731b215be99f921f33cf242d4ebe14cca19cb246",

--- a/bucket/pyfa.json
+++ b/bucket/pyfa.json
@@ -16,9 +16,6 @@
         "github": "https://github.com/pyfa-org/Pyfa"
     },
     "autoupdate": {
-        "url": "https://github.com/pyfa-org/Pyfa/releases/download/v$version/pyfa-v$version-win.zip",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://github.com/pyfa-org/Pyfa/releases/download/v$version/pyfa-v$version-win.zip"
     }
 }

--- a/bucket/sak.json
+++ b/bucket/sak.json
@@ -27,9 +27,7 @@
             "SAK"
         ]
     ],
-    "post_install": [
-        "Copy-Item \"$persist_dir\\prod.keys\" \"$dir\\bin\\prod.keys\" -Force -ErrorAction SilentlyContinue"
-    ],
+    "post_install": "Copy-Item \"$persist_dir\\prod.keys\" \"$dir\\bin\\prod.keys\" -Force -ErrorAction SilentlyContinue",
     "pre_uninstall": [
         "ensure $persist_dir",
         "Copy-Item \"$dir\\bin\\prod.keys\" \"$persist_dir\\prod.keys\" -Force -ErrorAction SilentlyContinue"

--- a/bucket/tickompiler.json
+++ b/bucket/tickompiler.json
@@ -12,7 +12,7 @@
     "bin": "tickompiler.cmd",
     "checkver": {
         "github": "https://github.com/rhmodding/Tickompiler",
-        "regex": "\/releases\/tag\/(?:v|V)?([\\d.]+[-\\w]+)(\/)?"
+        "regex": "/releases/tag/(?:v|V)?([\\d.]+[-\\w]+)(/)?"
     },
     "autoupdate": {
         "url": "https://github.com/rhmodding/Tickompiler/releases/download/v$version/tickompiler.jar"

--- a/bucket/toontownrewritten.json
+++ b/bucket/toontownrewritten.json
@@ -21,7 +21,8 @@
     "bin": "Launcher.exe",
     "shortcuts": [
         [
-            "Launcher.exe", "Toontown Rewritten"
+            "Launcher.exe",
+            "Toontown Rewritten"
         ]
     ],
     "persist": [

--- a/bucket/xonotic.json
+++ b/bucket/xonotic.json
@@ -29,7 +29,6 @@
     "autoupdate": {
         "url": "https://dl.xonotic.org/xonotic-$version.zip",
         "hash": {
-            "mode": "extract",
             "url": "https://dl.xonotic.org/xonotic-$version.sha512"
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `(chore)`: Run formatjson.ps1 for all manifests.

Relates to:
- https://github.com/ScoopInstaller/GithubActions/pull/61

To avoid existing manifests with lint issues also modified and appear in the commit list when contributors format manifests, I am now submitting a PR to format them all.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).