### PR TITLE
Add save data and config to persist

### DIFF
--- a/bucket/ringracers.json
+++ b/bucket/ringracers.json
@@ -13,9 +13,14 @@
         ]
     ],
     "persist": [
+        "addons",
+        "logs",
+        "media",
         "ringdata.dat",
         "ringprofiles.prf",
-        "ringconfig.cfg"
+        "ringconfig.cfg",
+        "srvstats.dat",
+        "srvbans.json"
     ],
     "checkver": {
         "github": "https://github.com/KartKrewDev/RingRacers"


### PR DESCRIPTION
When I initially wrote the manifest I forgot to persist the save and config data. This should just persist unlocks, profiles, and config.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
