### PR TITLE
wowup-cf: Add version 2.23.0

### DIFF
--- a/bucket/wowup-cf.json
+++ b/bucket/wowup-cf.json
@@ -1,6 +1,6 @@
 {
     "version": "2.23.0",
-    "description": "World of Warcraft addon updater with CurseForge support.",
+    "description": "World of Warcraft addon updater with CurseForge support",
     "homepage": "https://wowup.io/",
     "license": {
         "identifier": "GPL-3.0-or-later",

--- a/bucket/wowup-cf.json
+++ b/bucket/wowup-cf.json
@@ -1,0 +1,34 @@
+{
+    "version": "2.23.0",
+    "description": "World of Warcraft addon updater with CurseForge support.",
+    "homepage": "https://wowup.io/",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/WowUp/WowUp.CF/blob/main/LICENSE"
+    },
+    "url": "https://github.com/WowUp/WowUp.CF/releases/download/v2.23.0/WowUp-CF-Setup-2.23.0.exe#/dl.7z",
+    "hash": "sha512:bef64e0dd32ae83f1b208861869dbb7eec144e2fd9b28316f1ad7436c41f82cbc633f16a217ffa5a6bb7fa01bdc53d00d9e45434761d8e08828777dc2e8fd2d0",
+    "extract_dir": "$PLUGINSDIR",
+    "installer": {
+        "script": [
+            "Remove-Item \"$dir\\*\" -Exclude 'app-64.7z'",
+            "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\" -Removal"
+        ]
+    },
+    "shortcuts": [
+        [
+            "WowUp-CF.exe",
+            "WowUp-CF"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/WowUp/WowUp.CF"
+    },
+    "autoupdate": {
+        "url": "https://github.com/WowUp/WowUp.CF/releases/download/v$version/WowUp-CF-Setup-$version.exe#/dl.7z",
+        "hash": {
+            "url": "$baseurl/latest.yml",
+            "find": "sha512:\\s+(.*)"
+        }
+    }
+}


### PR DESCRIPTION
Adds a manifest for [WowUp-CF](https://github.com/WowUp/WowUp.CF), the Curseforge enabled build of WowUp.

**Why two Wow-Up versions?**: After WowUp and CurseForge parted ways, the main WowUp app (`wowup`, already [in this bucket](https://github.com/Calinou/scoop-games/blob/master/bucket/wowup.json)) can no longer fetch addons from CurseForge. WowUp.CF is a separate distribution that restores CurseForge support. They're distinct apps with separate repos and installers, so IMO both can coexist in the bucket.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
