### PR TITLE
mame: Update to version 0.282, fix autoupdate

### DIFF
--- a/bucket/mame.json
+++ b/bucket/mame.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.280",
+    "version": "0.282",
     "description": "Arcade machine emulator",
     "homepage": "http://mamedev.org",
     "license": {
@@ -28,8 +28,8 @@
             ]
         },
         "64bit": {
-            "url": "https://github.com/mamedev/mame/releases/download/mame0280/mame0280b_64bit.exe#/dl.7z",
-            "hash": "67cb5049e497fcd551ca052d815ba4a581435f49d405b501c6ac01ec7610073d",
+            "url": "https://github.com/mamedev/mame/releases/download/mame0282/mame0282b_x64.exe#/dl.7z",
+            "hash": "4f9b2965f250c62bd511a9f2c4df33da78b7a8523139d943e5a7676ed23bc3ba",
             "pre_install": [
                 "if(!(Test-Path \"$persist_dir\\mame.ini\")) {",
                 "   Start-Process \"$dir\\mame.exe\" -WorkingDirectory \"$dir\" -ArgumentList \"-createconfig\"",
@@ -76,7 +76,7 @@
                 "url": "https://raw.githubusercontent.com/Calinou/scoop-games/27ba46f443a3446a70bf1f93eeb09797be0fb286/bucket/mame.json"
             },
             "64bit": {
-                "url": "https://github.com/mamedev/mame/releases/download/mame$cleanVersion/mame$cleanVersionb_64bit.exe#/dl.7z"
+                "url": "https://github.com/mamedev/mame/releases/download/mame$cleanVersion/mame$cleanVersionb_x64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Update MAME to latest version and fix broken autoupdate caused by upstream asset name change:

```diff
-"url": "https://github.com/mamedev/mame/releases/download/mame0280/mame0280b_64bit.exe#/dl.7z",
+"url": "https://github.com/mamedev/mame/releases/download/mame0282/mame0282b_x64.exe#/dl.7z",
```

- [x] Update tested to work in http://github.com/Vinfall/sb/commit/c3df331dc8f1ed126a8ec71ba5fb20364db7c954
- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
