### PR TITLE
dolphin: Update to 2606; dolphin-dev: Update to 2606-13

### DIFF
--- a/bucket/dolphin-dev.json
+++ b/bucket/dolphin-dev.json
@@ -1,5 +1,5 @@
 {
-    "version": "2606-13",
+    "version": "2606-97",
     "description": "A Nintendo GameCube and Wii emulator, with enhancements and Netplay. (development version)",
     "homepage": "https://dolphin-emu.org/",
     "license": {
@@ -11,13 +11,13 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.dolphin-emu.org/builds/7f/b1/dolphin-master-2606-13-x64.7z",
-            "hash": "68a732aa6afbf29369730c6e29d48fd244be1afaa0f5aea21f0433ee43c5ff31",
+            "url": "https://dl.dolphin-emu.org/builds/56/dc/dolphin-master-2606-97-x64.7z",
+            "hash": "b8eca761cea04537081c0d576d83ca07d375fa96eabc6380518a203915c47460",
             "extract_dir": "Dolphin-x64"
         },
         "arm64": {
-            "url": "https://dl.dolphin-emu.org/builds/f3/42/dolphin-master-2606-13-ARM64.7z",
-            "hash": "eeb8d1f2b9c63c70f0979508bdb3d4b752881a4d3de6239796e8b9829c300942",
+            "url": "https://dl.dolphin-emu.org/builds/a7/6e/dolphin-master-2606-97-ARM64.7z",
+            "hash": "8d67056e0d8951055829573093545cf8803257e07a4394d163aa48acca070e5d",
             "extract_dir": "Dolphin-ARM64"
         }
     },
@@ -49,15 +49,15 @@
     "persist": "User",
     "checkver": {
         "url": "https://dolphin-emu.org/update/latest/dev",
-        "regex": "(?=.*\"shortrev\":\\s*\"(?<version>[\\w-]+)\")(?=.*\"(?<x64>https://[^\"]+-x64\\.7z)\")(?=.*\"(?<arm64>https://[^\"]+-ARM64\\.7z)\")"
+        "regex": "(?=.*\"shortrev\":\\s*\"(?<version>[\\w-]+)\")(?=.*\"https://(?<x64>[^\"]+-x64\\.7z)\")(?=.*\"https://(?<arm64>[^\"]+-ARM64\\.7z)\")"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "$matchX64"
+                "url": "https://$matchX64"
             },
             "arm64": {
-                "url": "$matchArm64"
+                "url": "https://$matchArm64"
             }
         }
     }

--- a/bucket/dolphin-dev.json
+++ b/bucket/dolphin-dev.json
@@ -1,5 +1,5 @@
 {
-    "version": "2603-379",
+    "version": "2606-13",
     "description": "A Nintendo GameCube and Wii emulator, with enhancements and Netplay. (development version)",
     "homepage": "https://dolphin-emu.org/",
     "license": {
@@ -11,13 +11,13 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.dolphin-emu.org/builds/46/7d/dolphin-master-2603-379-x64.7z",
-            "hash": "7bef59e6e023932c7122c51f421f470dee41f1a35021d2498339894234c63164",
+            "url": "https://dl.dolphin-emu.org/builds/7f/b1/dolphin-master-2606-13-x64.7z",
+            "hash": "68a732aa6afbf29369730c6e29d48fd244be1afaa0f5aea21f0433ee43c5ff31",
             "extract_dir": "Dolphin-x64"
         },
         "arm64": {
-            "url": "https://dl.dolphin-emu.org/builds/30/b1/dolphin-master-2603-379-ARM64.7z",
-            "hash": "59a0433e43623c80decff020f68fb14cd9eb82489516071ff4e7f301ad00d4aa",
+            "url": "https://dl.dolphin-emu.org/builds/f3/42/dolphin-master-2606-13-ARM64.7z",
+            "hash": "eeb8d1f2b9c63c70f0979508bdb3d4b752881a4d3de6239796e8b9829c300942",
             "extract_dir": "Dolphin-ARM64"
         }
     },
@@ -48,16 +48,16 @@
     ],
     "persist": "User",
     "checkver": {
-        "url": "https://dolphin-emu.org/download/",
-        "regex": "(?<prefix1>.{5})/dolphin-master-(?<version>[\\w-]+)-x64[\\s\\S]+?(?<prefix2>.{5})/dolphin-master-\\k<version>-ARM64"
+        "url": "https://dolphin-emu.org/update/latest/dev",
+        "regex": "(?=.*\"shortrev\":\\s*\"(?<version>[\\w-]+)\")(?=.*\"(?<x64>https://[^\"]+-x64\\.7z)\")(?=.*\"(?<arm64>https://[^\"]+-ARM64\\.7z)\")"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.dolphin-emu.org/builds/$matchPrefix1/dolphin-master-$version-x64.7z"
+                "url": "$matchX64"
             },
             "arm64": {
-                "url": "https://dl.dolphin-emu.org/builds/$matchPrefix2/dolphin-master-$version-ARM64.7z"
+                "url": "$matchArm64"
             }
         }
     }

--- a/bucket/dolphin.json
+++ b/bucket/dolphin.json
@@ -1,5 +1,5 @@
 {
-    "version": "2603a",
+    "version": "2606",
     "description": "Nintendo GameCube and Wii emulator, with enhancements and Netplay",
     "homepage": "https://dolphin-emu.org/",
     "license": {
@@ -11,13 +11,13 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.dolphin-emu.org/releases/2603a/dolphin-2603a-x64.7z",
-            "hash": "4cc6d975fe9646ed7326271ec9a2d84b93301de7cdb525c6b20ed97c0a715bf1",
+            "url": "https://dl.dolphin-emu.org/releases/2606/dolphin-2606-x64.7z",
+            "hash": "c6ea821c820cdc5d52d9f4d315fdca629d51a1b9f4f7e671948b905c085d7f59",
             "extract_dir": "Dolphin-x64"
         },
         "arm64": {
-            "url": "https://dl.dolphin-emu.org/releases/2603a/dolphin-2603a-ARM64.7z",
-            "hash": "d004c00fae9067183d91e2eb3ad2a789a6389f2cc02e21fc35358ae924fbde5a",
+            "url": "https://dl.dolphin-emu.org/releases/2606/dolphin-2606-ARM64.7z",
+            "hash": "ab5df5a8bc88e820714afbd7f78de6a36ed23a98c141b1e41ca12d7a08c5201e",
             "extract_dir": "Dolphin-ARM64"
         }
     },
@@ -42,8 +42,8 @@
     ],
     "persist": "User",
     "checkver": {
-        "url": "https://dolphin-emu.org/download/",
-        "regex": "https://dl.dolphin-emu.org/releases/(?<version>\\d+[\\w-]*)/"
+        "url": "https://dolphin-emu.org/update/latest/beta",
+        "jsonpath": "$.shortrev"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Dolphin homepage now blocks bot scraping and per [their blog post](https://dolphin-emu.org/blog/2026/06/25/dolphin-progress-report-release-2606/#a-note-to-the-nicer-kind-of-scrapers) have requested the use of this alternative version checking endpoint. Apologies for this ugly regex.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
