### PR TITLE
game-backup-monitor: Add `autoupdate.hash`

### DIFF
--- a/bucket/game-backup-monitor.json
+++ b/bucket/game-backup-monitor.json
@@ -33,6 +33,9 @@
             "32bit": {
                 "url": "https://github.com/MikeMaximus/gbm/releases/download/v$version/GBM.v$version.32-bit.7z"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums"
         }
     }
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).