### PR TITLE
fix: Epic Games Launcher autoupdate link

### DIFF
--- a/bucket/epic-games-launcher.json
+++ b/bucket/epic-games-launcher.json
@@ -1,13 +1,13 @@
 {
-    "version": "18.12.1",
+    "version": "19.0.0",
     "homepage": "https://store.epicgames.com/",
     "description": "The official launcher for Epic Games Store",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.epicgames.com/site/en-US/tos"
     },
-    "url": "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Win32/EpicInstaller-18.12.1.msi#/setup.msi_",
-    "hash": "8dc09359e3e33a3818a09432337d390de5fb640400cc5e21fcabbfb2e02bec91",
+    "url": "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Windows/EpicInstaller-19.0.0.msi#/setup.msi_",
+    "hash": "8cfbad219c4d2a21d32866a5bed0ad196730ca89ffc9d7fa54de1e5c1a1ec8cc",
     "post_install": [
         "if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
         "Start-Process 'msiexec' -Wait -Verb 'RunAs' -ArgumentList @('/i', \"`\"$dir\\setup.msi_`\"\", '/qn', \"INSTALLDIR=`\"$dir`\"\", \"TARGETDIR=`\"$dir`\"\")",
@@ -33,5 +33,3 @@
         "url": "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Windows/EpicInstaller-$version.msi#/setup.msi_"
     }
 }
-
-


### PR DESCRIPTION
Epic has changed the architecture naming in the actual download path from `Win32` to `Windows`. 
To make this less fragile if Epic changes it again in the future, it’d be better to use a stable direct link for fetching the installer.

Link diff:
```diff
- https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Win32/EpicInstaller-$version.msi
+ https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Windows/EpicInstaller-$version.msi
```

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
