### PR TITLE
woof: add version 15.3.0

### DIFF
--- a/bucket/woof.json
+++ b/bucket/woof.json
@@ -1,6 +1,6 @@
 {
     "version": "15.3.0",
-    "description": "Woof! is a continuation of the Boom/MBF bloodline of Doom source ports.",
+    "description": "Woof! is a continuation of the Boom/MBF bloodline of Doom source ports",
     "homepage": "https://fabiangreffrath.github.io/woof/",
     "license": "GPL-2.0",
     "notes": [


### PR DESCRIPTION
Closes #1615 

Installation output from my own bucket
<details>
<summary>Show output</summary>

```console
Installing 'woof' (15.3.0) [64bit] from 'doom' bucket
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: 68bf4a|OK  |   6.6MiB/s|C:/Users/luisjosemarquesborge/scoop/cache/woof#15.3.0#77abfa8.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of Woof-15.3.0-win64.zip ... ok.
Extracting Woof-15.3.0-win64.zip ... done.
Running pre_install script...done.
Linking ~\scoop\apps\woof\current => ~\scoop\apps\woof\15.3.0
Creating shim for 'woof'.
Making C:\Users\luisjosemarquesborge\scoop\shims\woof.exe a GUI binary.
Creating shortcut for Woof! (woof.exe)
Creating shortcut for Woof Setup (woof-setup.exe)
Persisting woof.cfg
Persisting autoload
Persisting savegames
'woof' (15.3.0) was installed successfully!
Notes
-----
Place your WAD files inside

C:\Users\<username>\scoop\persist\_doom\
```

</details>

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
