### PR TITLE
Fix URL for fissure information in wfinfo.json

### DIFF
--- a/bucket/wfinfo.json
+++ b/bucket/wfinfo.json
@@ -19,4 +19,3 @@
         "url": "https://github.com/WFCD/WFinfo/releases/download/v$version/WFInfo.zip"
     }
 }
-


### PR DESCRIPTION
Updates the wiki link for fissures to use Warframe's official wiki instead of the abandoned fandom one.

This is a simple change that doesn't affect the package and most people won't see, I don't feel like it warrants creating an issue.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
