### PR TITLE
cxbx-reloaded: Add pre_install script, modify persists

### DIFF
--- a/bucket/cxbx-reloaded.json
+++ b/bucket/cxbx-reloaded.json
@@ -1,14 +1,34 @@
 {
     "version": "cf031f1",
-    "description": "Microsoft Xbox emulator",
+    "description": "Xbox (Original) Emulator",
     "homepage": "https://cxbx-reloaded.co.uk/",
     "license": {
         "identifier": "GPL-2.0",
         "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/blob/master/COPYING"
     },
-    "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-cf031f1/CxbxReloaded-Release.zip",
-    "hash": "88a5e98876678095c34ca114a62c5ff5ad0845cdb03e20d3b53adeb61cf28373",
-    "pre_install": "if (!(Test-Path \"$persist_dir\\settings.ini\")) { $null = New-Item \"$dir\\settings.ini\" }",
+    "suggest": {
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-cf031f1/CxbxReloaded-Release.zip",
+            "hash": "88a5e98876678095c34ca114a62c5ff5ad0845cdb03e20d3b53adeb61cf28373"
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\")) {",
+        "   New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
+        "   if (Test-Path \"$env:APPDATA\\Cxbx-Reloaded\") {",
+        "       Write-Host \"Migrating AppData...\" -ForegroundColor yellow",
+        "       Copy-Item -Path \"$env:APPDATA\\Cxbx-Reloaded\\*\" -Destination \"$persist_dir\" -Recurse",
+        "       (Get-Content -Path \"$persist_dir\\settings.ini\").Replace(\"DataStorageToggle = 0x0\", \"DataStorageToggle = 0x1\") | Set-Content -Path \"$persist_dir\\settings.ini\"",
+        "       Remove-Item -Path \"$env:APPDATA\\Cxbx-Reloaded\" -Recurse -Force",
+        "   } else {",
+        "       New-Item \"$dir\\EEPROM.bin\" -ItemType File | Out-Null",
+        "       New-item \"$dir\\settings.ini\" -ItemType File | Out-Null",
+        "   }",
+        "}"
+    ],
     "bin": "cxbx.exe",
     "shortcuts": [
         [
@@ -18,6 +38,10 @@
     ],
     "persist": [
         "EmuDisk",
+        "EmuMediaBoard",
+        "EmuMu",
+        "SymbolCache",
+        "EEPROM.bin",
         "settings.ini"
     ],
     "checkver": {
@@ -25,6 +49,10 @@
         "regex": "CI-([a-f\\d]+)."
     },
     "autoupdate": {
-        "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-$version/CxbxReloaded-Release.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-$version/CxbxReloaded-Release.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Changes made in this PR:
- Slight change to description to match the project's Github short description
- Add suggestion to install VC redist dependency
- Change to use 'architecture' property to specify it's 64-bit app
- Add a 'pre_install' script to migrate existing appdata
- Modify 'persists' to add missing folders/files
- Change 'autoupdate' to account for 'architecture' property

Main purpose/motivation for this PR was to add support for migrating existing appdata as this is entirely missing from the current version of this manifest.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
