### PR TITLE
1647: Removed deletion of resources\app-update.yml to prevent a warni…

### DIFF
--- a/bucket/vortex.json
+++ b/bucket/vortex.json
@@ -14,7 +14,7 @@
         }
     },
     "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\", \"$dir\\`$TEMP\", \"$dir\\resources\\app-update.yml\" -Recurse -Force",
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\", \"$dir\\`$TEMP\" -Recurse -Force",
     "shortcuts": [
         [
             "Vortex.exe",


### PR DESCRIPTION
Removes the automatic deletion of `resources\app-update.yml` to prevent a warning about a corrupt installation when starting Vortex.

Closes #1647

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
