### PR TITLE
Update OpenHV website and shorten description

### DIFF
--- a/bucket/openhv.json
+++ b/bucket/openhv.json
@@ -1,7 +1,7 @@
 {
     "version": "20250725",
-    "description": "Open Hard Vacuum. 90s Pixelart Science-Fiction Real-time strategy game with multiplayer support, competent skirmish AI and an integrated map editor",
-    "homepage": "https://openhv.itch.io/openhv",
+    "description": "90s pixelart science-fiction real-time strategy game",
+    "homepage": "https://www.openhv.net/",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "32bit": {
@@ -17,7 +17,7 @@
     "shortcuts": [
         [
             "OpenHV.exe",
-            "Hard Vacuum (OpenHV)"
+            "OpenHV"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
The game is @OpenHV a reimagination of Hard Vacuum (not the legacy game itself) now with a proper homepage.

- [X] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
