### PR TITLE
Supermodel URLs update

### DIFF
--- a/bucket/supermodel.json
+++ b/bucket/supermodel.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.3a-git-487d642",
+    "version": "0.3a-20260101-git-92bd36b",
     "description": "Sega Model 3 Arcade Emulator",
-    "homepage": "https://supermodel3.com/index.html",
+    "homepage": "https://github.com/trzy/Supermodel",
     "license": "GPL-3.0-only",
-    "url": "https://supermodel3.com/Files/Git_Snapshots/Supermodel_0.3a-git-487d642_Win64.zip",
-    "hash": "368a028caf48085ff84901d517441c8b61493c0cab404fb21f47b81886706679",
+    "url": "https://github.com/trzy/Supermodel/releases/download/v0.3a-20260101-git-92bd36b/supermodel-0.3a-20260101-git-92bd36b-windows.zip",
+    "hash": "17a3230e57b3416d35e6c402f874e01f1d7474cc2495b914117703b10fa72d48",
     "bin": [
         [
             "Launch-Supermodel.ps1",
@@ -20,10 +20,10 @@
     ],
     "pre_install": "\"Push-Location $dir; & ./Supermodel.exe `$args; Pop-Location \" | Out-File (Join-Path $dir 'Launch-Supermodel.ps1')",
     "checkver": {
-        "url": "https://supermodel3.com/Download.html",
-        "regex": "Supermodel_([0-9a-zA-Z.-]+)_Win64.zip"
+        "url": "https://github.com/trzy/Supermodel/releases",
+        "regex": "releases/tag/v(?<version>[\\w.-]+)"
     },
     "autoupdate": {
-        "url": "https://supermodel3.com/Files/Git_Snapshots/Supermodel_$version_Win64.zip"
+        "url": "https://github.com/trzy/Supermodel/releases/download/v$version/supermodel-$version-windows.zip"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The previous homepage and download URLs were pointing to a non-existent domain.
The emulator is now available and up-to-date on GitHub.

Changes:
- Updated `homepage` to the official GitHub repository.
- Switched `checkver` to monitor GitHub releases using a regex to properly capture the full version string (including git hashes).
- Fixed `autoupdate` URL pattern to match the asset naming convention on GitHub.
- Updated to the latest release: `0.3a-20260101-git-0d61fa1`.

Verified locally with `checkver.ps1 -u` and confirmed the installation works correctly.

- [ X ] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
