### PR TITLE
cxbx-reloaded: Add timestamp extraction to checkver

### DIFF
--- a/bucket/cxbx-reloaded.json
+++ b/bucket/cxbx-reloaded.json
@@ -1,5 +1,5 @@
 {
-    "version": "9454f34",
+    "version": "20260130182937-9454f34",
     "description": "Xbox (Original) Emulator",
     "homepage": "https://cxbx-reloaded.co.uk/",
     "license": {
@@ -46,12 +46,20 @@
     ],
     "checkver": {
         "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases.atom",
-        "regex": "CI-([a-f\\d]+)."
+        "script": [
+            "$xml = [xml]$page",
+            "$entry = $xml.feed.entry | Select-Object -First 1",
+            "$updated = $entry.updated",
+            "$title = $entry.title",
+            "Write-Output \"$updated $title\""
+        ],
+        "regex": "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})T(?<hour>\\d{2}):(?<minute>\\d{2}):(?<second>\\d{2})Z CI-(?<commit>[a-f\\d]+)",
+        "replace": "${year}${month}${day}${hour}${minute}${second}-${commit}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-$version/CxbxReloaded-Release.zip"
+                "url": "https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/releases/download/CI-$matchCommit/CxbxReloaded-Release.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Changes made in this PR:
- Change the `checkver` property to now extract the timestamp from the commit and include that in the version string alongside the commit.
  - Also modify `autoupdate` to account for changes now made `checkver`
 
This fix is based on the way [`xenia-canary.json`](https://github.com/Calinou/scoop-games/blob/master/bucket/xenia-canary.json) & [`xenia-edge.json`](https://github.com/Calinou/scoop-games/blob/master/bucket/xenia-edge.json) handle this exact same issue,

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1642 

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
