### PR TITLE
wand: Init Wand at 12.22.0

### DIFF
--- a/bucket/wand.json
+++ b/bucket/wand.json
@@ -1,19 +1,19 @@
 {
-    "version": "11.6.0",
+    "version": "12.22.0",
     "description": "Thousands of free mods and trainers for your favorite single-player PC games — all in one place",
     "license": {
         "identifier": "Freeware",
-        "url": "https://www.wemod.com/terms"
+        "url": "https://www.wand.com/terms"
     },
-    "homepage": "https://www.wemod.com",
+    "homepage": "https://www.wand.com",
     "architecture": {
         "64bit": {
-            "url": "https://storage-cdn.wemod.com/app/releases/stable/WeMod-11.6.0-full.nupkg",
-            "hash": "5b94ae5592e698b13cbc06fae4c096fe2438cbd362daac3f842e13190bf836ba",
+            "url": "https://storage-cdn.wemod.com/app/releases/stable/Wand-12.22.0-full.nupkg",
+            "hash": "247c64696bbaa7740464ff3081edad86258279748b53f7718eb272b12ce9e75e",
             "shortcuts": [
                 [
-                    "WeMod.exe",
-                    "WeMod"
+                    "Wand.exe",
+                    "Wand"
                 ]
             ]
         }
@@ -37,11 +37,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://storage-cdn.wemod.com/app/releases/stable/WeMod-$version-full.nupkg"
+                "url": "https://storage-cdn.wemod.com/app/releases/stable/Wand-$version-full.nupkg"
             }
         }
-    },
-    "notes": [
-        "WeMod is renamed to 'Wand', so this entry has no further updates. Please use the Wand app instead."
-    ]
+    }
 }


### PR DESCRIPTION
This commit adds the new rebrand of WeMod (Wand) to the repo, but keeps
the legacy WeMod app, as it still serves files, and we don't want to
cause a major breaking change for consumers of this repo at this current
moment.

The new app in this commit is adjusted for the new installer, with the
correct hashes.

Working towards: https://github.com/Calinou/scoop-games/issues/1716.
Fixes: https://github.com/Calinou/scoop-games/issues/1716.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
