### PR TITLE
bugfix: Correct `xivlauncher` `extract_dir` for latest release

### DIFF
--- a/bucket/xivlauncher.json
+++ b/bucket/xivlauncher.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/goatcorp/FFXIVQuickLauncher/releases/download/7.0.20/XIVLauncher-7.0.20-full.nupkg",
     "hash": "8921d93888d7d2f9d136a494a7a65a0e3da81c686dcffa237f74dad545253f9c",
     "bin": "XIVLauncher.exe",
-    "extract_dir": "lib\\net45",
+    "extract_dir": "lib\\app",
     "shortcuts": [
         [
             "XIVLauncher.exe",


### PR DESCRIPTION
Fixed `xivlauncher` being broken by the changes released in v7.0.20.

Likely root cause was the upgrade from .NET Framework 4.7.2 to 9.0 in [goatcorp/FFXIVQuickLauncher#a55f88bc37b4db1917fa8b474493945123dcab4a](https://github.com/goatcorp/FFXIVQuickLauncher/commit/a55f88bc37b4db1917fa8b474493945123dcab4a).

Closes #1584

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
