### PR TITLE
psv-system-software: Add version 3.74

### DIFF
--- a/bucket/psv-system-software.json
+++ b/bucket/psv-system-software.json
@@ -1,0 +1,17 @@
+{
+    "version": "3.74",
+    "description": "Sony PlayStation Vita system software",
+    "homepage": "https://www.playstation.com/en-us/support/hardware/psvita/system-software/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://doc.dl.playstation.net/doc/psvita-eula/psvita_eula_en.html"
+    },
+    "url": [
+        "http://dus01.psv.update.playstation.net/update/psv/image/2022_0209/rel_f2c7b12fe85496ec88a0391b514d6e3b/PSVUPDAT.PUP",
+        "http://dus01.psp2.update.playstation.net/update/psp2/image/2022_0209/sd_59dcf059d3328fb67be7e51f8aa33418/PSP2UPDAT.PUP?dest=us#/PSP2UPDAT.PUP"
+    ],
+    "hash": [
+        "6ef6dc8da6db026f28647713e473486d770087a605c52a8d751bfca7478386cf",
+        "c3c03fc7363dd573d90e5157629bf11551f434b283cc898d9ffc71dd716b791c"
+    ]
+}

--- a/bucket/vita3k.json
+++ b/bucket/vita3k.json
@@ -4,8 +4,15 @@
     "homepage": "https://vita3k.org",
     "license": "GPL-2.0-only",
     "suggest": {
-        "vcredist": "extras/vcredist2022"
+        "vcredist": "extras/vcredist2022",
+        "PS Vita Firmware": "games/psv-system-software"
     },
+    "notes": [
+        "ATTENTION: Vita3K requires official PS Vita firmware to function.",
+        "Install the psv-system-software package.",
+        "You must still manually load PSVUPDAT.PUP and PSP2UPDAT.PUP through Vita3K",
+        "See the quickstart guide for further instructions: https://vita3k.org/quickstart"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/Vita3K/Vita3K/releases/download/continuous/windows-latest.zip",


### PR DESCRIPTION
Recent changes of Vita3K backend (probably since https://github.com/Vita3K/Vita3K/commit/91f533f86faa82fa61f1bb6411cd2d4bbedeb4a2#diff-c4f726a0d6972498e574d96ff7a02fbceba07f21907a69c4f42f38b283019ed5) refresh its UI to match RPCS3 and similarly requires PSV firmware to run certain games, this manifest is added for people who prefer to install it via scoop.

As Vita3K would show a popup to suggest (and optionally perform) firmware downloads, it's only added as `suggest` instead of a hard dependency.

Autoupdate is disabled as it's EOL years ago. While Sony still regularly releases PS3 firmware updates to rotate keys (see https://github.com/Calinou/scoop-games/commits/master/bucket/ps3-system-software.json), PSV firmware is last updated back in 2022.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1774

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
