### PR TITLE
eden: Switch to new stable release host

### DIFF
--- a/bucket/eden.json
+++ b/bucket/eden.json
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://git.eden-emu.dev/eden-emu/eden/releases/download/v0.2.0-rc2/Eden-Windows-v0.2.0-rc2-amd64-msvc-standard.zip",
+            "url": "https://stable.eden-emu.dev/v0.2.0-rc2/Eden-Windows-v0.2.0-rc2-amd64-msvc-standard.zip",
             "hash": "552001c0dc4964a058cedd2e2bd432c8a3a024d3291e035b56e8b91243531eb4"
         },
         "arm64": {
-            "url": "https://git.eden-emu.dev/eden-emu/eden/releases/download/v0.2.0-rc2/Eden-Windows-v0.2.0-rc2-mingw-arm64-clang-standard.zip",
+            "url": "https://stable.eden-emu.dev/v0.2.0-rc2/Eden-Windows-v0.2.0-rc2-mingw-arm64-clang-standard.zip",
             "hash": "4b599b113226b2d152652b4a9c612d451d0e008e9746390c723e8d056820b39d"
         }
     },
@@ -43,10 +43,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://git.eden-emu.dev/eden-emu/eden/releases/download/v$version/Eden-Windows-v$version-amd64-msvc-standard.zip"
+                "url": "https://stable.eden-emu.dev/v$version/Eden-Windows-v$version-amd64-msvc-standard.zip"
             },
             "arm64": {
-                "url": "https://git.eden-emu.dev/eden-emu/eden/releases/download/v$version/Eden-Windows-v$version-mingw-arm64-clang-standard.zip"
+                "url": "https://stable.eden-emu.dev/v$version/Eden-Windows-v$version-mingw-arm64-clang-standard.zip"
             }
         }
     }


### PR DESCRIPTION
Uses backblaze + cloudflare cdn, see https://eden-emu.dev/blog/distribution-challenges for more info. Forgejo hosted downloads will be retired soon

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
