### PR TITLE
eden(-nightly): Switch to PGO builds, add nightly builds

### DIFF
--- a/bucket/eden-nightly.json
+++ b/bucket/eden-nightly.json
@@ -1,0 +1,65 @@
+{
+    "version": "1780254271.bd2d344040",
+    "description": "Open source Nintendo Switch emulator (forked from yuzu — nightly build)",
+    "homepage": "https://eden-emu.dev/",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://git.eden-emu.dev/eden-emu/eden/raw/branch/master/LICENSE.txt"
+    },
+    "notes": [
+        "ATTENTION: Eden requires Nintendo Switch firmware and decryption keys to function.",
+        "Learn more at https://git.eden-emu.dev/eden-emu/eden/src/branch/master/docs/user/QuickStart.md#steps"
+    ],
+    "suggest": {
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://nightly.eden-emu.dev/v1780254271.bd2d344040/Eden-Windows-bd2d344040-amd64-clang-pgo.zip",
+            "hash": "9b95e2ca704ea85914e65367b12292df2a9db9a8e39904dfaecd19f0b8b36ddf"
+        },
+        "arm64": {
+            "url": "https://nightly.eden-emu.dev/v1780254271.bd2d344040/Eden-Windows-bd2d344040-arm64-clang-pgo.zip",
+            "hash": "ddedbf302b82c302d944e04310b941aac3c905e071666c1dd23ad993488e2971"
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\")) {",
+        "   New-item \"$persist_dir\" -ItemType Directory | Out-Null",
+        "   New-item \"$persist_dir\\user\" -ItemType Directory | Out-Null",
+        "   if (Test-Path \"$env:APPDATA\\eden\") {",
+        "       Write-host \"Migrating AppData...\" -ForegroundColor yellow",
+        "       Copy-Item -Path \"$env:APPDATA\\eden\\*\" -Destination \"$persist_dir\\user\" -Recurse",
+        "       Remove-Item -Path \"$env:APPDATA\\eden\" -Recurse",
+        "   }",
+        "}"
+    ],
+    "bin": [
+        [
+            "eden.exe",
+            "eden-nightly"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "eden.exe",
+            "Eden (nightly)"
+        ]
+    ],
+    "persist": "user",
+    "checkver": {
+        "url": "https://git.eden-emu.dev/api/v1/repos/eden-ci/nightly/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "v([\\d]+\\.(?<commit>[a-f\\d]+))"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://nightly.eden-emu.dev/v$version/Eden-Windows-$matchCommit-amd64-clang-pgo.zip"
+            },
+            "arm64": {
+                "url": "https://nightly.eden-emu.dev/v$version/Eden-Windows-$matchCommit-arm64-clang-pgo.zip"
+            }
+        }
+    }
+}

--- a/bucket/eden.json
+++ b/bucket/eden.json
@@ -6,14 +6,21 @@
         "identifier": "GPL-3.0-or-later",
         "url": "https://git.eden-emu.dev/eden-emu/eden/raw/branch/master/LICENSE.txt"
     },
+    "notes": [
+        "ATTENTION: Eden requires Nintendo Switch firmware and decryption keys to function.",
+        "Learn more at https://git.eden-emu.dev/eden-emu/eden/src/branch/master/docs/user/QuickStart.md#steps"
+    ],
+    "suggest": {
+        "Microsoft Visual C++ Runtime 2022": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://stable.eden-emu.dev/v0.2.1/Eden-Windows-v0.2.1-amd64-msvc-standard.zip",
-            "hash": "ff498e5da9630216926ac3cbe9fb493b14930665c728a40a8f5b59507fdd7ebf"
+            "url": "https://stable.eden-emu.dev/v0.2.1/Eden-Windows-v0.2.1-amd64-clang-pgo.zip",
+            "hash": "6c1b53ce325170a026cc0f87098380027dc6170d94ba95f913aab7596fd097cb"
         },
         "arm64": {
-            "url": "https://stable.eden-emu.dev/v0.2.1/Eden-Windows-v0.2.1-arm64-clang-standard.zip",
-            "hash": "7df16b64bb0a0225acddcb498e524aa7854c24708022ecbea599cc1aebf010dc"
+            "url": "https://stable.eden-emu.dev/v0.2.1/Eden-Windows-v0.2.1-arm64-clang-pgo.zip",
+            "hash": "ed03e04606d06d8efa63f239775e19a3b5539227c042f133c3170234c9fd277a"
         }
     },
     "pre_install": [
@@ -43,10 +50,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://stable.eden-emu.dev/v$version/Eden-Windows-v$version-amd64-msvc-standard.zip"
+                "url": "https://stable.eden-emu.dev/v$version/Eden-Windows-v$version-amd64-clang-pgo.zip"
             },
             "arm64": {
-                "url": "https://stable.eden-emu.dev/v$version/Eden-Windows-v$version-arm64-clang-standard.zip"
+                "url": "https://stable.eden-emu.dev/v$version/Eden-Windows-v$version-arm64-clang-pgo.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR does the following: 
 - `eden`:
 	- Add `notes` property informing user of required files for core functionality.
 	- Add `suggest` property informing user of [VCRedist dependency](https://git.eden-emu.dev/eden-emu/eden/src/branch/master/docs/user/QuickStart.md#pre-requisites)
 	- PGO builds have graduated to being "[recommended](https://git.eden-emu.dev/eden-emu/eden/releases#:~:text=httplib%20version%20restrictions-,Packages,-Targets)", as such, download urls have been updated to point at those builds
 - `eden-nightly`:
   - Creates `eden-nightly.json` based on the stable release manifest but modified to grab latest nightly build pgo builds

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
