### PR TITLE
xenia-canary, xenia-edge: Fix autoupdate, update persists

### DIFF
--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "20260213170340-9369464",
+    "version": "20260602185755-be6e53e",
     "description": "Xbox 360 Emulator Research Project (development version)",
     "homepage": "https://github.com/xenia-canary/xenia-canary",
     "license": {
@@ -11,8 +11,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/9369464/xenia_canary_windows.zip",
-            "hash": "69cded77b325ce73b0eea26c7ae517e48db72a4c27675e3bf3b59c96648f5056"
+            "url": "https://github.com/xenia-canary/xenia-canary/releases/download/be6e53e/xenia_canary_windows.zip",
+            "hash": "707ad9b6cc053f3797cc1b3087163f28852d7361b586dce40bc45317383f13d0"
         }
     },
     "pre_install": [
@@ -22,10 +22,12 @@
         "       Write-Host \"Migrating AppData...\" -ForegroundColor yellow",
         "       Copy-Item -Path \"$env:USERPROFILE\\Documents\\Xenia\\*\" -Destination \"$persist_dir\" -Recurse",
         "       New-Item \"$dir\\recent.toml\" -ItemType File | Out-Null",
+        "       New-Item \"$dir\\xconfig.settings\" -ItemType File | Out-Null",
         "       Rename-Item \"$persist_dir\\xenia.config.toml\" -NewName \"xenia-canary.config.toml\"",
         "       Remove-Item -Path \"$env:USERPROFILE\\Documents\\Xenia\" -Recurse",
         "   } else {",
         "       New-Item \"$dir\\recent.toml\" -ItemType File | Out-Null",
+        "       New-Item \"$dir\\xconfig.settings\" -ItemType File | Out-Null",
         "       New-Item \"$dir\\xenia-canary.config.toml\" -ItemType File | Out-Null",
         "   }",
         "}"
@@ -44,10 +46,11 @@
         "patches",
         "screenshots",
         "recent.toml",
+        "xconfig.settings",
         "xenia-canary.config.toml"
     ],
     "checkver": {
-        "url": "https://github.com/xenia-canary/xenia-canary-releases/releases.atom",
+        "url": "https://github.com/xenia-canary/xenia-canary/releases.atom",
         "script": [
             "$xml = [xml]$page",
             "$updated = ($xml.feed.entry | Where-Object {$_.title -ne 'canary_experimental'} | Sort-Object -Descending { $_.updated })[0].updated",
@@ -60,7 +63,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/xenia-canary/xenia-canary-releases/releases/download/$matchCommit/xenia_canary_windows.zip"
+                "url": "https://github.com/xenia-canary/xenia-canary/releases/download/$matchCommit/xenia_canary_windows.zip"
             }
         }
     }

--- a/bucket/xenia-edge.json
+++ b/bucket/xenia-edge.json
@@ -23,7 +23,6 @@
         "       Copy-Item -Path \"$env:USERPROFILE\\Documents\\Xenia\\*\" -Destination \"$persist_dir\" -Recurse",
         "       Remove-Item -Path \"$env:USERPROFILE\\Documents\\Xenia\" -Recurse",
         "   } else {",
-        "       New-Item \"$dir\\recent.toml\" -ItemType File | Out-Null",
         "       New-Item \"$dir\\xenia-edge.config.toml\" -ItemType File | Out-Null",
         "   }",
         "}"
@@ -41,9 +40,9 @@
         "cache_host",
         "config",
         "content",
+        "library",
         "patches",
         "screenshots",
-        "recent.toml",
         "xenia-edge.config.toml"
     ],
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR makes the following changes:
 - `xenia-canary`
   - Modified checkver & autoupdate to account for new release location
   - Manually updated to version 'v20260602185755-be6e53e'
   - Updated persists with new file
 - `xenia-edge`
   - Updated persists with current file/folder structure

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
