### PR TITLE
ryujinx(-canary): Drop suggest, modify autoupdate & shortcut/bin

### DIFF
--- a/bucket/ryujinx-canary.json
+++ b/bucket/ryujinx-canary.json
@@ -14,6 +14,10 @@
         "64bit": {
             "url": "https://git.ryujinx.app/ryubing/canary/releases/download/1.3.308/ryujinx-canary-1.3.308-win_x64.zip",
             "hash": "aedbc0cff468c69d9d27251c5dc8d146111700dcaa1196b96cc91c83cb70f83c"
+        },
+        "arm64": {
+            "url": "https://git.ryujinx.app/ryubing/canary/releases/download/1.3.308/ryujinx-canary-1.3.308-win_arm64.zip",
+            "hash": "90e456b59f12f40da6f3a8c3456699fea8778d2e1cc23f53df2530527ab801ac"
         }
     },
     "extract_dir": "publish",
@@ -46,6 +50,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://git.ryujinx.app/ryubing/canary/releases/download/$version/ryujinx-canary-$version-win_x64.zip"
+            },
+            "arm64": {
+                "url": "https://git.ryujinx.app/ryubing/canary/releases/download/$version/ryujinx-canary-$version-win_arm64.zip"
             }
         }
     }

--- a/bucket/ryujinx-canary.json
+++ b/bucket/ryujinx-canary.json
@@ -1,6 +1,6 @@
 {
     "version": "1.3.308",
-    "description": "A simple, experimental Nintendo Switch emulator",
+    "description": "A simple, experimental Nintendo Switch emulator (canary version)",
     "homepage": "https://ryujinx.app/",
     "license": {
         "identifier": "MIT",
@@ -10,9 +10,6 @@
         "ATTENTION: Ryujinx requires Nintendo Switch firmware and a prod.keys file to function.",
         "Learn more at https://git.ryujinx.app/ryubing/ryujinx/wiki/FAQ-&-Troubleshooting"
     ],
-    "suggest": {
-        "Switch Army Knife (SAK)": "games/sak"
-    },
     "architecture": {
         "64bit": {
             "url": "https://git.ryujinx.app/ryubing/canary/releases/download/1.3.308/ryujinx-canary-1.3.308-win_x64.zip",
@@ -30,17 +27,20 @@
         "   }",
         "}"
     ],
-    "bin": "Ryujinx.exe",
+    "bin": [
+        "Ryujinx.exe",
+        "ryujinx-canary"
+    ],
     "shortcuts": [
         [
             "Ryujinx.exe",
-            "Ryujinx"
+            "Ryujinx (canary)"
         ]
     ],
     "persist": "portable",
     "checkver": {
-        "url": "https://git.ryujinx.app/api/v1/repos/ryubing/canary/releases?limit=1",
-        "jsonpath": "$[0].tag_name"
+        "url": "https://git.ryujinx.app/api/v1/repos/ryubing/canary/releases/latest",
+        "jsonpath": "$.tag_name"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/ryujinx.json
+++ b/bucket/ryujinx.json
@@ -10,9 +10,6 @@
         "ATTENTION: Ryujinx requires Nintendo Switch firmware and a prod.keys file to function.",
         "Learn more at https://git.ryujinx.app/ryubing/ryujinx/wiki/FAQ-&-Troubleshooting"
     ],
-    "suggest": {
-        "Switch Army Knife (SAK)": "games/sak"
-    },
     "architecture": {
         "64bit": {
             "url": "https://git.ryujinx.app/ryubing/ryujinx/releases/download/1.3.3/ryujinx-1.3.3-win_x64.zip",
@@ -39,8 +36,8 @@
     ],
     "persist": "portable",
     "checkver": {
-        "url": "https://git.ryujinx.app/api/v1/repos/ryubing/ryujinx/releases?limit=1",
-        "jsonpath": "$[0].tag_name"
+        "url": "https://git.ryujinx.app/api/v1/repos/ryubing/ryujinx/releases/latest",
+        "jsonpath": "$.tag_name"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR does the following:
 - `ryujinx`:
   - Drop `suggest` property as the suggested item isn't relevant to Ryujinx specifically. It's a more generic tool usable with any Switch emulator and isn't a needed dependency. Additionally, the repo is no longer maintained & has been archived.
   - Updated `autoupdate` url to point at the 'latest' endpoint for the reason of more "correctness".
 - `ryujinx-canary`
   - Same two changes as above.
   - Added available arm64 build.
   - Modified description to specify this is a separate canary version (as can be seen with other emulators in the bucket).
   - Updated shortcuts/bin to again specify the version so one can install both stable and canary releases at the same time.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
