### PR TITLE
Make Chunker Manifest Use Zip Archive

### DIFF
--- a/bucket/chunker.json
+++ b/bucket/chunker.json
@@ -14,12 +14,6 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/HiveGamesOSS/Chunker/releases/download/$version/Chunker-$version-windows-x86.zip",
-        "shortcuts": [
-            [
-                "Chunker.exe",
-                "Chunker"
-            ]
-        ]
+        "url": "https://github.com/HiveGamesOSS/Chunker/releases/download/$version/Chunker-$version-windows-x86.zip"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The manifest for Chunker downloads a `Chunker-1.14.0-windows-x86.exe` file, which is actually an NSIS installer that extracts Chunker to a temporary directory and runs it. Changing the manifest to use the zip file provided on the Chunker GitHub would provide a cleaner install that does not extract the program to the temporary directory each time you run it and clean it up afterwards.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1624

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
