### PR TITLE
(chore): Use explicit version numbers when suggesting .NET runtime/SDK

### DIFF
--- a/bucket/assetstudio.json
+++ b/bucket/assetstudio.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/zhangjiequan/AssetStudio",
     "license": "MIT",
     "suggest": {
-        ".NET 6.0 Desktop Runtime": "versions/windowsdesktop-runtime-6.0"
+        ".NET Desktop Runtime 6.0": "versions/windowsdesktop-runtime-6.0"
     },
     "url": "https://github.com/zhangjiequan/AssetStudio/releases/download/v0.16.53/AssetStudio.net6.0-windows_v0.16.53.zip",
     "hash": "0922b22b62853cd77e7b796124d52373fc1e1257179a1e3f3d7258137723616b",

--- a/bucket/bedrock-launcher.json
+++ b/bucket/bedrock-launcher.json
@@ -9,7 +9,7 @@
     ],
     "suggest": {
         "VCRedist": "extras/vcredist2022",
-        ".NET 8.0 Desktop Runtime": "extras/windowsdesktop-runtime-lts"
+        ".NET Desktop Runtime 8.0": "versions/windowsdesktop-runtime-8.0"
     },
     "architecture": {
         "64bit": {

--- a/bucket/fishstrap.json
+++ b/bucket/fishstrap.json
@@ -5,7 +5,7 @@
     "homepage": "https://www.fishstrap.app/",
     "license": "MIT",
     "suggest": {
-        ".NET 6.0 Desktop Runtime": "versions/windowsdesktop-runtime-6.0"
+        ".NET Desktop Runtime 6.0": "versions/windowsdesktop-runtime-6.0"
     },
     "architecture": {
         "64bit": {

--- a/bucket/froststrap.json
+++ b/bucket/froststrap.json
@@ -5,7 +5,7 @@
     "homepage": "https://realmeddsam.github.io/Froststrap-Website/",
     "license": "MIT",
     "suggest": {
-        ".NET 8.0 Desktop Runtime": "extras/windowsdesktop-runtime-lts"
+        ".NET Desktop Runtime 8.0": "versions/windowsdesktop-runtime-8.0"
     },
     "architecture": {
         "64bit": {

--- a/bucket/reloaded-ii.json
+++ b/bucket/reloaded-ii.json
@@ -7,8 +7,7 @@
         "url": "https://github.com/Reloaded-Project/Reloaded-II/blob/master/LICENSE.md"
     },
     "suggest": {
-        "Microsoft .NET 9.0 Desktop Runtime": "extras/windowsdesktop-runtime",
-        "Microsoft .NET 9.0 Desktop Runtime (x86)": "extras/windowsdesktop-runtime -a 32bit"
+        ".NET Desktop Runtime 9.0": "versions/windowsdesktop-runtime-9.0"
     },
     "url": "https://github.com/Reloaded-Project/Reloaded-II/releases/download/1.29.3/Release.zip",
     "hash": "e09ec41d6da9970114829f9d34870764a5c5fbc69160bb5ee4bff6b1e9491754",

--- a/bucket/romsorter.json
+++ b/bucket/romsorter.json
@@ -11,12 +11,12 @@
         "",
         "Since the runtime gets installed globally, sudo functionality is needed, which is part of the Main bucket.",
         "",
-        "With something like the 'gsudo' app installed, you could execute the following to get the dependencies: sudo scoop install extras/windowsdesktop-runtime-lts",
+        "With something like the 'gsudo' app installed, you could execute the following to get the dependencies: sudo scoop install versions/windowsdesktop-runtime-6.0",
         ""
     ],
     "suggest": {
         "Sudo": "main/gsudo",
-        ".NET runtime": "extras/windowsdesktop-runtime"
+        ".NET Desktop Runtime 6.0": "versions/windowsdesktop-runtime-6.0"
     },
     "url": "https://github.com/drakewill-CRL/ROMSorter/releases/download/release6/ROMSorter-Release6.zip",
     "hash": "63b060b4b4aa16485cf3b56b0e91ca5e25cc43527e5dccdde81947ed6147142d",


### PR DESCRIPTION
> Currently, manifests that recommend a .NET SDK or runtime LTS, or tags like current or lts, point to moving targets. These targets change whenever a new .NET LTS or preview release is published.

> As a result, once the referenced version advances, the original recommendation may no longer be valid. Applications built against a previous runtime are not guaranteed to be forward compatible with the newer runtime versions.

> Some manifests that depend on `windowsdesktop-runtime-lts` are actually referring to version 6.0, since they weren't updated when the LTS version changed last time.

> To ensure consistency and prevent unexpected compatibility issues, it's recommended to specify an exact version (e.g., windowsdesktop-runtime-8.0) instead of using rolling tags such as 'lts'.

This PR makes the following changes:
- (chore): Use explicit version numbers when suggesting .NET runtime/SDK

Relates to:
- https://github.com/ScoopInstaller/Extras/issues/16577

<!-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).