### PR TITLE
correct urls for ryujinx-canary

### DIFF
--- a/bucket/ryujinx-canary.json
+++ b/bucket/ryujinx-canary.json
@@ -4,18 +4,18 @@
     "homepage": "https://ryujinx.app/",
     "license": {
         "identifier": "MIT",
-        "url": "https://git.ryujinx.app/ryubing/ryujinx/-/blob/master/LICENSE.txt"
+        "url": "https://git.ryujinx.app/ryubing/ryujinx/raw/branch/master/LICENSE.txt"
     },
     "notes": [
         "ATTENTION: Ryujinx requires Nintendo Switch firmware and a prod.keys file to function.",
-        "Learn more at https://git.ryujinx.app/ryubing/ryujinx/-/wikis/FAQ-&-Troubleshooting"
+        "Learn more at https://git.ryujinx.app/ryubing/ryujinx/wiki/FAQ-&-Troubleshooting"
     ],
     "suggest": {
         "Switch Army Knife (SAK)": "games/sak"
     },
     "architecture": {
         "64bit": {
-            "url": "https://git.ryujinx.app/api/v4/projects/68/packages/generic/Ryubing-Canary/1.3.266/ryujinx-canary-1.3.266-win_x64.zip",
+            "url": "https://git.ryujinx.app/ryubing/canary/releases/download/1.3.266/ryujinx-canary-1.3.266-win_x64.zip",
             "hash": "1194165b7e8cfa393ec26afbd8d43968e2970275a7939f6746bd2fc5983b92bf"
         }
     },
@@ -39,13 +39,13 @@
     ],
     "persist": "portable",
     "checkver": {
-        "url": "https://git.ryujinx.app/api/v4/projects/ryubing%2Fcanary/releases",
+        "url": "https://git.ryujinx.app/api/v1/repos/ryubing/canary/releases?limit=1",
         "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://git.ryujinx.app/api/v4/projects/68/packages/generic/Ryubing-Canary/$version/ryujinx-canary-$version-win_x64.zip"
+                "url": "https://git.ryujinx.app/ryubing/canary/releases/download/$version/ryujinx-canary-$version-win_x64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
fixes the urls for ryujinx-canary to point the correct places in their repo. i think they had some reorganising or smth idk.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


Relates to #1720

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
