### PR TITLE
dolphin-dev: Update to version 2606-134, fix checkver

### DIFF
--- a/bucket/dolphin-dev.json
+++ b/bucket/dolphin-dev.json
@@ -1,5 +1,5 @@
 {
-    "version": "2603-379",
+    "version": "2606-134",
     "description": "A Nintendo GameCube and Wii emulator, with enhancements and Netplay. (development version)",
     "homepage": "https://dolphin-emu.org/",
     "license": {
@@ -11,13 +11,13 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.dolphin-emu.org/builds/46/7d/dolphin-master-2603-379-x64.7z",
-            "hash": "7bef59e6e023932c7122c51f421f470dee41f1a35021d2498339894234c63164",
+            "url": "https://dl.dolphin-emu.org/builds/16/fb/dolphin-master-2606-134-x64.7z",
+            "hash": "fb1eb8ddaf10d7ef5ce0a189a702d21a6eec1d8ba2f36237d74080460c5022ba",
             "extract_dir": "Dolphin-x64"
         },
         "arm64": {
-            "url": "https://dl.dolphin-emu.org/builds/30/b1/dolphin-master-2603-379-ARM64.7z",
-            "hash": "59a0433e43623c80decff020f68fb14cd9eb82489516071ff4e7f301ad00d4aa",
+            "url": "https://dl.dolphin-emu.org/builds/5a/8e/dolphin-master-2606-134-ARM64.7z",
+            "hash": "2c4da1cbe89de744674aef80764d755152a384a5632a00c80b1ddb76253223a9",
             "extract_dir": "Dolphin-ARM64"
         }
     },
@@ -48,7 +48,7 @@
     ],
     "persist": "User",
     "checkver": {
-        "url": "https://dolphin-emu.org/download/",
+        "url": "https://dolphin-emu.org/update/latest/dev",
         "regex": "(?<prefix1>.{5})/dolphin-master-(?<version>[\\w-]+)-x64[\\s\\S]+?(?<prefix2>.{5})/dolphin-master-\\k<version>-ARM64"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The developers of Dolphin Simulator have enabled a WAF, which will block bots from accessing their download page. They have also kindly provided an API to retrieve the latest version number. This PR updates the version detection URL to the API URL and updates the package to the latest version.

For more details, please refer to:
- https://dolphin-emu.org/blog/2026/06/25/dolphin-progress-report-release-2606/#a-note-to-the-nicer-kind-of-scrapers

> We have noticed that there are several well-meaning bots which scrape our website to find the latest version of Dolphin. While we are trying to keep some of these bots working by adding exceptions for them in Bunny's WAF, we can't guarantee that this type of scraping will continue to function in the future.

> If you are operating one of these scrapers, we highly recommend that you switch to the API endpoints used by Dolphin's auto-updater. They allow you to query the latest Dolphin version and get direct links to the build artifacts. Most importantly though, the endpoints are exempt from Bunny's bot protection.

> Use the endpoint GET /update/latest/(track name) to fetch the latest Dolphin version. The beta track is for releases, and the dev track is for development builds.


p.s. This PR is a subset of #1763 and fixes the CI failure in #1763.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
