### PR TITLE
Rollback amulet-map-editor manifest to version 0.10.44 and add notes

### DIFF
--- a/bucket/amulet-map-editor.json
+++ b/bucket/amulet-map-editor.json
@@ -1,6 +1,6 @@
 {
     "version": "0.10.44",
-    "description": "Minecraft world editor and converter.",
+    "description": "Minecraft world editor and converter",
     "homepage": "https://www.amuletmc.com",
     "license": "Proprietary",
     "notes": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Amulet has moved to a paid subscription model for distribution for versions 0.10.45+. This has resulted in autoupdate bots putting invalid links (using the same structure as the links for previous releases) for non-public versions distributed under this new model. I have rolled back the manifest to the last publicly available version (0.10.44) and added a note.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1626

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
