### PR TITLE
xenia-canary: Update to version 22d91c8, fix autoupdate

### DIFF
--- a/bucket/xenia-canary.json
+++ b/bucket/xenia-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "20260623192403-2771366",
+    "version": "20260710211723-22d91c8",
     "description": "Xbox 360 Emulator Research Project (development version)",
     "homepage": "https://github.com/xenia-canary/xenia-canary",
     "license": {
@@ -11,8 +11,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/xenia-canary/xenia-canary/releases/download/2771366/xenia_canary_windows.zip",
-            "hash": "d02a07cd20461396790c14f6279e029aa131db1ede158b3f33cfee9b5d223c35"
+            "url": "https://github.com/xenia-canary/xenia-canary/releases/download/22d91c8/xenia_canary_windows.7z",
+            "hash": "7a4cd7febd5c078e5f5dc8a4eb0cbfd90ea39ef6f656ee8296382d4c2de9779c"
         }
     },
     "pre_install": [
@@ -63,7 +63,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/xenia-canary/xenia-canary/releases/download/$matchCommit/xenia_canary_windows.zip"
+                "url": "https://github.com/xenia-canary/xenia-canary/releases/download/$matchCommit/xenia_canary_windows.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR does the following:
 - Updates the manifest to version 20260710211723-22d91c8.
 - Modifies the autoupdate url to reflect change to release file format.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
