### PR TITLE
nugget-doom: add version 4.5.0

### DIFF
--- a/bucket/nugget-doom.json
+++ b/bucket/nugget-doom.json
@@ -1,7 +1,6 @@
 {
     "version": "4.5.0",
     "description": "Doom source port forked from Woof! with additional features",
-
     "homepage": "https://github.com/MrAlaux/Nugget-Doom",
     "license": "GPL-2.0",
     "notes": [


### PR DESCRIPTION
Note: Because Nugget Doom is a fork of Woof the repo structure is nearly identical and so is this manifest to the Woof manifest.

Closes #1619 

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
