### PR TITLE
Froststrap@1.3.0.0: Change recommended dotnet runtime version to 8

### DIFF
--- a/bucket/froststrap.json
+++ b/bucket/froststrap.json
@@ -5,7 +5,7 @@
     "homepage": "https://realmeddsam.github.io/Froststrap-Website/",
     "license": "MIT",
     "suggest": {
-        ".NET 6.0 Desktop Runtime": "versions/windowsdesktop-runtime-6.0"
+        ".NET 8.0 Desktop Runtime": "extras/windowsdesktop-runtime-lts"
     },
     "architecture": {
         "64bit": {
@@ -14,7 +14,7 @@
         }
     },
     "installer": {
-        "script": "if ($cmd -eq 'update') {Start-Process \"$dir\\Froststrap.exe\" -Wait -Args @('-quiet', '-upgrade'); } else { Start-Process \"$dir\\Froststrap.exe\" -Wait -Args @('-quiet'); }"
+        "script": "if ($cmd -eq 'update') { Start-Process \"$dir\\Froststrap.exe\" -Wait -Args @('-quiet', '-upgrade'); exit 0 } else { Start-Process \"$dir\\Froststrap.exe\" -Wait -Args @('-quiet'); }"
     },
     "uninstaller": {
         "script": "Start-Process \"$dir\\Froststrap.exe\" -Wait -Args @('-uninstall', '-quiet');"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Changed the recommended dotnet runtime version from versions/windowsdesktop-runtime-6.0 to extras/windowsdesktop-runtime-lts (aka dotnet 8) as Froststrap now requires .NET 8. I also tried making it so updating the app doesn't uninstall the app, instead it uses the `-upgrade` parameter to update the app instead of uninstalling. However, I'm not sure how I can verify this works.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
