### PR TITLE
xemu@0.8.133: Modify autoupdate to include version in filename

### DIFF
--- a/bucket/xemu.json
+++ b/bucket/xemu.json
@@ -16,11 +16,11 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/xemu-project/xemu/releases/download/v0.8.133/xemu-win-x86_64-release.zip",
+            "url": "https://github.com/xemu-project/xemu/releases/download/v0.8.133/xemu-0.8.133-windows-x86_64.zip",
             "hash": "6a8dd63c247596efa8594699f9a476868d2f020552b1670fcc2e90f1bf649673"
         },
         "arm64": {
-            "url": "https://github.com/xemu-project/xemu/releases/download/v0.8.133/xemu-win-aarch64-release.zip",
+            "url": "https://github.com/xemu-project/xemu/releases/download/v0.8.133/xemu-0.8.133-windows-arm64.zip",
             "hash": "745492d5af9d9dc4e3fc4040adbb85452a228502b8950f22f95210112ad3ec53"
         }
     },
@@ -67,10 +67,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/xemu-project/xemu/releases/download/v$version/xemu-win-x86_64-release.zip"
+                "url": "https://github.com/xemu-project/xemu/releases/download/v$version/xemu-$version-windows-x86_64.zip"
             },
             "arm64": {
-                "url": "https://github.com/xemu-project/xemu/releases/download/v$version/xemu-win-aarch64-release.zip"
+                "url": "https://github.com/xemu-project/xemu/releases/download/v$version/xemu-$version-windows-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Changes made in this PR:
 - Update the `autoupdate` property to include the version number in the release asset
 
	This change has been made because as of version 0.8.131, the Xemu project has moved to include the version number on all release archvies.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
