### PR TITLE
steam-game-idler: Fix url, hash and autoupdate

### DIFF
--- a/bucket/steam-game-idler.json
+++ b/bucket/steam-game-idler.json
@@ -24,6 +24,6 @@
         "github": "https://github.com/zevnda/steam-game-idler"
     },
     "autoupdate": {
-        "url": "https://github.com/zevnda/steam-game-idler/releases/download/$version/Steam.Game.Idler_$version_x64-portable.exe"
+        "url": "https://github.com/zevnda/steam-game-idler/releases/download/$version/Steam.Game.Idler_$version_x64-portable.zip"
     }
 }


### PR DESCRIPTION
Fixes hash not present, wrong url and autoupdate mechanism.