### PR TITLE
new game: perfect-dark.json

### DIFF
--- a/bucket/perfect-dark.json
+++ b/bucket/perfect-dark.json
@@ -1,5 +1,5 @@
 {
-    "version": "latest",
+    "version": "20260523-45139a9",
     "description": "Decompiled and PC-modded build of Nintendo 64's Perfect Dark.",
     "homepage": "https://github.com/fgsfdsfgs/perfect_dark",
     "license": "MIT",
@@ -67,15 +67,19 @@
         "script": [
             "$url = 'https://github.com/fgsfdsfgs/perfect_dark/releases/tag/ci-dev-build'",
             "$commit_regex = '([a-f0-9]{7})[^>]*</a>\\s+This commit was'",
+            "$date_regex = 'released this[^<]*<relative-time[^>]*datetime=\"([^T]+)T'",
             "",
             "$cont = (Invoke-WebRequest $url -UseBasicParsing).Content",
             "",
             "if(!($cont -match $commit_regex)) { error \"Could not match commit regex on '$url'\"; break }",
             "$commit_sha = $matches[1]",
+            "if(!($cont -match $date_regex)) { error \"Could not match date regex on '$url'\"; break }",
+            "$date = $matches[1] -replace '-', ''",
             "",
-            "Write-Output $commit_sha"
+            "$script_ver = \"$date-$commit_sha\"",
+            "Write-Output $script_ver"
         ],
-        "regex": "([a-f0-9]{7})"
+        "regex": "(\\d{8}-[a-f0-9]{7})"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/perfect-dark.json
+++ b/bucket/perfect-dark.json
@@ -1,5 +1,5 @@
 {
-    "version": "20260523-45139a9",
+    "version": "20260522-132e59d",
     "description": "Decompiled and PC-modded build of Nintendo 64's Perfect Dark.",
     "homepage": "https://github.com/fgsfdsfgs/perfect_dark",
     "license": "MIT",
@@ -65,19 +65,13 @@
     "notes": "You must provide your own legally sourced Perfect Dark ROM file (.z64) to run this port. Refer to https://github.com/fgsfdsfgs/perfect_dark#running for instructions.",
     "checkver": {
         "script": [
-            "$url = 'https://github.com/fgsfdsfgs/perfect_dark/releases/tag/ci-dev-build'",
-            "$commit_regex = '([a-f0-9]{7})[^>]*</a>\\s+This commit was'",
-            "$date_regex = 'released this[^<]*<relative-time[^>]*datetime=\"([^T]+)T'",
-            "",
-            "$cont = (Invoke-WebRequest $url -UseBasicParsing).Content",
-            "",
-            "if(!($cont -match $commit_regex)) { error \"Could not match commit regex on '$url'\"; break }",
-            "$commit_sha = $matches[1]",
-            "if(!($cont -match $date_regex)) { error \"Could not match date regex on '$url'\"; break }",
-            "$date = $matches[1] -replace '-', ''",
-            "",
-            "$script_ver = \"$date-$commit_sha\"",
-            "Write-Output $script_ver"
+            "$api = 'https://api.github.com/repos/fgsfdsfgs/perfect_dark/releases/tags/ci-dev-build'",
+            "$data = (Invoke-WebRequest $api -UseBasicParsing | ConvertFrom-Json)",
+            "$commit = $data.target_commitish",
+            "$short = $commit.Substring(0, 7)",
+            "$date = ([datetime]$data.updated_at).ToString('yyyyMMdd')",
+            "$version = \"$date-$short\"",
+            "Write-Output $version"
         ],
         "regex": "(\\d{8}-[a-f0-9]{7})"
     },

--- a/bucket/perfect-dark.json
+++ b/bucket/perfect-dark.json
@@ -16,14 +16,17 @@
         }
     },
     "bin": [
-        "pd.x86_64.exe",
+        [
+            "pd.x86_64.exe",
+            "perfect-dark"
+        ],
         [
             "pd.pal.x86_64.exe",
-            "pd-pal"
+            "perfect-dark-pal"
         ],
         [
             "pd.jpn.x86_64.exe",
-            "pd-jpn"
+            "perfect-dark-jpn"
         ]
     ],
     "shortcuts": [

--- a/bucket/perfect-dark.json
+++ b/bucket/perfect-dark.json
@@ -81,29 +81,11 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/fgsfdsfgs/perfect_dark/releases/download/ci-dev-build/pd-x86_64-windows.zip",
-                "extract_dir": "pd-x86_64-windows",
-                "hash": {
-                    "script": [
-                        "$url = 'https://github.com/fgsfdsfgs/perfect_dark/releases/tag/ci-dev-build'",
-                        "$pattern = 'pd-x86_64-windows\\.zip.*?sha256:([a-f0-9]{64})'",
-                        "$cont = (Invoke-WebRequest $url -UseBasicParsing).Content -replace '\\s+', ' '",
-                        "if($cont -match $pattern) { Write-Output \"sha256:$($matches[1])\" }",
-                        "else { error 'Could not extract x86_64 hash' }"
-                    ]
-                }
+                "extract_dir": "pd-x86_64-windows"
             },
             "32bit": {
                 "url": "https://github.com/fgsfdsfgs/perfect_dark/releases/download/ci-dev-build/pd-i686-windows.zip",
-                "extract_dir": "pd-i686-windows",
-                "hash": {
-                    "script": [
-                        "$url = 'https://github.com/fgsfdsfgs/perfect_dark/releases/tag/ci-dev-build'",
-                        "$pattern = 'pd-i686-windows\\.zip.*?sha256:([a-f0-9]{64})'",
-                        "$cont = (Invoke-WebRequest $url -UseBasicParsing).Content -replace '\\s+', ' '",
-                        "if($cont -match $pattern) { Write-Output \"sha256:$($matches[1])\" }",
-                        "else { error 'Could not extract i686 hash' }"
-                    ]
-                }
+                "extract_dir": "pd-i686-windows"
             }
         }
     }

