### PR TITLE
shadps4, shadps4-dev: Update to latest version, fix autoupdate

### DIFF
--- a/bucket/shadps4-dev.json
+++ b/bucket/shadps4-dev.json
@@ -1,5 +1,5 @@
 {
-    "version": "20260418220905-e7d736a",
+    "version": "20260419211420-6671c44",
     "description": "PlayStation 4 emulator (development version)",
     "homepage": "https://shadps4.net/",
     "license": {
@@ -11,10 +11,45 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/releases/download/shadPS4QtLauncher-2026-04-18-e7d736af3487b08d9bf2e39a493e980d6657f61d/shadPS4QtLauncher-win64-qt-2026-04-18-e7d736a.zip",
-            "hash": "ebe74422e72fbdc659600d291bbfaf70a333b5b8205c30ea444fdbc25e95ac2d"
+            "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/releases/download/shadPS4QtLauncher-2026-04-19-6671c44982100cd6fefe9612aa941f07d682aac9/shadPS4QtLauncher-win64-qt-2026-04-19-6671c44.zip",
+            "hash": "26d42fdb9c2070f3aa1cc35966a282adac300e327c62a6c489d434db88c4852f"
         }
     },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\")) {",
+        "    New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
+        "    $map = @{ 'shadPS4' = 'user'; 'shadPS4QtLauncher' = 'launcher' }",
+        "    $found = $map.Keys.Where({ Test-Path \"$env:APPDATA\\$_\" })",
+        "    if ($found) {",
+        "        Write-Host 'Migrating AppData...' -ForegroundColor Yellow",
+        "        foreach ($folder in $found) {",
+        "            $dest = \"$persist_dir\\$($map[$folder])\"",
+        "            New-Item $dest -ItemType Directory | Out-Null",
+        "            Copy-Item -Path \"$env:APPDATA\\$folder\\*\" -Destination $dest -Recurse",
+        "            Remove-Item -Path \"$env:APPDATA\\$folder\" -Recurse",
+        "        }",
+        "    }",
+        "}"
+    ],
+    "post_install": [
+        "if (Test-Path \"$persist_dir\\user\\config.toml\") {",
+        "    $oldAddonDir = ($env:APPDATA + '\\shadPS4\\addcont').Replace('\\', '\\\\')",
+        "    $newAddonDir = ($dir + '\\user\\addcont').Replace('\\', '\\\\')",
+        "    (Get-Content \"$persist_dir\\user\\config.toml\").Replace($oldAddonDir, $newAddonDir) | Set-Content \"$persist_dir\\user\\config.toml\"",
+        "}",
+        "if (Test-Path \"$persist_dir\\launcher\\qt_ui.ini\") {",
+        "    $oldVersionPath = ($env:APPDATA + '\\shadPS4QtLauncher\\versions').Replace('\\', '\\\\')",
+        "    $newVersionPath = ($dir + '\\launcher\\versions').Replace('\\', '\\\\')",
+        "    $oldVersionSel = ($env:APPDATA + '\\shadPS4QtLauncher\\versions').Replace('\\', '/')",
+        "    $newVersionSel = ($dir + '\\launcher\\versions').Replace('\\', '/')",
+        "    (Get-Content \"$persist_dir\\launcher\\qt_ui.ini\").Replace($oldVersionPath, $newVersionPath).Replace($oldVersionSel, $newVersionSel) | Set-Content \"$persist_dir\\launcher\\qt_ui.ini\"",
+        "}",
+        "if (Test-Path \"$persist_dir\\launcher\\versions.json\") {",
+        "    $oldPath = ($env:APPDATA + '\\shadPS4QtLauncher\\versions').Replace('\\', '/')",
+        "    $newPath = ($dir + '\\launcher\\versions').Replace('\\', '/')",
+        "    (Get-Content \"$persist_dir\\launcher\\versions.json\").Replace($oldPath, $newPath) | Set-Content \"$persist_dir\\launcher\\versions.json\"",
+        "}"
+    ],
     "bin": [
         [
             "shadPS4QtLauncher.exe",

--- a/bucket/shadps4-dev.json
+++ b/bucket/shadps4-dev.json
@@ -1,5 +1,5 @@
 {
-    "version": "2026-04-18-e7d736a",
+    "version": "20260418220905-e7d736a",
     "description": "PlayStation 4 emulator (development version)",
     "homepage": "https://shadps4.net/",
     "license": {
@@ -33,13 +33,19 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/shadps4-emu/shadps4-qtlauncher/releases?per_page=1",
-        "jsonpath": "$[?(@.prerelease == true)]",
-        "regex": "/(?<tag>[\\w-]+)/shadPS4QtLauncher-win64-qt-(?<version>[\\w-]+)\\.zip"
+        "script": [
+            "$release = (Invoke-RestMethod $url | Where-Object { $_.prerelease })[0]",
+            "$time = (Get-Date $release.published_at).ToString('yyyyMMddHHmmss')",
+            "$suffix = $release.name -replace '^shadPS4QtLauncher-'",
+            "$commit = ($suffix -split '-')[-1]",
+            "return \"$time-$commit $($release.tag_name) $suffix\""
+        ],
+        "regex": "(?<version>[\\w-]+) (?<tag>[\\w-]+) (?<suffix>[\\w.-]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/releases/download/$matchTag/shadPS4QtLauncher-win64-qt-$version.zip"
+                "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/releases/download/$matchTag/shadPS4QtLauncher-win64-qt-$matchSuffix.zip"
             }
         }
     }

--- a/bucket/shadps4-dev.json
+++ b/bucket/shadps4-dev.json
@@ -1,27 +1,46 @@
 {
-    "version": "2025-10-30-715eb51",
-    "description": "PlayStation 4 emulator for Windows, Linux and macOS (development version)",
+    "version": "2026-04-18-e7d736a",
+    "description": "PlayStation 4 emulator (development version)",
     "homepage": "https://shadps4.net/",
     "license": {
         "identifier": "GPL-2.0-only",
-        "url": "https://github.com/shadps4-emu/shadPS4/blob/main/LICENSE"
+        "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/blob/main/LICENSE"
     },
-    "url": "https://github.com/shadps4-emu/shadPS4/releases/download/Pre-release-shadPS4-2025-10-30-715eb512c9b84bfcc5f208881a657dd02a58393e/shadps4-win64-qt-2025-10-30-715eb51.zip",
-    "hash": "2d0d67816f628582776ff5b390f7567c0aff342c8293e3d2d5e9309302936ace",
-    "bin": "shadPS4.exe",
+    "suggest": {
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/releases/download/shadPS4QtLauncher-2026-04-18-e7d736af3487b08d9bf2e39a493e980d6657f61d/shadPS4QtLauncher-win64-qt-2026-04-18-e7d736a.zip",
+            "hash": "ebe74422e72fbdc659600d291bbfaf70a333b5b8205c30ea444fdbc25e95ac2d"
+        }
+    },
+    "bin": [
+        [
+            "shadPS4QtLauncher.exe",
+            "shadPS4-dev"
+        ]
+    ],
     "shortcuts": [
         [
-            "shadPS4.exe",
+            "shadPS4QtLauncher.exe",
             "shadPS4 (Development)"
         ]
     ],
-    "persist": "user",
+    "persist": [
+        "launcher",
+        "user"
+    ],
     "checkver": {
-        "url": "https://api.github.com/repos/shadps4-emu/shadPS4/releases?per_page=1",
+        "url": "https://api.github.com/repos/shadps4-emu/shadps4-qtlauncher/releases?per_page=1",
         "jsonpath": "$[?(@.prerelease == true)]",
-        "regex": "/(?<tag>[\\w-]+)/shadps4-win64-qt-(?<version>[\\w-]+)\\.zip"
+        "regex": "/(?<tag>[\\w-]+)/shadPS4QtLauncher-win64-qt-(?<version>[\\w-]+)\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/shadps4-emu/shadPS4/releases/download/$matchTag/shadps4-win64-qt-$version.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/releases/download/$matchTag/shadPS4QtLauncher-win64-qt-$version.zip"
+            }
+        }
     }
 }

