### PR TITLE
eden: drop msvc-arm64, add mingw-arm64

### DIFF
--- a/bucket/eden.json
+++ b/bucket/eden.json
@@ -1,5 +1,5 @@
 {
-    "version": "v0.0.4-rc2",
+    "version": "v0.0.4-rc3",
     "description": "Open source Nintendo Switch emulator (forked from yuzu)",
     "homepage": "https://eden-emu.dev/",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/eden-emulator/Releases/releases/download/v0.0.4-rc2/Eden-Windows-v0.0.4-rc2-amd64-msvc-standard.zip",
-            "hash": "82f8b17c718e8d748b252afd8959c85e7060f394dc429ea4f81e2d4a76ce7f56"
+            "url": "https://github.com/eden-emulator/Releases/releases/download/v0.0.4-rc3/Eden-Windows-v0.0.4-rc3-amd64-msvc-standard.zip",
+            "hash": "9294a2b7fd60acc485f20cf7be4d3f10a2b8c95bdae78f17fde9b9c78b296818"
         },
         "arm64": {
-            "url": "https://github.com/eden-emulator/Releases/releases/download/v0.0.4-rc2/Eden-Windows-v0.0.4-rc2-arm64-msvc-standard.zip",
-            "hash": "8d43720d8895d9a7a2b847675a714a4d272905f977aa51ea149889d613917ad7"
+            "url": "https://github.com/eden-emulator/Releases/releases/download/v0.0.4-rc3/Eden-Windows-v0.0.4-rc3-mingw-arm64-clang-standard.zip",
+            "hash": "6ee97ebbec2cef8d02f32df2f7dfd257525594a62411026ad00f00d821fbe043"
         }
     },
     "pre_install": [
@@ -45,7 +45,7 @@
                 "url": "https://github.com/eden-emulator/Releases/releases/download/$version/Eden-Windows-$version-amd64-msvc-standard.zip"
             },
             "arm64": {
-                "url": "https://github.com/eden-emulator/Releases/releases/download/$version/Eden-Windows-$version-arm64-msvc-standard.zip"
+                "url": "https://github.com/eden-emulator/Releases/releases/download/$version/Eden-Windows-$version-mingw-arm64-clang-standard.zip"
             }
         }
     }


### PR DESCRIPTION
We removed MSVC/arm64 builds entirely in v0.0.4-rc3 because they never worked properly for 64 bit games. The MinGW/arm64 builds work perfectly fine though.