--- a/bucket/perfect-dark.json
+++ b/bucket/perfect-dark.json
@@ -1,6 +1,6 @@
 {
     "version": "20260522-132e59d",
-    "description": "Decompiled and PC-modded build of Nintendo 64's Perfect Dark.",
+    "description": "Decompiled and PC-modded build of Nintendo 64's Perfect Dark",
     "homepage": "https://github.com/fgsfdsfgs/perfect_dark",
     "license": "MIT",
     "architecture": {

--- a/bucket/perfect-dark.json
+++ b/bucket/perfect-dark.json
@@ -1,0 +1,110 @@
+{
+    "version": "latest",
+    "description": "Decompiled and PC-modded build of Nintendo 64's Perfect Dark.",
+    "homepage": "https://github.com/fgsfdsfgs/perfect_dark",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fgsfdsfgs/perfect_dark/releases/download/ci-dev-build/pd-x86_64-windows.zip",
+            "hash": "sha256:0162398691c9e1e90bda303d16b8ca8aa82afb58139b0a78a334ff7ac3884e01",
+            "extract_dir": "pd-x86_64-windows"
+        },
+        "32bit": {
+            "url": "https://github.com/fgsfdsfgs/perfect_dark/releases/download/ci-dev-build/pd-i686-windows.zip",
+            "hash": "sha256:365df7e4a14fd1f6c7d6fd40d960d71ced9657019231867458f9d5f6f7d492f3",
+            "extract_dir": "pd-i686-windows"
+        }
+    },
+    "bin": [
+        "pd.x86_64.exe",
+        [
+            "pd.pal.x86_64.exe",
+            "pd-pal"
+        ],
+        [
+            "pd.jpn.x86_64.exe",
+            "pd-jpn"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "pd.x86_64.exe",
+            "Perfect Dark"
+        ],
+        [
+            "pd.pal.x86_64.exe",
+            "Perfect Dark (PAL)"
+        ],
+        [
+            "pd.jpn.x86_64.exe",
+            "Perfect Dark (Japanese)"
+        ]
+    ],
+    "persist": [
+        "pd.ini",
+        "eeprom.bin",
+        "mpsetups.bin",
+        "data/pd.ntsc-final.z64"
+    ],
+    "installer": {
+        "script": [
+            "$FILES = @('pd.ini', 'eeprom.bin', 'mpsetups.bin')",
+            "foreach ($FILE in $FILES) {",
+            "  if (!(Test-Path \"$persist_dir\\$FILE\")) {",
+            "    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
+            "  }",
+            "}",
+            "if (!(Test-Path \"$dir\\data\")) {",
+            "  New-Item \"$dir\\data\" -Type Directory | Out-Null",
+            "}",
+            "if (!(Test-Path \"$persist_dir\\data\\pd.ntsc-final.z64\")) {",
+            "  New-Item \"$dir\\data\\pd.ntsc-final.z64\" -Type File | Out-Null",
+            "}"
+        ]
+    },
+    "notes": "You must provide your own legally sourced Perfect Dark ROM file (.z64) to run this port. Refer to https://github.com/fgsfdsfgs/perfect_dark#running for instructions.",
+    "checkver": {
+        "script": [
+            "$url = 'https://github.com/fgsfdsfgs/perfect_dark/releases/tag/ci-dev-build'",
+            "$commit_regex = '([a-f0-9]{7})[^>]*</a>\\s+This commit was'",
+            "",
+            "$cont = (Invoke-WebRequest $url -UseBasicParsing).Content",
+            "",
+            "if(!($cont -match $commit_regex)) { error \"Could not match commit regex on '$url'\"; break }",
+            "$commit_sha = $matches[1]",
+            "",
+            "Write-Output $commit_sha"
+        ],
+        "regex": "([a-f0-9]{7})"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fgsfdsfgs/perfect_dark/releases/download/ci-dev-build/pd-x86_64-windows.zip",
+                "extract_dir": "pd-x86_64-windows",
+                "hash": {
+                    "script": [
+                        "$url = 'https://github.com/fgsfdsfgs/perfect_dark/releases/tag/ci-dev-build'",
+                        "$pattern = 'pd-x86_64-windows\\.zip.*?sha256:([a-f0-9]{64})'",
+                        "$cont = (Invoke-WebRequest $url -UseBasicParsing).Content -replace '\\s+', ' '",
+                        "if($cont -match $pattern) { Write-Output \"sha256:$($matches[1])\" }",
+                        "else { error 'Could not extract x86_64 hash' }"
+                    ]
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/fgsfdsfgs/perfect_dark/releases/download/ci-dev-build/pd-i686-windows.zip",
+                "extract_dir": "pd-i686-windows",
+                "hash": {
+                    "script": [
+                        "$url = 'https://github.com/fgsfdsfgs/perfect_dark/releases/tag/ci-dev-build'",
+                        "$pattern = 'pd-i686-windows\\.zip.*?sha256:([a-f0-9]{64})'",
+                        "$cont = (Invoke-WebRequest $url -UseBasicParsing).Content -replace '\\s+', ' '",
+                        "if($cont -match $pattern) { Write-Output \"sha256:$($matches[1])\" }",
+                        "else { error 'Could not extract i686 hash' }"
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Perfect Dark pc port: https://github.com/fgsfdsfgs/perfect_dark

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1734

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).

Disclaimer: generated and iterated upon by claude, tested manually locally (`scoop install pd.json`), with inspiration for the persisted file handling from melonds.json which I wrote by hand some time ago.

It works fine, the install is clean, the right files persist, and the game does not seem to have an issue with the blank files created. Only thing I'm not sure of is the github update mechanism since time needs to pass to test that, but I'm sure a reviewer can eyeball if it's correct. The source repo just has a [single release](https://github.com/fgsfdsfgs/perfect_dark/releases/tag/ci-dev-build) that gets updated with the latest dev build assets.

```
scoop install "C:\Users\Marnes\Downloads\perfect-dark.json"
Installing 'perfect-dark' (latest) [64bit] from 'C:\Users\Marnes\Downloads\perfect-dark.json'
Loading pd-x86_64-windows.zip from cache
Checking hash of pd-x86_64-windows.zip ... ok.
Extracting pd-x86_64-windows.zip ... done.
Running installer script...done.
Linking ~\scoop\apps\perfect-dark\current => ~\scoop\apps\perfect-dark\latest
Creating shim for 'pd.x86_64'.
Making C:\Users\Marnes\scoop\shims\pd.x86_64.exe a GUI binary.
Creating shim for 'pd-pal'.
Making C:\Users\Marnes\scoop\shims\pd-pal.exe a GUI binary.
Creating shim for 'pd-jpn'.
Making C:\Users\Marnes\scoop\shims\pd-jpn.exe a GUI binary.
Creating shortcut for Perfect Dark (pd.x86_64.exe)
Creating shortcut for Perfect Dark (PAL) (pd.pal.x86_64.exe)
Creating shortcut for Perfect Dark (Japanese) (pd.jpn.x86_64.exe)
Persisting pd.ini
Persisting eeprom.bin
Persisting mpsetups.bin
Persisting data/pd.ntsc-final.z64
'perfect-dark' (latest) was installed successfully!
Notes
-----
You must provide your own legally sourced Perfect Dark ROM file (.z64) to run this port. Refer to https://github.com/fgsfdsfgs/perfect_dark#running for instructions.
```

Maintainer permission for a manifest ✅ https://github.com/fgsfdsfgs/perfect_dark/issues/726