### PR TITLE
dsda-doom: add version 0.29.4

### DIFF
--- a/bucket/dsda-doom.json
+++ b/bucket/dsda-doom.json
@@ -1,6 +1,6 @@
 {
     "version": "0.29.4",
-    "description": "A modern Doom sourceport with a focus on speedrunning features. Successor of PrBoom+.",
+    "description": "Modern Doom source port with a focus on speedrunning features (successor of PrBoom+)",
     "homepage": "https://github.com/kraflab/dsda-doom",
     "license": "GPL-2.0-only",
     "notes": [


### PR DESCRIPTION
Closes #1609 (for real this time)

Output of installation from my [own doom bucket](https://github.com/via-dev/doom-scoop)
<details>
<summary>Show Output</summary>

```
~> scoop install doom/dsda-doom
Installing 'dsda-doom' (0.29.4) [64bit] from 'doom' bucket
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: c759c8|OK  |   7.3MiB/s|C:/Users/redacted/scoop/cache/dsda-doom#0.29.4#966f59f.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of dsda-doom-0.29.4-win-x64.zip ... ok.
Extracting dsda-doom-0.29.4-win-x64.zip ... done.
Running pre_install script...done.
Linking ~\scoop\apps\dsda-doom\current => ~\scoop\apps\dsda-doom\0.29.4
Creating shim for 'dsda-doom'.
Creating shortcut for DSDA Doom (dsda-doom.exe)
Persisting dsda-doom.cfg
Persisting dsda_doom_data
'dsda-doom' (0.29.4) was installed successfully!
Notes
-----
To persist your screenshots:

1) Create a screenshots folder somewhere like
        - C:\Users\<username>\Pictures\dsda-doom\
        - C:\Users\<username>\scoop\persist\dsda-doom\screenshots\

2) Set the "screenshot_dir" variable inside your config file to the directory's full path, like so
        - "C:\Users\<username>\Pictures\dsda-doom\"
        - "C:\Users\<username>\scoop\persist\dsda-doom\screenshots\"

Place your WAD files inside

C:\Users\<username>\scoop\persist\_doom\
'dsda-doom' suggests installing 'games/doomrunner' or 'games/zdl'.
```

</details>


- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).