### PR TITLE
pkhex@25.11.16: Add plugins folder persist

### DIFF
--- a/bucket/pkhex.json
+++ b/bucket/pkhex.json
@@ -14,6 +14,7 @@
     "bin": "PKHeX.exe",
     "persist": [
         "bak",
+        "plugins",
         "cfg.json"
     ],
     "pre_install": [
@@ -44,3 +45,4 @@
         "url": "https://github.com/kwsch/PKHeX/raw/master/Directory.Build.props"
     }
 }
+


### PR DESCRIPTION
Added the plugins folder to persist, so that user-installed plugins are retained after the update.

Obviously, this does not guarantee that they will work after the update, but it keeps the directory structure in order and ensures that any additional files for the plugins remain in place.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1573

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
