### PR TITLE
blockbench@5.1.6: fix hash, fix autoupdate, fix architectures

### DIFF
--- a/bucket/blockbench.json
+++ b/bucket/blockbench.json
@@ -3,18 +3,20 @@
     "description": "Modern model editor for boxy models and pixel art textures.",
     "homepage": "https://blockbench.net/",
     "license": "GPL-3.0-or-later",
-    "url": "https://github.com/JannisX11/blockbench/releases/download/v5.1.6/Blockbench_5.1.6.exe#/dl.7z",
-    "hash": "sha512:9f37c8f74825fadf27cbf9fbc765ac1b335de2242bf26aad2faa966ba1344e212bb5bf2fe9bae9f2238abdba2363d762550a19d7775e14fcbfb8b8678b59c1c4",
     "architecture": {
-        "32bit": {
+        "arm64": {
+            "url": "https://github.com/JannisX11/blockbench/releases/download/v5.1.6/Blockbench_arm64_5.1.6.exe#/dl.7z",
+            "hash": "8a788708d62bad41aa578c8b89bb4078f77b1eb8a6d766e08a2473786239d515",
             "installer": {
                 "script": [
-                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" \"$dir\"",
                     "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
                 ]
             }
         },
         "64bit": {
+            "url": "https://github.com/JannisX11/blockbench/releases/download/v5.1.6/Blockbench_x64_5.1.6.exe#/dl.7z",
+            "hash": "fb209ebf7be3a2b077ee0d2a817a31e2ca8e837e4f42c714fc7659c414ece5ed",
             "installer": {
                 "script": [
                     "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
@@ -33,10 +35,13 @@
         "github": "https://github.com/JannisX11/blockbench/"
     },
     "autoupdate": {
-        "url": "https://github.com/JannisX11/blockbench/releases/download/v$version/Blockbench_$version.exe#/dl.7z",
-        "hash": {
-            "url": "$baseurl/latest.yml",
-            "find": "sha512:\\s+(.*)"
+        "architecture": {
+            "arm64": {
+                "url": "https://github.com/JannisX11/blockbench/releases/download/v$version/Blockbench_arm64_$version.exe#/dl.7z"
+            },
+            "64bit": {
+                "url": "https://github.com/JannisX11/blockbench/releases/download/v$version/Blockbench_x64_$version.exe#/dl.7z"
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- Hashes are now retrieved directly from GitHub (no more sha512 inside release yaml)
- The 32-bit version has been removed because it is no longer distributed (since 4.8, Jul 2023)
- The URLs now point to architecture-specific executables

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
