### PR TITLE
(chore): Use default SCOOP_BRANCH in workflows

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -22,4 +22,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKIP_UPDATED: "1"
-          SCOOP_BRANCH: "develop"

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -21,4 +21,3 @@ jobs:
         if: startsWith(github.event.comment.body, '/verify')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCOOP_BRANCH: "develop"

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -26,4 +26,3 @@ jobs:
           contains(github.event.issue.labels.*.name, 'verify'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCOOP_BRANCH: "develop"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,4 +20,3 @@ jobs:
         uses: ScoopInstaller/GithubActions@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCOOP_BRANCH: "develop"


### PR DESCRIPTION
This PR makes the following changes:
- Revert the `SCOOP_BRANCH` change to shield this bucket from any breaking changes on the develop branch.

Relates to https://github.com/Calinou/scoop-games/pull/1724.

<!-- or -->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