--- a/bucket/shadps4.json
+++ b/bucket/shadps4.json
@@ -35,7 +35,7 @@
         "github": "https://github.com/shadps4-emu/shadps4-qtlauncher"
     },
     "autoupdate": {
-        "architecure": {
+        "architecture": {
             "64bit": {
                 "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/releases/download/v$version/shadPS4QtLauncher-win64-qt-v$version.zip"
             }

--- a/bucket/shadps4.json
+++ b/bucket/shadps4.json
@@ -1,27 +1,44 @@
 {
-    "version": "0.12.0",
-    "description": "PlayStation 4 emulator for Windows, Linux and macOS",
+    "version": "224",
+    "description": "PlayStation 4 emulator",
     "homepage": "https://shadps4.net/",
     "license": {
         "identifier": "GPL-2.0-only",
-        "url": "https://github.com/shadps4-emu/shadPS4/blob/main/LICENSE"
+        "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/blob/main/LICENSE"
     },
-    "url": "https://github.com/shadps4-emu/shadPS4/releases/download/v.0.12.0/shadps4-win64-qt-0.12.0.zip",
-    "hash": "f6af1dcfe6dbc19e0190c72ca1b2d0b83d1fda8f11deda007347863fa0d6cbe9",
-    "bin": "shadPS4.exe",
-    "shortcuts": [
+    "suggest": {
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/releases/download/v224/shadPS4QtLauncher-win64-qt-v224.zip",
+            "hash": "021871249bae6867900f62efd728a6cbdbed9934b69c28488b41d413280e2e1d"
+        }
+    },
+    "bin": [
         [
-            "shadPS4.exe",
+            "shadPS4QtLauncher.exe",
             "shadPS4"
         ]
     ],
-    "persist": "user",
+    "shortcuts": [
+        [
+            "shadPS4QtLauncher.exe",
+            "shadPS4"
+        ]
+    ],
+    "persist": [
+        "launcher",
+        "user"
+    ],
     "checkver": {
-        "url": "https://api.github.com/repos/shadps4-emu/shadPS4/releases/latest",
-        "jsonpath": "$.tag_name",
-        "regex": "v\\.([\\d.]+)"
+        "github": "https://github.com/shadps4-emu/shadps4-qtlauncher"
     },
     "autoupdate": {
-        "url": "https://github.com/shadps4-emu/shadPS4/releases/download/v.$version/shadps4-win64-qt-$version.zip"
+        "architecure": {
+            "64bit": {
+                "url": "https://github.com/shadps4-emu/shadps4-qtlauncher/releases/download/v$version/shadPS4QtLauncher-win64-qt-v$version.zip"
+            }
+        }
     }
 }

--- a/bucket/shadps4.json
+++ b/bucket/shadps4.json
@@ -15,6 +15,41 @@
             "hash": "021871249bae6867900f62efd728a6cbdbed9934b69c28488b41d413280e2e1d"
         }
     },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\")) {",
+        "    New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
+        "    $map = @{ 'shadPS4' = 'user'; 'shadPS4QtLauncher' = 'launcher' }",
+        "    $found = $map.Keys.Where({ Test-Path \"$env:APPDATA\\$_\" })",
+        "    if ($found) {",
+        "        Write-Host 'Migrating AppData...' -ForegroundColor Yellow",
+        "        foreach ($folder in $found) {",
+        "            $dest = \"$persist_dir\\$($map[$folder])\"",
+        "            New-Item $dest -ItemType Directory | Out-Null",
+        "            Copy-Item -Path \"$env:APPDATA\\$folder\\*\" -Destination $dest -Recurse",
+        "            Remove-Item -Path \"$env:APPDATA\\$folder\" -Recurse",
+        "        }",
+        "    }",
+        "}"
+    ],
+    "post_install": [
+        "if (Test-Path \"$persist_dir\\user\\config.toml\") {",
+        "    $oldAddonDir = ($env:APPDATA + '\\shadPS4\\addcont').Replace('\\', '\\\\')",
+        "    $newAddonDir = ($dir + '\\user\\addcont').Replace('\\', '\\\\')",
+        "    (Get-Content \"$persist_dir\\user\\config.toml\").Replace($oldAddonDir, $newAddonDir) | Set-Content \"$persist_dir\\user\\config.toml\"",
+        "}",
+        "if (Test-Path \"$persist_dir\\launcher\\qt_ui.ini\") {",
+        "    $oldVersionPath = ($env:APPDATA + '\\shadPS4QtLauncher\\versions').Replace('\\', '\\\\')",
+        "    $newVersionPath = ($dir + '\\launcher\\versions').Replace('\\', '\\\\')",
+        "    $oldVersionSel = ($env:APPDATA + '\\shadPS4QtLauncher\\versions').Replace('\\', '/')",
+        "    $newVersionSel = ($dir + '\\launcher\\versions').Replace('\\', '/')",
+        "    (Get-Content \"$persist_dir\\launcher\\qt_ui.ini\").Replace($oldVersionPath, $newVersionPath).Replace($oldVersionSel, $newVersionSel) | Set-Content \"$persist_dir\\launcher\\qt_ui.ini\"",
+        "}",
+        "if (Test-Path \"$persist_dir\\launcher\\versions.json\") {",
+        "    $oldPath = ($env:APPDATA + '\\shadPS4QtLauncher\\versions').Replace('\\', '/')",
+        "    $newPath = ($dir + '\\launcher\\versions').Replace('\\', '/')",
+        "    (Get-Content \"$persist_dir\\launcher\\versions.json\").Replace($oldPath, $newPath) | Set-Content \"$persist_dir\\launcher\\versions.json\"",
+        "}"
+    ],
     "bin": [
         [
             "shadPS4QtLauncher.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Changes made in this PR:
 - Simplified description by removing mention of platforms
 - Updated licence url to point to qtlauncher repo
 - Added `suggest` property to inform the user of the [VCRedist dependency](https://shadps4.net/quickstart/#21-download-shadps4qtlauncher:~:text=First%2C%20you%20will%20need%20Microsoft%20Visual%20C%2B%2B%202022%20to%20run%20it.)
 - Added `architecture` property and updated url & hash to latest version from new repo
 - Added `pre_install` & `post_install` scripts to support AppData migration
 - Modified `bin` & `shortcuts` to account for new executable name of the launcher
 - Added the 'launcher' folder to `persist`
 - Updated `checkver` with qtlauncher repo
   - For the non-dev release, changed to just track github as it uses regular-enough versioning
   - For the dev release, added a script to parse the date & time so the resulting version string has both (as there can be multiple updates in one day)
 - Updated `autoupdate` with new repo & file naming convention

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1569
Closes #1350 

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).