### PR TITLE
vkquake: update to version 1.34.0, fix autoupdate

### DIFF
--- a/bucket/vkquake.json
+++ b/bucket/vkquake.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.32.3.1",
+    "version": "1.34.0",
     "description": "Quake 1 port using Vulkan instead of OpenGL for rendering, based on QuakeSpasm",
     "homepage": "https://github.com/Novum/vkQuake",
     "license": "GPL-2.0-or-later",
@@ -27,13 +27,9 @@
         "vcredist": "extras/vcredist2022"
     },
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/Novum/vkQuake/releases/download/1.32.3.1/vkquake-1.32.3_win32.zip",
-            "hash": "3f3bbd33b67dd438db2651b3b8003ec072218b3ddd434ccb8b4736ab04a3b424"
-        },
         "64bit": {
-            "url": "https://github.com/Novum/vkQuake/releases/download/1.32.3.1/vkquake-1.32.3_win64.zip",
-            "hash": "cbdca7bb429d8078a801f0cc038085a887d3079b279afcbd92ff9d0792b0b057"
+            "url": "https://github.com/Novum/vkQuake/releases/download/1.34.0/vkQuake-1.34.0_windows_x64.zip",
+            "hash": "716f99f7417849aa03099f4a3bdc7aee370dc12d2f0285b4edba8e58e2160988"
         }
     },
     "bin": [
@@ -79,11 +75,8 @@
     "checkver": "github",
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/Novum/vkQuake/releases/download/$version/vkquake-$matchHead_win32.zip"
-            },
             "64bit": {
-                "url": "https://github.com/Novum/vkQuake/releases/download/$version/vkquake-$matchHead_win64.zip"
+                "url": "https://github.com/Novum/vkQuake/releases/download/$version/vkQuake-$matchHead_windows_x64.zip"
             }
         }
     }


### PR DESCRIPTION
Note: 32 bit support has been removed

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
