### PR TITLE
cs-demo-manager: Fix `pre_install`

### DIFF
--- a/bucket/cs-demo-manager.json
+++ b/bucket/cs-demo-manager.json
@@ -11,7 +11,7 @@
     },
     "extract_dir": "$PLUGINSDIR",
     "pre_install": [
-        "Remove-Item *.dll",
+        "Remove-Item $dir\\*.dll",
         "Expand-7zipArchive -Path $dir\\app-64.7z -DestinationPath $dir -Removal"
     ],
     "installer": {


### PR DESCRIPTION

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).

The `Remove-Item *.dll` command in `pre_install` was missing the `$dir\` prefix, causing it to target the current working directory instead of the application's install directory. This could lead to unintended file deletions and the command silently failing.