### PR TITLE
betacraft-launcher, betacraft-launcher-v2: Add v1, v2 version

### DIFF
--- a/bucket/betacraft-launcher-v2.json
+++ b/bucket/betacraft-launcher-v2.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.0.0-alpha.20230623",
+    "description": "Unofficial launcher for legacy versions of Minecraft (v2 alpha)",
+    "homepage": "https://betacraft.uk/",
+    "license": {
+        "identifier": "GPL-3.0-only",
+        "url": "https://github.com/betacraftuk/betacraft-launcher/blob/v2/LICENSE"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/betacraftuk/betacraft-launcher/releases/download/2.0.0-alpha.20230623/betacraft-2.0.0-alpha.20230623-win64.zip",
+            "hash": "4fba435ee222a261de63f759f638e4bf9bf2471aa2cd050e1e6d808683d26f9c"
+        }
+    },
+    "extract_dir": "Betacraft",
+    "shortcuts": [
+        [
+            "Betacraft.exe",
+            "Betacraft Launcher (alpha)"
+        ]
+    ],
+    "persist": "betacraft",
+    "checkver": {
+        "url": "https://api.github.com/repos/betacraftuk/betacraft-launcher/releases",
+        "jsonpath": "$[?(@.target_commitish == 'v2')].tag_name"
+    },
+    "autoupdate": {
+        "url": "https://github.com/betacraftuk/betacraft-launcher/releases/download/$version/betacraft-$version-win64.zip"
+    }
+}

--- a/bucket/betacraft-launcher.json
+++ b/bucket/betacraft-launcher.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.09_17",
+    "description": "Unofficial launcher for legacy versions of Minecraft",
+    "homepage": "https://betacraft.uk/",
+    "license": {
+        "identifier": "GPL-3.0-only",
+        "url": "https://github.com/betacraftuk/betacraft-launcher/blob/v1/LICENSE"
+    },
+    "notes": "Jave Runtime Environment (JRE) 1.8 is required.",
+    "url": "https://github.com/betacraftuk/betacraft-launcher/releases/download/1.09_17/launcher-1.09_17-portable.exe",
+    "hash": "4196fa3b83a0cfbc2f5daa2f8ed5c2c9176c3b3daa0ca06e469c6219410355f1",
+    "shortcuts": [
+        [
+            "launcher-1.09_17-portable.exe",
+            "Betacraft Launcher"
+        ]
+    ],
+    "persist": ".betacraft",
+    "checkver": {
+        "url": "https://api.github.com/repos/betacraftuk/betacraft-launcher/releases",
+        "jsonpath": "$[?(@.target_commitish == 'v1')].tag_name"
+    },
+    "autoupdate": {
+        "url": "https://github.com/betacraftuk/betacraft-launcher/releases/download/$version/launcher-$version-portable.exe",
+        "shortcuts": [
+            [
+                "launcher-$version-portable.exe",
+                "Betacraft Launcher"
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR creates an app manifest for 'betacraft-launcher' & 'betacraft-launcher-v2'.
v1: [betacraftuk/betacraft-launcher/tree/v1](https://github.com/betacraftuk/betacraft-launcher/tree/v1)
v2: [betacraftuk/betacraft-launcher/tree/v2](https://github.com/betacraftuk/betacraft-launcher/tree/v2)

Both versions are provided as both are presented/supported on the [main website](https://betacraft.uk/downloads).

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1704 

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
