### PR TITLE
millennium-installer: Add version 1.12.1

### DIFF
--- a/bucket/millennium-installer.json
+++ b/bucket/millennium-installer.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.12.1",
+    "description": "A simple standalone program which automates the installation, removal and maintenance of Millennium.",
+    "homepage": "https://steambrew.app",
+    "license": "MIT",
+    "suggest": {
+        "steam": "games/steam"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/SteamClientHomebrew/Installer/releases/download/v1.12.1/MillenniumInstaller-Windows.exe",
+            "hash": "1a3baf49f20c321bdcc9421f5b7aab8c1e8a33792c93086463d148b502c1be3d"
+        }
+    },
+    "shortcuts": [
+        [
+            "MillenniumInstaller-Windows.exe",
+            "Millennium Installer"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/SteamClientHomebrew/Installer"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/SteamClientHomebrew/Installer/releases/download/v$version/MillenniumInstaller-Windows.exe"
+            }
+        }
+    }
+}

--- a/bucket/millennium-installer.json
+++ b/bucket/millennium-installer.json
@@ -1,6 +1,6 @@
 {
     "version": "1.12.1",
-    "description": "A simple standalone program which automates the installation, removal and maintenance of Millennium.",
+    "description": "Simple standalone program which automates the installation, removal and maintenance of Millennium",
     "homepage": "https://steambrew.app",
     "license": "MIT",
     "suggest": {

--- a/bucket/steam.json
+++ b/bucket/steam.json
@@ -22,6 +22,9 @@
     "persist": [
         "skins",
         "steamapps",
-        "userdata"
+        "userdata",
+        "millennium\\config",
+        "millennium\\plugins",
+        "millennium\\themes"
     ]
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
# Summary
Adds a manifest for the install manager of Millennium, a popular mod framework for the Steam client (basically, Vencord but for steam).
The app is sufficiently popular. 4,000 stars on their [github](https://github.com/SteamClientHomebrew/Millennium) page.

I have a inquiry about what should be done with this app, however.
Millennium stores all of its config files in %STEAM_DIR%/millennium, and ideally we want this to be persisted.
I believe the existing steam manifest could be modified to persist these and it wouldn't cause issues for non-millennium users, but is that okay with you?

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
 -->
 
- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
