### PR TITLE
crispy-doom: fix autoupdate, persist settings

### DIFF
--- a/bucket/crispy-doom.json
+++ b/bucket/crispy-doom.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.1.0",
+    "version": "7.1",
     "description": "Faithful enhanced-resolution source port for Doom",
     "homepage": "https://fabiangreffrath.github.io/crispy-homepage",
     "license": "GPL-2.0-or-later",
@@ -83,12 +83,12 @@
     "checkver": {
         "url": "https://api.github.com/repositories/17395051/releases/latest",
         "regex": "crispy-doom-([\\d.]+)\\/crispy-doom-([\\d.]+)-win64.zip",
-        "replace": "${2}"
+        "replace": "${1}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/fabiangreffrath/crispy-doom/releases/download/crispy-doom-$match1/crispy-doom-$version-win64.zip"
+                "url": "https://github.com/fabiangreffrath/crispy-doom/releases/download/crispy-doom-$version/crispy-doom-$match2-win64.zip"
             }
         }
     }


### PR DESCRIPTION
Closes #1608 

Crispy Doom's manifest should now update correctly and persist user settings in `crispy-doom.cfg`

The autoupdate URL has been changed to so that scoop will look at the tag version `crispy-doom-x.x.x` and manually derive the major, minor and patch version to download the correct zip file. This was done because the owner of the Crispy Doom repo releases zip files with the full `major.minor.patch` semver structure but omits the patch number in the actual release tag if it's equal to zero.

Hopefully this change will avoid issues with the repo's release tag structure. 

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
