### PR TITLE
mesen@2.2.1: Update to MesenCE

### DIFF
--- a/bucket/mesen.json
+++ b/bucket/mesen.json
@@ -1,13 +1,13 @@
 {
-    "version": "2.1.1",
-    "description": "Multi-system emulator (NES, SNES, GB, GBA, PCE, SMS/GG, WS) for Windows, Linux and macOS",
+    "version": "2.2.1",
+    "description": "Multi-system emulator (NES, SNES, GB, GBA, PCE, SMS/GG, WS) for Windows, Linux and macOS (MesenCE)",
     "homepage": "https://www.mesen.ca",
     "license": {
         "identifier": "GPL-3.0",
-        "url": "https://github.com/SourMesen/Mesen2/blob/master/LICENSE"
+        "url": "https://github.com/nesdev-org/MesenCE/blob/master/LICENSE"
     },
-    "url": "https://github.com/SourMesen/Mesen2/releases/download/2.1.1/Mesen_2.1.1_Windows.zip",
-    "hash": "23ccc2bc060b663c68dad3a8c5d6da7d23a50f872d04f135bafa2b04ff7d5cbe",
+    "url": "https://github.com/nesdev-org/MesenCE/releases/download/2.2.1/Mesen_2.2.1_Windows.zip",
+    "hash": "c19e10b3b3865eb0e86e4d01bf09a5027a4452081c04b5bd5b6cbbf76e346fd6",
     "pre_install": "if (!(Test-Path \"$persist_dir\\settings.json\")) { New-Item -ItemType File \"$dir\\settings.json\" | Out-Null }",
     "bin": "Mesen.exe",
     "shortcuts": [
@@ -28,12 +28,16 @@
         "SaveStates",
         "Cheats",
         "GameConfig",
-        "Firmware"
+        "Firmware",
+        "Debugger",
+        "Backups",
+        "Tests",
+        "Dumps"
     ],
     "checkver": {
-        "github": "https://github.com/SourMesen/Mesen2"
+        "github": "https://github.com/nesdev-org/MesenCE"
     },
     "autoupdate": {
-        "url": "https://github.com/SourMesen/Mesen2/releases/download/$version/Mesen_$version_Windows.zip"
+        "url": "https://github.com/nesdev-org/MesenCE/releases/download/$version/Mesen_$version_Windows.zip"
     }
 }


### PR DESCRIPTION
Update manifest to point to [MesenCE](https://github.com/nesdev-org/MesenCE) repo.

Adds "MesenCE" as a keyword in description, and includes additional data locations in persist directory.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1752

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
