### PR TITLE
dlss-updater: Update to version 4.3.1 (switch from deprecated zip to MSI)

### DIFF
--- a/bucket/dlss-updater.json
+++ b/bucket/dlss-updater.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.2.3",
+    "version": "4.3.1",
     "description": "A tool that allows you to conveniently update all the DLSS/XeSS/FSR DLLs for the games detected on your system",
     "homepage": "https://github.com/Recol/DLSS-Updater",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Recol/DLSS-Updater/releases/download/V4.2.3/DLSS.Updater.4.2.3.msi",
-            "hash": "c4ced18cf5afcdf10b729da8600f903c55de54dce589abd97a2c794e51fe596a"
+            "url": "https://github.com/Recol/DLSS-Updater/releases/download/V4.3.1/DLSS.Updater.4.3.1.msi",
+            "hash": "064e903b0a0a32065c9b2e2a283eaa6cc4b7693ddd636c9cc785945235e50a06"
         }
     },
     "extract_dir": "PFiles64\\DLSS Updater",

--- a/bucket/dlss-updater.json
+++ b/bucket/dlss-updater.json
@@ -1,14 +1,15 @@
 {
-    "version": "3.9.7",
+    "version": "4.2.3",
     "description": "A tool that allows you to conveniently update all the DLSS/XeSS/FSR DLLs for the games detected on your system",
     "homepage": "https://github.com/Recol/DLSS-Updater",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Recol/DLSS-Updater/releases/download/V3.9.7/DLSS.Updater.3.9.7.zip",
-            "hash": "03e30e48c77d8e5fe6d5fd79faeedfc6c719e91743eb6877288e3d812f266b61"
+            "url": "https://github.com/Recol/DLSS-Updater/releases/download/V4.2.3/DLSS.Updater.4.2.3.msi",
+            "hash": "c4ced18cf5afcdf10b729da8600f903c55de54dce589abd97a2c794e51fe596a"
         }
     },
+    "extract_dir": "PFiles64\\DLSS Updater",
     "shortcuts": [
         [
             "DLSS_Updater.exe",
@@ -19,7 +20,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Recol/DLSS-Updater/releases/download/V$version/DLSS.Updater.$version.zip"
+                "url": "https://github.com/Recol/DLSS-Updater/releases/download/V$version/DLSS.Updater.$version.msi"
             }
         }
     }


### PR DESCRIPTION
The manifest has been stuck on 3.9.7 because that was the last release to ship a portable zip. The zip artifact was permanently discontinued upstream (Windows Defender false-positives on the PyInstaller bootloader in zip form — see Recol/DLSS-Updater#238), so releases since then ship an MSI and a Flatpak.

The MSI is a plain file-layout package (PyInstaller onedir wrapped by WiX/Briefcase, no registry dependencies, per-user data in %LOCALAPPDATA%), so Scoop's archive-style MSI extraction works: extracting yields `PFiles64\DLSS Updater\` containing `DLSS_Updater.exe` + `_internal\`, verified with an administrative extract of the 4.3.1 MSI.

Changes:
- `url`/`hash`: point at the 4.3.1 MSI release asset
- `extract_dir`: `PFiles64\DLSS Updater`
- `autoupdate` template: `.msi` instead of `.zip`

I'm the upstream author (Recol/DLSS-Updater). The MSI naming scheme (`DLSS.Updater.$version.msi`) is stable across releases, so excavator should keep this current going forward.

Fixes the update path requested in Recol/DLSS-Updater#238.