### PR TITLE
asset-ripper: Add bin shim

### DIFF
--- a/bucket/asset-ripper.json
+++ b/bucket/asset-ripper.json
@@ -22,6 +22,7 @@
             "AssetRipper"
         ]
     ],
+    "bin": "AssetRipper.GUI.Free.exe",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\AssetRipper.Settings.json\")) {",
         "    $config = @{'Import' = @{}; 'Processing' = @{}; 'Export' = @{}}",


### PR DESCRIPTION
Despite the name of the binary, it's actually a CLI bin, it logs to stdout, and launches a browser on the port it hosts it's http webserver on.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
