### PR TITLE
gopher64: Add version 1.1.11

### DIFF
--- a/bucket/gopher64.json
+++ b/bucket/gopher64.json
@@ -25,9 +25,16 @@
         "}"
     ],
     "post_install": "New-item \"$dir\\portable.txt\" -ItemType File | Out-Null",
-    "shortcuts": [["gopher64-windows-x86_64.exe", "Gopher64"]],
+    "shortcuts": [
+        [
+            "gopher64-windows-x86_64.exe",
+            "Gopher64"
+        ]
+    ],
     "persist": "portable_data",
-    "checkver": { "github": "https://github.com/gopher64/gopher64" },
+    "checkver": {
+        "github": "https://github.com/gopher64/gopher64"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1617.

Output:
<details>

```pwsh

Installing 'gopher64' (1.1.11) [64bit] from 'C:\Users\AE\git\sg\gopher64.json'
Loading gopher64-windows-x86_64.exe from cache.
Checking hash of gopher64-windows-x86_64.exe ... ok.
Running pre_install script...Migrating AppData...
done.
Linking ~\scoop\apps\gopher64\current => ~\scoop\apps\gopher64\1.1.11
Creating shortcut for Gopher64 (gopher64-windows-x86_64.exe)
Persisting portable_data
Running post_install script...done.
'gopher64' (1.1.11) was installed successfully!
Notes
-----
You must completely uninstall Bandicam and Mirillis Action if you have them installed; they are incompatible with
gopher64.
Wiki: https://github.com/gopher64/gopher64/wiki

```

</details>

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
