### PR TITLE
osulazer: Fix autoupdate and update to 2026.518.0-lazer

### DIFF
--- a/bucket/osulazer.json
+++ b/bucket/osulazer.json
@@ -20,10 +20,6 @@
         "regex": "([\\d.]+-lazer)"
     },
     "autoupdate": {
-        "url": "https://github.com/ppy/osu/releases/download/$version/osulazer-$version-full.nupkg#/dl.7z",
-        "hash": {
-            "url": "https://github.com/ppy/osu/releases/expanded_assets/$version",
-            "regex": "$basename</a>.*?sha256:$sha256"
-        }
+        "url": "https://github.com/ppy/osu/releases/download/$version/osulazer-$version-full.nupkg#/dl.7z"
     }
 }

--- a/bucket/osulazer.json
+++ b/bucket/osulazer.json
@@ -1,10 +1,10 @@
 {
-    "version": "2026.429.0-lazer",
+    "version": "2026.518.0-lazer",
     "description": "A free-to-win rhythm game. Rhythm is just a click away!",
     "homepage": "https://osu.ppy.sh/",
     "license": "MIT",
-    "url": "https://github.com/ppy/osu/releases/download/2026.429.0-lazer/osulazer-2026.429.0-lazer-full.nupkg#/dl.7z",
-    "hash": "0b5020b1a58f7d77e2ce6d72d313664d30d2cb5ec4897bbcece58e6bebef9450",
+    "url": "https://github.com/ppy/osu/releases/download/2026.518.0-lazer/osulazer-2026.518.0-lazer-full.nupkg#/dl.7z",
+    "hash": "2c76259f215e2bea21a1ffa085dfb5538ac3497056a859f5db99e4da8943a4d6",
     "extract_dir": "lib\\app",
     "pre_install": "Rename-Item -Path $dir/osu!.exe -NewName $dir/osulazer.exe",
     "bin": "osulazer.exe",
@@ -15,10 +15,15 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/ppy/osu",
-        "regex": "/releases/tag/(?:v|V)?([\\w-.]+)"
+        "url": "https://api.github.com/repos/ppy/osu/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "([\\d.]+-lazer)"
     },
     "autoupdate": {
-        "url": "https://github.com/ppy/osu/releases/download/$version/osulazer-$version-full.nupkg#/dl.7z"
+        "url": "https://github.com/ppy/osu/releases/download/$version/osulazer-$version-full.nupkg#/dl.7z",
+        "hash": {
+            "url": "https://github.com/ppy/osu/releases/expanded_assets/$version",
+            "regex": "$basename</a>.*?sha256:$sha256"
+        }
     }
 }


### PR DESCRIPTION
## Fix osulazer autoupdate and bump to 2026.518.0-lazer

Closes #1757 

osulazer's been stuck on `2026.429.0-lazer` since April. Turns out the `checkver` regex was looking for the `/releases/tag/...` pattern from the HTML release page, but it's running against the GitHub JSON API, which doesn't have that string — so it matched nothing and the manifest never moved. The Excavator job log reads:

```
osulazer: couldn't match '/releases/tag/(?:v|V)?([\w-.]+)' in https://api.github.com/repos/ppy/osu/releases/latest
```

Switched checkver to read `tag_name` via `jsonpath: $.tag_name`, constrained to `-lazer` so tachyon pre-releases are ignored. Also bumped `version`, `url`, and `hash` to `2026.518.0-lazer`.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
