### PR TITLE
xxmi: add `EFMI` and `HIMI` to persist

### DIFF
--- a/bucket/xxmi.json
+++ b/bucket/xxmi.json
@@ -18,10 +18,12 @@
         ]
     ],
     "persist": [
+        "EFMI",
+        "WWMI",
         "ZZMI",
         "SRMI",
         "GIMI",
-        "WWMI"
+        "HIMI"
     ],
     "checkver": {
         "github": "https://github.com/SpectrumQT/XXMI-Launcher"


### PR DESCRIPTION
update `SpectrumQT/XXMI-Launcher` supporting XXMIs to persist

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
