### PR TITLE
xonotic@0.8.6: fix decompression error with 7z

### DIFF
--- a/bucket/xonotic.json
+++ b/bucket/xonotic.json
@@ -3,15 +3,22 @@
     "description": "Free fast-paced first-person shooter",
     "homepage": "https://xonotic.org/",
     "license": "GPL-3.0-or-later",
-    "url": "https://dl.xonotic.org/xonotic-0.8.6.zip",
+    "url": "https://dl.xonotic.org/xonotic-0.8.6.zip#/xonotic-0.8.6.archive",
     "hash": "sha512:cb39879e96f19abb2877588c2d50c5d3e64dd68153bec3dd1bebedf4d765e506afa419c28381d7005aed664cb1a042571c132b5b319e4308cab67745d996c2a6",
     "architecture": {
         "32bit": {
-            "pre_install": "Set-Content -Path \"$dir\\xonotic.bat\" -Value \"pushd $dir\\Xonotic && xonotic-x86.exe && popd\""
+            "pre_install": "Set-Content -Path \"$dir\\xonotic.bat\" -Value \"pushd $dir && xonotic-x86.exe && popd\""
         },
         "64bit": {
-            "pre_install": "Set-Content -Path \"$dir\\xonotic.bat\" -Value \"pushd $dir\\Xonotic && xonotic.exe && popd\""
+            "pre_install": "Set-Content -Path \"$dir\\xonotic.bat\" -Value \"pushd $dir && xonotic.exe && popd\""
         }
+    },
+    "installer": {
+        "script": [
+            "Expand-7zipArchive -Path \"$dir\\$fname\" -DestinationPath \"$dir\" -Switches \"-x!Xonotic/Xonotic.app -x!Xonotic/xonotic-linux-dedicated.sh -x!Xonotic/xonotic-linux-glx.sh -x!Xonotic/misc/tools/rsync-updater/update-to-release.sh\" -Overwrite All -Removal",
+            "Move-Item -Path \"$dir\\Xonotic\\*\" -Destination \"$dir\\\" -Force",
+            "Remove-Item -Path \"$dir\\Xonotic\" -Force -Recurse"
+        ]
     },
     "bin": "xonotic.bat",
     "shortcuts": [
@@ -19,7 +26,7 @@
             "xonotic.bat",
             "Xonotic",
             "",
-            "Xonotic/misc/logos/icons_ico/xonotic.ico"
+            "misc/logos/icons_ico/xonotic.ico"
         ]
     ],
     "checkver": {
@@ -27,7 +34,7 @@
         "regex": "Download Xonotic ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://dl.xonotic.org/xonotic-$version.zip",
+        "url": "https://dl.xonotic.org/xonotic-$version.zip#/xonotic-$version.archive",
         "hash": {
             "url": "https://dl.xonotic.org/xonotic-$version.sha512"
         }


### PR DESCRIPTION
Since scoop doesn't exposes any way to disable [auto extraction](https://github.com/ScoopInstaller/Scoop/blob/b588a06e41d920d2123ec70aee682bae14935939/lib/install.ps1#L53),
the only option left is to use URL fragment (See: [ScoopInstaller/lib/download.ps1](https://github.com/ScoopInstaller/Scoop/blob/b588a06e41d920d2123ec70aee682bae14935939/lib/download.ps1#L687))
This will rename the downloaded archive with a new name that
doesn't ends in an extension which scoop can auto-extract. So
it can be extracted in the `installer.script` section with desired
flags, like ignoring symlinks or extracting only required files.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #818

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
